### PR TITLE
Note Quick Edit Lyric Input

### DIFF
--- a/et --hard 85e1ff9ee41d34ee3375a94371f584aca91523af
+++ b/et --hard 85e1ff9ee41d34ee3375a94371f584aca91523af
@@ -1,0 +1,8 @@
+[33mcommit 27cd6992175ad24b3c99addfd975f34a857523b1[m
+Author: KRKT <foxiti.a@gmail.com>
+Date:   Fri Nov 28 14:30:23 2025 +0800
+
+    Set the timecode to a monospaced font to prevent the timecode container from jittering in width during playback.
+
+ src/app/UI/Views/MainTitleBar/PlaybackView.cpp | 4 [32m++++[m
+ 1 file changed, 4 insertions(+)

--- a/et --hard 85e1ff9ee41d34ee3375a94371f584aca91523af
+++ b/et --hard 85e1ff9ee41d34ee3375a94371f584aca91523af
@@ -1,8 +1,0 @@
-[33mcommit 27cd6992175ad24b3c99addfd975f34a857523b1[m
-Author: KRKT <foxiti.a@gmail.com>
-Date:   Fri Nov 28 14:30:23 2025 +0800
-
-    Set the timecode to a monospaced font to prevent the timecode container from jittering in width during playback.
-
- src/app/UI/Views/MainTitleBar/PlaybackView.cpp | 4 [32m++++[m
- 1 file changed, 4 insertions(+)

--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteView.h
@@ -11,6 +11,8 @@
 #include "Utils/UniqueObject.h"
 
 class PronunciationView;
+class QGraphicsProxyWidget;
+class QLineEdit;
 
 class NoteView final : public AbstractGraphicsRectItem,
                        public UniqueObject,
@@ -46,14 +48,28 @@ public:
     // Style
     Property<int> fontPixelSize = 13;
 
+    // Inline editing
+    void startEditingLyric();
+    void finishEditingLyric();
+    bool isEditingLyric() const;
+
+signals:
+    void lyricEditingFinished(const QString &lyric);
+    void tabKeyPressed();
+
 private:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
     // void hoverMoveEvent(QGraphicsSceneHoverEvent *event) override;
     void updateRectAndPos() override;
     void adjustPronView() const;
     void initUi();
+    void updateLineEditGeometry();
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
     PronunciationView *m_pronView = nullptr;
+    QGraphicsProxyWidget *m_lineEditProxy = nullptr;
+    QLineEdit *m_lineEdit = nullptr;
+    bool m_editingLyric = false;
     // int m_start = 0;
     int m_rStart = 0;
     int m_length = 480;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -739,6 +739,13 @@ void PianoRollGraphicsViewPrivate::prepareForEditingNotes(const QMouseEvent *eve
 
 void PianoRollGraphicsViewPrivate::PrepareForDrawingNote(const int tick, const int keyIndex) {
     Q_Q(PianoRollGraphicsView);
+    // Finish editing any notes that are currently being edited
+    for (const auto view : noteViews) {
+        if (view->isEditingLyric()) {
+            view->finishEditingLyric();
+        }
+    }
+    
     appStatus->currentEditObject = AppStatus::EditObjectType::Note;
     const auto snappedTick = MathUtils::roundDown(tick, 1920 / appStatus->quantize);
     Log::d(CLASS_NAME, "Draw note at: " + qStrNum(snappedTick));

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView_p.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView_p.h
@@ -127,6 +127,10 @@ public slots:
 
     void onDeleteSelectedNotes() const;
     void onOpenNotePropertyDialog(int noteId, AppGlobal::NotePropertyType propertyType);
+    void onStartEditingNoteLyric(NoteView *noteView);
+    void onNoteLyricEditingFinished(NoteView *noteView, const QString &lyric);
+    void onNoteTabKeyPressed(NoteView *noteView);
+    NoteView *findNextNoteView(NoteView *currentNoteView) const;
 
 private:
     PianoRollGraphicsView *q_ptr;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView_p.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView_p.h
@@ -78,7 +78,7 @@ public:
 
     void prepareForEditingNotes(const QMouseEvent *event, QPointF scenePos, int keyIndex,
                                 NoteView *noteItem);
-    void PrepareForDrawingNote(int tick, int keyIndex);
+    void PrepareForDrawingNote(int tick, int keyIndex, int initialLength = -1);
 
     void handleNotesMoved(int deltaTick, int deltaKey) const;
     static void handleNoteLeftResized(int noteId, int deltaTick);


### PR DESCRIPTION
Add the ability to quickly input lyrics by double-clicking notes and swiftly switch between editable notes using the tab key while in edit mode