### PR TITLE
实现钢琴卷帘音符连续范围选择

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteInteractionController.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteInteractionController.cpp
@@ -49,19 +49,30 @@ void NoteInteractionController::prepareForEditingNotes(const QMouseEvent *event,
         return;
     }
 
-    const bool ctrlDown = event->modifiers() == Qt::ControlModifier;
-    m_selectionModel->applyNoteSelection(
-        noteItem, ctrlDown ? PianoRollSelectionModel::NoteSelectionMode::Toggle
-                           : PianoRollSelectionModel::NoteSelectionMode::Plain);
+    const auto modifiers = event->modifiers();
+    const auto ctrlDown = modifiers.testFlag(Qt::ControlModifier);
+    const auto shiftDown = modifiers.testFlag(Qt::ShiftModifier);
+    auto selectionMode = PianoRollSelectionModel::NoteSelectionMode::Plain;
+    if (shiftDown)
+        selectionMode = ctrlDown ? PianoRollSelectionModel::NoteSelectionMode::AddRange
+                                 : PianoRollSelectionModel::NoteSelectionMode::ReplaceRange;
+    else if (ctrlDown)
+        selectionMode = PianoRollSelectionModel::NoteSelectionMode::Toggle;
+    m_preserveSelectionOnClickRelease = ctrlDown || shiftDown;
+    m_selectionModel->applyNoteSelection(noteItem, selectionMode);
+
+    if (!noteItem->isSelected()) {
+        m_mouseMoveBehavior = None;
+        m_currentEditingNote = nullptr;
+        return;
+    }
 
     const auto rPos = noteItem->mapFromScene(scenePos);
     const auto rx = rPos.x();
     if (rx >= 0 && rx <= resizeTolerance) {
         m_mouseMoveBehavior = ResizeLeft;
-        noteItem->setSelected(true);
     } else if (rx >= noteItem->rect().width() - resizeTolerance && rx <= noteItem->rect().width()) {
         m_mouseMoveBehavior = ResizeRight;
-        noteItem->setSelected(true);
     } else {
         m_mouseMoveBehavior = Move;
     }
