### PR TITLE
Fix Piano Keys Hover Style

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoKeyboardView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoKeyboardView.cpp
@@ -106,14 +106,14 @@ void PianoKeyboardView::mouseMoveEvent(QMouseEvent *event) {
     QWidget::mouseMoveEvent(event);
     const auto x = event->position().x();
     const auto y = event->position().y();
-    const int keyIndex = xyToKeyIndex(x, y);
+    const int keyIndex = posToKeyIndex(x, y);
     if (keyIndex != m_hoveredKeyIndex) {
         m_hoveredKeyIndex = keyIndex;
         update();
     }
 }
 
-int PianoKeyboardView::yToKeyIndex(double y) const {
+int PianoKeyboardView::sceneYToKeyIndex(double y) const {
     if (y < 0 || y > height())
         return -1;
 
@@ -189,13 +189,13 @@ int PianoKeyboardView::yToKeyIndex(double y) const {
     }
 }
 
-int PianoKeyboardView::xyToKeyIndex(double x, double y) const {
+int PianoKeyboardView::posToKeyIndex(double x, double y) const {
     if (y < 0 || y > height())
         return -1;
 
     if (m_style == Uniform) {
         // Uniform style doesn't need x coordinate
-        return yToKeyIndex(y);
+        return sceneYToKeyIndex(y);
     } else {
         // Classic style: first check x coordinate, then y coordinate
         const auto blackKeyWidth = width() / 5.0 * 3;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoKeyboardView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoKeyboardView.h
@@ -43,8 +43,8 @@ private:
     void drawUniformKeyboard(QPainter &painter) const;
     void drawClassicKeyboard(QPainter &painter);
     void drawHoverOverlay(QPainter &painter) const;
-    int yToKeyIndex(double y) const;
-    int xyToKeyIndex(double x, double y) const;
+    int sceneYToKeyIndex(double y) const;
+    int posToKeyIndex(double x, double y) const;
 
     double m_top = 0;
     double m_bottom = 127;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoKeyboardView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoKeyboardView.h
@@ -19,6 +19,7 @@ public:
     enum KeyboardStyle { Uniform, Classic };
 
     explicit PianoKeyboardView(QWidget *parent = nullptr);
+    void setHoveredKeyIndex(int keyIndex);
 
 public slots:
     void setKeyRange(double top, double bottom);
@@ -43,6 +44,7 @@ private:
     void drawClassicKeyboard(QPainter &painter);
     void drawHoverOverlay(QPainter &painter) const;
     int yToKeyIndex(double y) const;
+    int xyToKeyIndex(double x, double y) const;
 
     double m_top = 0;
     double m_bottom = 127;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.h
@@ -47,6 +47,8 @@ public:
 
 signals:
     void keyRangeChanged(double start, double end);
+    void keyHovered(int keyIndex);
+    void keyHoverCleared();
 
 public slots:
     void onSceneSelectionChanged() const;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
@@ -87,6 +87,10 @@ PianoRollView::PianoRollView(QWidget *parent) : QWidget(parent) {
             &TimelineView::setTimeRange);
     connect(m_graphicsView, &PianoRollGraphicsView::keyRangeChanged, m_keyboardView,
             &PianoKeyboardView::setKeyRange);
+    connect(m_graphicsView, &PianoRollGraphicsView::keyHovered, m_keyboardView,
+            &PianoKeyboardView::setHoveredKeyIndex);
+    connect(m_graphicsView, &PianoRollGraphicsView::keyHoverCleared, m_keyboardView,
+            [this]() { m_keyboardView->setHoveredKeyIndex(-1); });
 }
 
 PianoRollGraphicsView *PianoRollView::graphicsView() const {


### PR DESCRIPTION
1. Limited the highlight behavior so that black keys only light up when the mouse hover is precisely on a black key.

2. Added a feature where the corresponding piano key lights up based on the cursor’s pitch when the cursor is in the piano window.