### PR TITLE
修复语种选择框硬编码

### DIFF
--- a/src/app/Model/AppModel/Track.cpp
+++ b/src/app/Model/AppModel/Track.cpp
@@ -59,10 +59,9 @@ static void setTrackVoiceContextForClip(Clip *clip, const SingerInfo &singerInfo
 void Track::insertClip(Clip *clip) {
     m_clips.add(clip);
     setTrackVoiceContextForClip(clip, m_singerInfo, m_speakerInfo, m_speakerMixData);
-    connect(this, &Track::singerOrSpeakerChanged, clip,
-            [clip, this] {
-                setTrackVoiceContextForClip(clip, m_singerInfo, m_speakerInfo, m_speakerMixData);
-            });
+    connect(this, &Track::singerOrSpeakerChanged, clip, [clip, this] {
+        setTrackVoiceContextForClip(clip, m_singerInfo, m_speakerInfo, m_speakerMixData);
+    });
     connect(this, &Track::speakerMixChanged, clip,
             [clip, this](const SpeakerMixModel::SpeakerMixData &) {
                 setTrackVoiceContextForClip(clip, m_singerInfo, m_speakerInfo, m_speakerMixData);
@@ -95,9 +94,12 @@ QString Track::defaultLanguage() const {
 }
 
 void Track::setDefaultLanguage(const QString &language) {
-    // TODO: validate
+    if (m_defaultLanguage == language)
+        return;
     m_defaultLanguage = language;
     this->updateDefaultG2pId(language);
+    emit defaultLanguageChanged(language);
+    emit propertyChanged();
 }
 
 QString Track::defaultG2pId() const {

--- a/src/app/Model/AppModel/Track.h
+++ b/src/app/Model/AppModel/Track.h
@@ -82,6 +82,7 @@ public:
 signals:
     void propertyChanged();
     void clipChanged(Track::ClipChangeType type, Clip *clip);
+    void defaultLanguageChanged(const QString &language);
     void singerOrSpeakerChanged();
     void speakerMixChanged(const SpeakerMixModel::SpeakerMixData &data);
 

--- a/src/app/Resources/translate/translation_zh_CN.ts
+++ b/src/app/Resources/translate/translation_zh_CN.ts
@@ -4483,6 +4483,34 @@ All current mix settings will be lost.</source>
     </message>
 </context>
 <context>
+    <name>LanguageComboBox</name>
+    <message>
+        <location filename="../../UI/Views/Common/LanguageComboBox.cpp" line="17"/>
+        <source>Mandarin</source>
+        <translation>普通话</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Views/Common/LanguageComboBox.cpp" line="19"/>
+        <source>English</source>
+        <translation>英语</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Views/Common/LanguageComboBox.cpp" line="21"/>
+        <source>Japanese</source>
+        <translation>日语</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Views/Common/LanguageComboBox.cpp" line="23"/>
+        <source>Cantonese</source>
+        <translation>粤语</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Views/Common/LanguageComboBox.cpp" line="25"/>
+        <source>Unknown</source>
+        <translation>未知</translation>
+    </message>
+</context>
+<context>
     <name>TwoLevelComboBox</name>
     <message>
         <location filename="../../UI/Controls/TwoLevelComboBox.cpp" line="37"/>

--- a/src/app/UI/Dialogs/Note/PhonemeNameListWidget.cpp
+++ b/src/app/UI/Dialogs/Note/PhonemeNameListWidget.cpp
@@ -90,12 +90,12 @@ void PhonemeNameListWidget::updateItemWidget(int row) {
         setItemWidget(item(row), widget);
 
         auto listItem = item(row);
-        connect(widget->cbLanguage(), &QComboBox::currentTextChanged, this,
-                [this, listItem](const QString &text) {
+        connect(widget->cbLanguage(), &LanguageComboBox::currentLanguageChanged, this,
+                [this, listItem](const QString &language) {
                     if (m_model) {
                         int currentRow = this->row(listItem);
                         if (currentRow >= 0)
-                            m_model->setData(m_model->index(currentRow), text,
+                            m_model->setData(m_model->index(currentRow), language,
                                              PhonemeNameListModel::LanguageRole);
                     }
                 });
@@ -132,7 +132,7 @@ void PhonemeNameListWidget::updateItemWidget(int row) {
 
     QModelIndex index = m_model->index(row);
     widget->blockSignals(true);
-    widget->cbLanguage()->setCurrentText(
+    widget->cbLanguage()->setCurrentLanguage(
         m_model->data(index, PhonemeNameListModel::LanguageRole).toString());
     widget->leName()->setText(m_model->data(index, PhonemeNameListModel::NameRole).toString());
     widget->cbIsOnset()->setChecked(

--- a/src/app/UI/Dialogs/Options/Pages/GeneralPage.cpp
+++ b/src/app/UI/Dialogs/Options/Pages/GeneralPage.cpp
@@ -32,7 +32,7 @@ GeneralPage::GeneralPage(QWidget *parent) : IOptionPage(parent) {
 void GeneralPage::modifyOption() {
     const auto option = appOptions->general();
     option->uiLanguage = m_cbUiLanguage->currentData().toString();
-    option->defaultSingingLanguage = m_cbDefaultSingingLanguage->currentText();
+    option->defaultSingingLanguage = m_cbDefaultSingingLanguage->currentLanguage();
     option->defaultLyrics[option->defaultSingingLanguage] = m_leDefaultLyric->text();
 
     option->gameDir = m_fsGameDir->path();
@@ -77,7 +77,7 @@ QWidget *GeneralPage::createContentWidget() {
     connect(m_cbDefaultSingingLanguage, &ComboBox::currentIndexChanged, this, [this]() {
         const auto option = appOptions->general();
         option->defaultLyrics[m_previousLanguage] = m_leDefaultLyric->text();
-        const auto newLang = m_cbDefaultSingingLanguage->currentText();
+        const auto newLang = m_cbDefaultSingingLanguage->currentLanguage();
         m_leDefaultLyric->setText(option->defaultLyricForLanguage(newLang));
         m_previousLanguage = newLang;
         modifyOption();

--- a/src/app/UI/Views/ClipEditor/ToolBar/ClipEditorToolBarView.cpp
+++ b/src/app/UI/Views/ClipEditor/ToolBar/ClipEditorToolBarView.cpp
@@ -296,7 +296,7 @@ void ClipEditorToolBarViewPrivate::onClipPropertyChanged() const {
 }
 
 void ClipEditorToolBarViewPrivate::onClipLanguageChanged(const QString &language) const {
-    m_cbClipLanguage->setCurrentText(language);
+    m_cbClipLanguage->setCurrentLanguage(language);
 }
 
 void ClipEditorToolBarViewPrivate::onLanguageEdited(const QString &language) const {
@@ -386,11 +386,10 @@ void ClipEditorToolBarViewPrivate::setPianoRollToolsEnabled(const bool on) const
         connect(m_singingClip, &SingingClip::speakerMixChanged, this,
                 [this](const SpeakerMixData &) { refreshSingerComboPresentation(); });
 
-        m_cbClipLanguage->setCurrentText(m_singingClip->defaultLanguage());
-        connect(m_cbClipLanguage, &ComboBox::currentTextChanged, this,
+        connect(m_cbClipLanguage, &LanguageComboBox::currentLanguageChanged, this,
                 &ClipEditorToolBarViewPrivate::onLanguageEdited);
-        connect(m_singingClip, &SingingClip::defaultLanguageChanged, m_cbClipLanguage,
-                &ComboBox::setCurrentText);
+        connect(m_singingClip, &SingingClip::defaultLanguageChanged, this,
+                &ClipEditorToolBarViewPrivate::onClipLanguageChanged);
     } else {
         disconnect(m_cbSinger, &TwoLevelComboBox::currentDataChanged, this,
                    &ClipEditorToolBarViewPrivate::onSingerEdited);
@@ -398,13 +397,13 @@ void ClipEditorToolBarViewPrivate::setPianoRollToolsEnabled(const bool on) const
             disconnect(m_singingClip, &SingingClip::singerOrSpeakerChanged, this,
                        &ClipEditorToolBarViewPrivate::onClipSingerChanged);
             disconnect(m_singingClip, &SingingClip::speakerMixChanged, this, nullptr);
-            disconnect(m_singingClip, &SingingClip::defaultLanguageChanged, m_cbClipLanguage,
-                       &ComboBox::setCurrentText);
+            disconnect(m_singingClip, &SingingClip::defaultLanguageChanged, this,
+                       &ClipEditorToolBarViewPrivate::onClipLanguageChanged);
         }
 
-        disconnect(m_cbClipLanguage, &ComboBox::currentTextChanged, this,
+        disconnect(m_cbClipLanguage, &LanguageComboBox::currentLanguageChanged, this,
                    &ClipEditorToolBarViewPrivate::onLanguageEdited);
-        m_cbClipLanguage->setCurrentText("unknown");
+        m_cbClipLanguage->setLanguages({}, QStringLiteral("unknown"));
     }
 }
 
@@ -442,6 +441,18 @@ void ClipEditorToolBarViewPrivate::refreshSingerComboPresentation() const {
     }
     m_cbSinger->setToolTip(m_cbSinger->currentText());
     populatePresetMenus();
+    refreshLanguageComboPresentation();
+}
+
+void ClipEditorToolBarViewPrivate::refreshLanguageComboPresentation() const {
+    if (!m_singingClip || !m_cbClipLanguage)
+        return;
+
+    const auto singerInfo = m_singingClip->singerInfo();
+    const auto language = m_cbClipLanguage->setLanguages(
+        singerInfo.languages(), m_singingClip->defaultLanguage(), singerInfo.defaultLanguage());
+    if (language != m_singingClip->defaultLanguage())
+        m_singingClip->setDefaultLanguage(language);
 }
 
 void ClipEditorToolBarViewPrivate::populatePresetMenus() const {

--- a/src/app/UI/Views/ClipEditor/ToolBar/ClipEditorToolBarView_p.h
+++ b/src/app/UI/Views/ClipEditor/ToolBar/ClipEditorToolBarView_p.h
@@ -35,6 +35,7 @@ public:
     void moveToSingingClipState() const;
     void moveToAudioClipState() const;
     void refreshSingerComboPresentation() const;
+    void refreshLanguageComboPresentation() const;
     void populatePresetMenus() const;
     void retranslateUi() const;
     void onPresetApplied(const QString &presetId) const;

--- a/src/app/UI/Views/Common/LanguageComboBox.cpp
+++ b/src/app/UI/Views/Common/LanguageComboBox.cpp
@@ -5,10 +5,107 @@
 #include "LanguageComboBox.h"
 
 #include "Global/AppGlobal.h"
+#include "Modules/PackageManager/Models/LanguageInfo.h"
+
+#include <QEvent>
+#include <QSet>
+#include <QSignalBlocker>
+
+namespace {
+    QString displayName(const QString &id, const QString &packageName) {
+        if (id == QStringLiteral("cmn"))
+            return LanguageComboBox::tr("Mandarin");
+        if (id == QStringLiteral("eng"))
+            return LanguageComboBox::tr("English");
+        if (id == QStringLiteral("jpn"))
+            return LanguageComboBox::tr("Japanese");
+        if (id == QStringLiteral("yue"))
+            return LanguageComboBox::tr("Cantonese");
+        if (id == QStringLiteral("unknown"))
+            return LanguageComboBox::tr("Unknown");
+        if (!packageName.trimmed().isEmpty())
+            return packageName.trimmed();
+        return id;
+    }
+}
 
 LanguageComboBox::LanguageComboBox(const QString &langKey, bool scrollWheelChangeSelection,
                                    QWidget *parent)
     : ComboBox(scrollWheelChangeSelection, parent) {
-    addItems(AppGlobal::languageNames);
-    setCurrentText(langKey);
+    setLanguageCodes(AppGlobal::languageNames, langKey);
+    connect(this, &QComboBox::currentIndexChanged, this, [this](int index) {
+        if (index >= 0)
+            emit currentLanguageChanged(itemData(index).toString());
+    });
+}
+
+QString LanguageComboBox::currentLanguage() const {
+    return currentData().toString();
+}
+
+void LanguageComboBox::setCurrentLanguage(const QString &language) {
+    setCurrentIndex(findData(language));
+}
+
+QString LanguageComboBox::setLanguages(const QList<LanguageInfo> &languages,
+                                       const QString &currentLanguage,
+                                       const QString &preferredLanguage) {
+    QSignalBlocker blocker(this);
+    clear();
+
+    QSet<QString> addedIds;
+    for (const auto &language : languages) {
+        const auto id = language.id().trimmed();
+        if (id.isEmpty() || addedIds.contains(id))
+            continue;
+        addedIds.insert(id);
+        addItem(displayName(id, language.name()), id);
+        setItemData(count() - 1, language.name(), Qt::UserRole + 1);
+    }
+
+    if (count() == 0) {
+        addItem(displayName(QStringLiteral("unknown"), {}), QStringLiteral("unknown"));
+        setItemData(0, QString(), Qt::UserRole + 1);
+    }
+
+    auto selected = currentLanguage;
+    if (findData(selected) < 0)
+        selected = preferredLanguage;
+    if (findData(selected) < 0)
+        selected = itemData(0).toString();
+    setCurrentIndex(findData(selected));
+    return selected;
+}
+
+QString LanguageComboBox::setLanguageCodes(const QStringList &languageCodes,
+                                           const QString &currentLanguage,
+                                           bool preserveUnknownCurrent) {
+    QList<LanguageInfo> languages;
+    QSet<QString> addedIds;
+    for (const auto &languageCode : languageCodes) {
+        const auto id = languageCode.trimmed();
+        if (id.isEmpty() || addedIds.contains(id))
+            continue;
+        addedIds.insert(id);
+        languages.emplace_back(id);
+    }
+    if (preserveUnknownCurrent && !currentLanguage.trimmed().isEmpty() &&
+        !addedIds.contains(currentLanguage)) {
+        languages.emplace_back(currentLanguage, currentLanguage);
+    }
+    return setLanguages(languages, currentLanguage);
+}
+
+void LanguageComboBox::changeEvent(QEvent *event) {
+    ComboBox::changeEvent(event);
+    if (event->type() == QEvent::LanguageChange)
+        refreshDisplayNames();
+}
+
+void LanguageComboBox::refreshDisplayNames() {
+    QSignalBlocker blocker(this);
+    for (int index = 0; index < count(); ++index) {
+        setItemText(index, displayName(itemData(index).toString(),
+                                       itemData(index, Qt::UserRole + 1).toString()));
+    }
 }

--- a/src/app/UI/Views/Common/LanguageComboBox.h
+++ b/src/app/UI/Views/Common/LanguageComboBox.h
@@ -7,11 +7,32 @@
 
 #include "UI/Controls/ComboBox.h"
 
+class LanguageInfo;
+class QEvent;
+
 class LanguageComboBox : public ComboBox {
     Q_OBJECT
 
 public:
-    explicit LanguageComboBox(const QString &langKey, bool scrollWheelChangeSelection = false, QWidget *parent = nullptr);
+    explicit LanguageComboBox(const QString &langKey, bool scrollWheelChangeSelection = false,
+                              QWidget *parent = nullptr);
+
+    [[nodiscard]] QString currentLanguage() const;
+    void setCurrentLanguage(const QString &language);
+
+    QString setLanguages(const QList<LanguageInfo> &languages, const QString &currentLanguage,
+                         const QString &preferredLanguage = {});
+    QString setLanguageCodes(const QStringList &languageCodes, const QString &currentLanguage,
+                             bool preserveUnknownCurrent = true);
+
+signals:
+    void currentLanguageChanged(const QString &language);
+
+protected:
+    void changeEvent(QEvent *event) override;
+
+private:
+    void refreshDisplayNames();
 };
 
 #endif // LANGUAGECOMBOBOX_H

--- a/src/app/UI/Views/TrackEditor/TrackControlView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackControlView.cpp
@@ -139,6 +139,11 @@ TrackControlView::TrackControlView(QListWidgetItem *item, Track *track, QWidget 
     cbLanguage = new LanguageComboBox("unknown");
     cbLanguage->setObjectName("cbLanguage");
     cbLanguage->setMaximumWidth(144);
+    connect(cbLanguage, &LanguageComboBox::currentLanguageChanged, this,
+            [this](const QString &language) {
+                if (m_track && m_track->defaultLanguage() != language)
+                    m_track->setDefaultLanguage(language);
+            });
 
     singerLanguageLayout = new QHBoxLayout;
     singerLanguageLayout->addWidget(cbSinger);
@@ -168,7 +173,6 @@ TrackControlView::TrackControlView(QListWidgetItem *item, Track *track, QWidget 
     setName(track->name());
     setControl(track->control());
     refreshSingerComboPresentation();
-    setLanguage(track->defaultLanguage());
     updateTrackColor();
 
     // Nullify m_track when the Track is destroyed (e.g. during
@@ -180,6 +184,7 @@ TrackControlView::TrackControlView(QListWidgetItem *item, Track *track, QWidget 
 
     connect(track, &Track::singerOrSpeakerChanged, this,
             &TrackControlView::refreshSingerComboPresentation);
+    connect(track, &Track::defaultLanguageChanged, this, &TrackControlView::setLanguage);
     connect(track, &Track::speakerMixChanged, this,
             [this](const SpeakerMixData &) { refreshSingerComboPresentation(); });
 
@@ -251,7 +256,7 @@ void TrackControlView::setNarrowMode(const bool on) const {
 }
 
 void TrackControlView::setLanguage(const QString &language) const {
-    cbLanguage->setCurrentText(language);
+    cbLanguage->setCurrentLanguage(language);
 }
 
 LevelMeter *TrackControlView::levelMeter() const {
@@ -350,6 +355,18 @@ void TrackControlView::refreshSingerComboPresentation() const {
     }
     cbSinger->setToolTip(cbSinger->currentText());
     populatePresetMenus();
+    refreshLanguageComboPresentation();
+}
+
+void TrackControlView::refreshLanguageComboPresentation() const {
+    if (!m_track || !cbLanguage)
+        return;
+
+    const auto singerInfo = m_track->singerInfo();
+    const auto language = cbLanguage->setLanguages(
+        singerInfo.languages(), m_track->defaultLanguage(), singerInfo.defaultLanguage());
+    if (language != m_track->defaultLanguage())
+        m_track->setDefaultLanguage(language);
 }
 
 void TrackControlView::populatePresetMenus() const {

--- a/src/app/UI/Views/TrackEditor/TrackControlView.h
+++ b/src/app/UI/Views/TrackEditor/TrackControlView.h
@@ -62,6 +62,7 @@ private:
     void retranslateUi();
     void changeTrackProperty() const;
     void refreshSingerComboPresentation() const;
+    void refreshLanguageComboPresentation() const;
     void populatePresetMenus() const;
     void onPresetApplied(const QString &presetId) const;
     void onManagePresetsAction(const SingerInfo &singerInfo) const;


### PR DESCRIPTION
<!-- codex-worker issue=45 kind=initial-pr head=1bb8ec6273c072ec0bd9cbcd721087b57bfe44b7 -->
关闭 #45

已批准计划：`plan-v4`

## 变更内容

- 让 `LanguageComboBox` 以 ISO 语种代码作为数据值，显示名与持久化值解耦；内置语种名支持动态翻译，未知代码保留声库提供的名称。
- 轨道与歌声剪辑的语种选项改为根据当前有效歌手的 `SingerInfo::languages()` 动态生成，并按“当前值 → 歌手默认值 → 首项 → unknown”回退。
- 增加轨道默认语种变更通知，统一常规设置与音素名称列表中的 ISO 代码读写。

## 验证结果

- 构建或自动检查：PASS — `& '.\.agents\skills\scripts\run-cmake-preset.ps1' -Mode ConfigureAndBuild -Preset debug` 完成 configure 与 443/443 全量构建；`git diff --check` 通过。
- 针对改动的自测：PASS — 使用独立测试声库（仅 `cmn` 与额外代码 `sa`）验证轨道/剪辑下拉框只展示声库声明语种；选择 `sa` 后切换中英文界面，显示名重译且 ISO 选择保持；保存 DSPX 后轨道与剪辑均持久化 `defaultLanguage: "sa"`。
- `$gui-smoke-test`：PASS — 使用真实已安装歌手 Jun Ninghua，在 C4 附近绘制音符并确认音高曲线、音素与非平坦波形；播放超过 2 秒且播放头/时间推进；保存 DSPX 并导出全部范围 WAV。导出文件为 RIFF/WAVE、PCM F32LE、44.1 kHz、双声道、8.000 s，`max_volume: -17.7 dB`。
- Computer Use：分别完成针对改动的界面验证与独立端到端 GUI 冒烟测试；两个测试实例、配置覆盖与临时产物均已隔离并清理，用户原配置已按 SHA-256 恢复。
- 候选提交：`1bb8ec6273c072ec0bd9cbcd721087b57bfe44b7`

## 已知限制

- 按已批准的 `plan-v4` 未新增、配置、枚举或运行 CTest。