@@ -72,6 +83,12 @@ void NoteInteractionController::prepareForEditingNotes(const QMouseEvent *event,
     m_mouseDownLength = m_currentEditingNote->length();
     m_mouseDownKeyIndex = keyIndex;
     updateMoveDeltaKeyRange();
+}
+
+void NoteInteractionController::finalizeClickSelection() const {
+    if (!m_currentEditingNote || m_movedBeforeMouseUp || m_preserveSelectionOnClickRelease)
+        return;
+    m_selectionModel->selectOnly(m_currentEditingNote);
 }
 
 void NoteInteractionController::handleNotesMoved(const int deltaTick, const int deltaKey) const {
@@ -145,6 +162,7 @@ void NoteInteractionController::reset() {
     m_deltaTick = 0;
     m_deltaKey = 0;
     m_movedBeforeMouseUp = false;
+    m_preserveSelectionOnClickRelease = false;
     m_moveMaxDeltaKey = 127;
     m_moveMinDeltaKey = 0;
     m_currentEditingNote = nullptr;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteInteractionController.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteInteractionController.cpp
@@ -50,14 +50,9 @@ void NoteInteractionController::prepareForEditingNotes(const QMouseEvent *event,
     }
 
     const bool ctrlDown = event->modifiers() == Qt::ControlModifier;
-    if (!ctrlDown) {
-        if (m_selectionModel->selectedNoteItems().count() <= 1 ||
-            !m_selectionModel->selectedNoteItems().contains(noteItem))
-            m_view->clearNoteSelections();
-        noteItem->setSelected(true);
-    } else {
-        noteItem->setSelected(!noteItem->isSelected());
-    }
+    m_selectionModel->applyNoteSelection(
+        noteItem, ctrlDown ? PianoRollSelectionModel::NoteSelectionMode::Toggle
+                           : PianoRollSelectionModel::NoteSelectionMode::Plain);
 
     const auto rPos = noteItem->mapFromScene(scenePos);
     const auto rx = rPos.x();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteInteractionController.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteInteractionController.h
@@ -126,6 +126,7 @@ public:
     // Interaction preparation
     void prepareForEditingNotes(const QMouseEvent *event, QPointF scenePos, int keyIndex,
                                 NoteView *noteItem);
+    void finalizeClickSelection() const;
 
     // Action handlers
     void handleNotesMoved(int deltaTick, int deltaKey) const;
@@ -160,6 +161,7 @@ private:
     int m_deltaTick = 0;
     int m_deltaKey = 0;
     bool m_movedBeforeMouseUp = false;
+    bool m_preserveSelectionOnClickRelease = false;
     int m_moveMaxDeltaKey = 127;
     int m_moveMinDeltaKey = 0;
 

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -45,7 +45,6 @@
 #include "Utils/Linq.h"
 #include "Utils/MathUtils.h"
 #include "Utils/TimelineSnapUtils.h"
-#include <algorithm>
 #include <climits>
 #include <cmath>
 
@@ -768,6 +767,7 @@ void PianoRollGraphicsView::setParamBackgroundLayerColor(const QColor &color) {
 
 void PianoRollGraphicsView::reset() {
     Q_D(PianoRollGraphicsView);
+    d->m_selectionModel->clearSelectionAnchor();
     for (const auto &noteView : d->noteViews) {
         d->removeNoteViewFromScene(noteView);
         delete noteView;
@@ -1083,13 +1083,7 @@ NoteView *PianoRollGraphicsViewPrivate::findAdjacentNoteView(NoteView *currentNo
                                                              const bool backwards) const {
     if (!currentNoteView)
         return nullptr;
-    auto orderedViews = noteViews;
-    std::sort(orderedViews.begin(), orderedViews.end(),
-              [](const NoteView *lhs, const NoteView *rhs) {
-                  if (lhs->rStart() != rhs->rStart())
-                      return lhs->rStart() < rhs->rStart();
-                  return lhs->id() < rhs->id();
-              });
+    const auto orderedViews = m_selectionModel->orderedNoteItems();
     const auto index = orderedViews.indexOf(currentNoteView);
     const auto targetIndex = backwards ? index - 1 : index + 1;
     return targetIndex >= 0 && targetIndex < orderedViews.size() ? orderedViews.at(targetIndex)
@@ -1151,6 +1145,7 @@ void PianoRollGraphicsViewPrivate::applyPronunciationEdit(const int noteId, cons
 
 void PianoRollGraphicsViewPrivate::moveToNullClipState() {
     Q_Q(PianoRollGraphicsView);
+    m_selectionModel->clearSelectionAnchor();
     finishInlineEditing();
     m_pitchEditor->cancelEdit();
     endPitchEditSession(EditSessionEndReason::Cancel);
@@ -1168,6 +1163,7 @@ void PianoRollGraphicsViewPrivate::moveToNullClipState() {
 
 void PianoRollGraphicsViewPrivate::moveToSingingClipState(SingingClip *clip) {
     Q_Q(PianoRollGraphicsView);
+    m_selectionModel->clearSelectionAnchor();
     finishInlineEditing();
     m_pitchEditor->cancelEdit();
     endPitchEditSession(EditSessionEndReason::Cancel);
@@ -1284,6 +1280,7 @@ void PianoRollGraphicsViewPrivate::handleNoteInserted(Note *note) {
 }
 
 void PianoRollGraphicsViewPrivate::handleNoteRemoved(Note *note) {
+    m_selectionModel->invalidateSelectionAnchor(note->id());
     if (m_inlineEditingNoteId == note->id())
         finishInlineEditing();
     m_selectionModel->setSelectionChangeBarrier(true);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -317,6 +317,7 @@ void PianoRollGraphicsView::mousePressEvent(QMouseEvent *event) {
                 clearNoteSelections();
             noteView->setSelected(true);
         } else {
+            d->m_selectionModel->clearSelectionAnchor();
             clearNoteSelections();
             TimeGraphicsView::mousePressEvent(event);
         }
@@ -333,8 +334,10 @@ void PianoRollGraphicsView::mousePressEvent(QMouseEvent *event) {
     if (d->m_editMode == Select) {
         if (d->m_currentHandler)
             d->m_currentHandler->mousePressEvent(event);
-        if (!noteView)
+        if (!noteView) {
+            d->m_selectionModel->clearSelectionAnchor();
             TimeGraphicsView::mousePressEvent(event);
+        }
     } else if (d->m_editMode == DrawNote) {
         if (d->m_currentHandler)
             d->m_currentHandler->mousePressEvent(event);
@@ -353,8 +356,10 @@ void PianoRollGraphicsView::mousePressEvent(QMouseEvent *event) {
     } else if (d->m_editMode == IntervalSelect) {
         if (d->m_currentHandler)
             d->m_currentHandler->mousePressEvent(event);
-        if (!noteView)
+        if (!noteView) {
+            d->m_selectionModel->clearSelectionAnchor();
             TimeGraphicsView::mousePressEvent(event);
+        }
     } else if (d->m_editMode == EditPitchAnchor) {
         if (d->m_currentHandler)
             d->m_currentHandler->mousePressEvent(event);
@@ -513,13 +518,9 @@ void PianoRollGraphicsView::mouseReleaseEvent(QMouseEvent *event) {
         }
         cancelRequested = false;
     }
-    if (!cancelRequested)
+    if (!cancelRequested) {
+        d->m_interactionController->finalizeClickSelection();
         commitAction();
-    const bool ctrlDown = event->modifiers() == Qt::ControlModifier;
-    if (d->m_interactionController->mouseMoveBehavior() == NoteInteractionController::Move) {
-        if (!d->m_interactionController->movedBeforeMouseUp() && !ctrlDown) {
-            clearNoteSelections(d->m_interactionController->currentEditingNote());
-        }
     }
     cancelRequested = false;
     TimeGraphicsView::mouseReleaseEvent(event);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.cpp
@@ -12,6 +12,8 @@
 
 #include "UI/Views/Common/TimeGraphicsScene.h"
 
+#include <algorithm>
+
 PianoRollSelectionModel::PianoRollSelectionModel(PianoRollGraphicsView *view,
                                                  QList<NoteView *> &noteViews,
                                                  QHash<int, NoteView *> &noteViewIndex,
@@ -22,6 +24,82 @@ PianoRollSelectionModel::PianoRollSelectionModel(PianoRollGraphicsView *view,
 
 QList<NoteView *> PianoRollSelectionModel::selectedNoteItems() const {
     return Linq::where(m_noteViews, L_PRED(n, n->isSelected()));
+}
+
+QList<NoteView *> PianoRollSelectionModel::orderedNoteItems() const {
+    auto orderedItems = m_noteViews;
+    std::sort(orderedItems.begin(), orderedItems.end(),
+              [](const NoteView *lhs, const NoteView *rhs) {
+                  if (lhs->rStart() != rhs->rStart())
+                      return lhs->rStart() < rhs->rStart();
+                  return lhs->id() < rhs->id();
+              });
+    return orderedItems;
+}
+
+void PianoRollSelectionModel::applyNoteSelection(NoteView *noteView,
+                                                 const NoteSelectionMode mode) {
+    if (!noteView)
+        return;
+
+    if (mode == NoteSelectionMode::Plain) {
+        m_selectionAnchorId = noteView->id();
+        const auto selectedItems = selectedNoteItems();
+        if (selectedItems.count() <= 1 || !selectedItems.contains(noteView))
+            selectOnly(noteView);
+        else
+            noteView->setSelected(true);
+        return;
+    }
+
+    if (mode == NoteSelectionMode::Toggle) {
+        m_selectionAnchorId = noteView->id();
+        noteView->setSelected(!noteView->isSelected());
+        return;
+    }
+
+    const auto anchor = selectionAnchor();
+    if (!anchor) {
+        m_selectionAnchorId = noteView->id();
+        selectOnly(noteView);
+        return;
+    }
+    selectRange(anchor, noteView, mode == NoteSelectionMode::AddRange);
+}
+
+void PianoRollSelectionModel::selectOnly(NoteView *noteView) const {
+    m_view->clearNoteSelections(noteView);
+    if (noteView)
+        noteView->setSelected(true);
+}
+
+void PianoRollSelectionModel::clearSelectionAnchor() {
+    m_selectionAnchorId = -1;
+}
+
+void PianoRollSelectionModel::invalidateSelectionAnchor(const int noteId) {
+    if (m_selectionAnchorId == noteId)
+        clearSelectionAnchor();
+}
+
+NoteView *PianoRollSelectionModel::selectionAnchor() const {
+    return m_noteViewIndex.value(m_selectionAnchorId, nullptr);
+}
+
+void PianoRollSelectionModel::selectRange(NoteView *anchor, NoteView *target,
+                                          const bool additive) const {
+    const auto orderedItems = orderedNoteItems();
+    const auto anchorIndex = orderedItems.indexOf(anchor);
+    const auto targetIndex = orderedItems.indexOf(target);
+    if (anchorIndex < 0 || targetIndex < 0)
+        return;
+
+    if (!additive)
+        m_view->clearNoteSelections();
+    const auto first = qMin(anchorIndex, targetIndex);
+    const auto last = qMax(anchorIndex, targetIndex);
+    for (auto index = first; index <= last; ++index)
+        orderedItems.at(index)->setSelected(true);
 }
 
 void PianoRollSelectionModel::updateSceneSelectionState() {
@@ -36,6 +114,8 @@ void PianoRollSelectionModel::updateSceneSelectionState() {
         }
         noteView->setSelected(true);
     }
+    if (!selectionAnchor())
+        clearSelectionAnchor();
     m_selectionChangeBarrier = false;
 }
 

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.h
@@ -14,11 +14,18 @@ class PianoRollSelectionModel : public QObject {
     Q_OBJECT
 
 public:
+    enum class NoteSelectionMode { Plain, Toggle, ReplaceRange, AddRange };
+
     explicit PianoRollSelectionModel(PianoRollGraphicsView *view, QList<NoteView *> &noteViews,
                                      QHash<int, NoteView *> &noteViewIndex, QList<Note *> &notes,
                                      QObject *parent = nullptr);
 
     [[nodiscard]] QList<NoteView *> selectedNoteItems() const;
+    [[nodiscard]] QList<NoteView *> orderedNoteItems() const;
+    void applyNoteSelection(NoteView *noteView, NoteSelectionMode mode);
+    void selectOnly(NoteView *noteView) const;
+    void clearSelectionAnchor();
+    void invalidateSelectionAnchor(int noteId);
 
     [[nodiscard]] bool isSelecting() const {
         return m_selecting;
@@ -74,8 +81,12 @@ signals:
     void selectionChanged();
 
 private:
+    [[nodiscard]] NoteView *selectionAnchor() const;
+    void selectRange(NoteView *anchor, NoteView *target, bool additive) const;
+
     bool m_selecting = false;
     bool m_selectionChangeBarrier = false;
+    int m_selectionAnchorId = -1;
     QList<NoteView *> m_pastePreviewViews;
     QList<NoteView *> m_noteViewsToErase;
 


### PR DESCRIPTION
<!-- codex-worker issue=47 kind=initial-pr head=4ad0d474f81e41bb4165df8e4f09a31e2350f344 -->
Closes #47

已批准计划：`plan-v1`

## 变更内容

- 将钢琴卷帘音符选择状态和时间顺序统一收口到 `PianoRollSelectionModel`。
- 引入稳定的选择锚点，实现 Shift+点击替换连续范围、Ctrl+Shift+点击追加连续范围。
- 保留 Ctrl+点击切换与普通点击收敛选择的行为，并在空白点击、音符删除和工程/片段切换时失效锚点。
- 统一相邻音符导航和范围选择的排序规则：先按起始时间，再按音符 ID。

## 验证结果

- 构建与自动检查：PASS — 在候选提交上完成标准 CMake Debug 配置与构建，成功生成 `DsEditorLite.exe`。
- 针对改动的 Computer Use 自测：SKIPPED — 本次由本地主会话明确要求跳过自动范围选择验收，交由 reviewer 手动测试。
- CTest: SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基本功能回归冒烟测试（用于确认基本功能未发生回归）：PASS — 已验证声库加载、五个音符及合成波形、播放推进、DSPX 保存和 WAV 导出；导出音频为 44.1 kHz 双声道、8 秒且非静音。
- Computer Use：真实程序中已验证普通点击将选择收敛到单个音符，以及保存、播放和导出流程；Shift/Ctrl+Shift 范围点击未自动执行。
- 候选提交：`4ad0d474f81e41bb4165df8e4f09a31e2350f344`

## 已知限制

- 请 reviewer 手动验证：Shift+点击替换为锚点到目标音符的连续范围；Ctrl+Shift+点击将该范围追加到现有选择；Ctrl+点击切换单个音符；普通点击已选音符时最终收敛为单选。
- 冒烟测试临时目录的自动清理由本地命令策略拒绝；不影响应用验证结果。