### PR TITLE
fix: 修复钢琴卷帘连选锚点同步

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/DrawNoteHandler.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/DrawNoteHandler.cpp
@@ -4,6 +4,7 @@
 #include "PianoRollGraphicsScene.h"
 #include "PianoRollGraphicsView.h"
 #include "PianoRollGraphicsView_p.h"
+#include "PianoRollSelectionModel.h"
 #include "PianoRollCoord.h"
 #include "NoteInteractionController.h"
 #include "PianoRollGraphicsViewHelper.h"
@@ -43,7 +44,7 @@ bool DrawNoteHandler::mousePressEvent(QMouseEvent *event) {
         return false;
     } else if (pronView) {
         const auto currentNoteView = d->findNoteViewById(pronView->id());
-        currentNoteView->setSelected(true);
+        d->m_selectionModel->selectOnly(currentNoteView);
         return false;
     } else {
         prepareForDrawingNote(tick, keyIndex);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -312,10 +312,8 @@ void PianoRollGraphicsView::mousePressEvent(QMouseEvent *event) {
          d->m_editMode == EraseNote || d->m_editMode == SplitNote)) {
         d->m_interactionController->setMouseMoveBehavior(NoteInteractionController::None);
         if (const auto noteView = d->noteViewAt(event->pos())) {
-            if (d->m_selectionModel->selectedNoteItems().count() <= 1 ||
-                !d->m_selectionModel->selectedNoteItems().contains(noteView))
-                clearNoteSelections();
-            noteView->setSelected(true);
+            d->m_selectionModel->applyNoteSelection(
+                noteView, PianoRollSelectionModel::NoteSelectionMode::Plain);
         } else {
             d->m_selectionModel->clearSelectionAnchor();
             clearNoteSelections();
@@ -1059,8 +1057,7 @@ void PianoRollGraphicsViewPrivate::onInlineNavigationRequested(const QString &te
     onInlineTextSubmitted(text);
     const auto nextNoteView = findAdjacentNoteView(currentNoteView, backwards);
     if (nextNoteView) {
-        q->clearNoteSelections();
-        nextNoteView->setSelected(true);
+        m_selectionModel->selectOnly(nextNoteView);
         const auto notes = q->selectedNotesId();
         clipController->selectNotes(notes, true);
         onStartEditingNoteLyric(nextNoteView);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.cpp
@@ -67,7 +67,8 @@ void PianoRollSelectionModel::applyNoteSelection(NoteView *noteView,
     selectRange(anchor, noteView, mode == NoteSelectionMode::AddRange);
 }
 
-void PianoRollSelectionModel::selectOnly(NoteView *noteView) const {
+void PianoRollSelectionModel::selectOnly(NoteView *noteView) {
+    m_selectionAnchorId = noteView ? noteView->id() : -1;
     m_view->clearNoteSelections(noteView);
     if (noteView)
         noteView->setSelected(true);
@@ -106,6 +107,7 @@ void PianoRollSelectionModel::updateSceneSelectionState() {
     m_selectionChangeBarrier = true;
     m_view->clearNoteSelections();
 
+    QList<NoteView *> selectedNoteViews;
     for (const auto id : appStatus->selectedNotes.get()) {
         const auto noteView = m_noteViewIndex.value(id, nullptr);
         if (!noteView) {
@@ -113,9 +115,14 @@ void PianoRollSelectionModel::updateSceneSelectionState() {
             continue;
         }
         noteView->setSelected(true);
+        selectedNoteViews.append(noteView);
     }
-    if (!selectionAnchor())
+
+    const auto anchor = selectionAnchor();
+    if (selectedNoteViews.isEmpty())
         clearSelectionAnchor();
+    else if (!selectedNoteViews.contains(anchor))
+        m_selectionAnchorId = selectedNoteViews.constLast()->id();
     m_selectionChangeBarrier = false;
 }
 

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.h
@@ -23,7 +23,7 @@ public:
     [[nodiscard]] QList<NoteView *> selectedNoteItems() const;
     [[nodiscard]] QList<NoteView *> orderedNoteItems() const;
     void applyNoteSelection(NoteView *noteView, NoteSelectionMode mode);
-    void selectOnly(NoteView *noteView) const;
+    void selectOnly(NoteView *noteView);
     void clearSelectionAnchor();
     void invalidateSelectionAnchor(int noteId);
 


### PR DESCRIPTION
<!-- codex-worker issue=49 kind=initial-pr head=0d4d75ffed5d73889f20366c6ede2c2d9d070354 -->
Closes #49

已批准计划：`plan-v1`

## 变更内容

- 让单选入口统一更新钢琴卷帘的连选锚点。
- 从模型同步场景选择时，仅保留仍处于选中状态的旧锚点；旧锚点失效或已取消选择时，使用最后一个有效选中音符作为确定性锚点。
- 覆盖绘制/拆分后的模型选择、右键选择、发音点击和歌词行内导航等相似入口。

## 验证结果

- 构建或自动检查：PASS — 使用项目 Debug preset 完成 CMake configure 和 `DsEditorLite` 构建。
- 针对改动的 Computer Use 自测：SKIPPED — Computer Use 能力限制：接口不能在鼠标点击期间保持 Shift 修饰键，无法执行“新绘制音符作为锚点后 Shift 点击另一音符”的关键断言；已确认真实程序可启动并连续绘制三个音符，未观察到业务异常；需要人工补测。
- CTest: SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基本功能回归冒烟测试（用于确认基本功能未发生回归）：SKIPPED — Computer Use 能力限制：Windows 另存为对话框的可见文件名框已选中，但辅助功能持续将焦点报告为搜索框；按规范完成一次诊断重试后仍无法安全输入保存路径，未观察到业务异常；需要人工补测。已完成的前置断言包括加载 `Jun Ninghua`、绘制音符、观察音素/音高曲线/非平直波形，以及播放时间从 `001:01:000` 向前推进。
- Computer Use：使用 `build/Debug/bin/DsEditorLite.exe` 启动独立实例，完成音符绘制、声库加载、合成观察和播放；测试实例已关闭。
- 人工补测：REQUIRED — ① 启动该候选构建，在钢琴卷帘绘制至少三个有序音符；新绘制第三个音符后按住 Shift 点击第一个音符，预期三个音符全部选中且不遗漏新音符；再分别验证拆分新音符、右键单选、点击发音文本、歌词行内前后导航后进行 Shift 连选，预期范围均以最近的单选结果为锚点。② 新建工程，加载可用声库，绘制起点前留一拍且长度 1–2 拍的音符；确认音素、音高曲线、非平直波形和播放推进；另存为非空 DSPX，导出全部范围 WAV，并确认 WAV 为非空、可解码、非静音。
- 候选提交：`0d4d75ffed5d73889f20366c6ede2c2d9d070354`

## 已知限制

- Computer Use 无法直接完成 Shift+鼠标点击，也无法可靠确认本次 Windows 保存对话框的输入焦点；上述断言需 reviewer 人工补测。