### PR TITLE
fix: 异步探测声学缓存并接入推理状态机

### DIFF
--- a/src/app/Modules/Inference/InferController.cpp
+++ b/src/app/Modules/Inference/InferController.cpp
@@ -110,6 +110,8 @@ InferController::InferController(QObject *parent)
         makePlaybackPriorityComparator<InferVarianceTask>());
     d->m_inferAcousticTasks.setPriorityComparator(
         makePlaybackPriorityComparator<InferAcousticTask>());
+    d->m_inferAcousticCacheProbeTasks.setPriorityComparator(
+        makePlaybackPriorityComparator<InferAcousticCacheProbeTask>());
 
     connect(appStatus, &AppStatus::moduleStatusChanged, d,
             &InferControllerPrivate::onModuleStatusChanged);
@@ -186,6 +188,21 @@ bool InferController::finishCurrentInferAcousticTask(InferAcousticTask *task) {
     return d->m_inferAcousticTasks.onCurrentFinished(task);
 }
 
+void InferController::addInferAcousticCacheProbeTask(InferAcousticCacheProbeTask &task) {
+    Q_D(InferController);
+    d->m_inferAcousticCacheProbeTasks.add(&task);
+}
+
+void InferController::cancelInferAcousticCacheProbeTask(int taskId) {
+    Q_D(InferController);
+    d->m_inferAcousticCacheProbeTasks.cancelIf(L_PRED(t, t->id() == taskId));
+}
+
+bool InferController::finishCurrentInferAcousticCacheProbeTask(InferAcousticCacheProbeTask *task) {
+    Q_D(InferController);
+    return d->m_inferAcousticCacheProbeTasks.onCurrentFinished(task);
+}
+
 void InferControllerPrivate::onModuleStatusChanged(const AppStatus::ModuleType module,
                                                    const AppStatus::ModuleStatus status) {
     if (module == AppStatus::ModuleType::Language)
@@ -219,6 +236,7 @@ void InferControllerPrivate::onInferOptionChanged(const AppOptionsGlobal::Option
         return;
 
     m_autoStartAcousticInfer = appOptions->inference()->autoStartInfer;
+    m_inferAcousticCacheProbeTasks.cancelAll();
 }
 
 void InferControllerPrivate::onPlaybackStatusChanged(const PlaybackGlobal::PlaybackStatus status) {
@@ -245,6 +263,7 @@ void InferControllerPrivate::handleModelChanged() {
     m_inferPitchTasks.cancelAll();
     m_inferVarianceTasks.cancelAll();
     m_inferAcousticTasks.cancelAll();
+    m_inferAcousticCacheProbeTasks.cancelAll();
     for (const auto pipeline : std::as_const(m_inferPipelines))
         delete pipeline;
     m_inferPipelines.clear();
@@ -370,6 +389,7 @@ void InferControllerPrivate::handleParamChanged(const ParamInfo::Name name, cons
                 m_inferPitchTasks.cancelIf(pred);
                 m_inferVarianceTasks.cancelIf(pred);
                 m_inferAcousticTasks.cancelIf(pred);
+                m_inferAcousticCacheProbeTasks.cancelIf(pred);
 
                 auto pipelines = Linq::where(m_inferPipelines, [piece](const InferPipeline *p) {
                     return p->pieceId() == piece->id();
@@ -383,6 +403,7 @@ void InferControllerPrivate::handleParamChanged(const ParamInfo::Name name, cons
                 auto pred = L_PRED(t, t->pieceId() == piece->id());
                 m_inferVarianceTasks.cancelIf(pred);
                 m_inferAcousticTasks.cancelIf(pred);
+                m_inferAcousticCacheProbeTasks.cancelIf(pred);
 
                 auto pipelines = Linq::where(m_inferPipelines, [piece](const InferPipeline *p) {
                     return p->pieceId() == piece->id();
@@ -402,6 +423,7 @@ void InferControllerPrivate::handleParamChanged(const ParamInfo::Name name, cons
             for (const auto &piece : dirtyPieces) {
                 auto pred = L_PRED(t, t->pieceId() == piece->id());
                 m_inferAcousticTasks.cancelIf(pred);
+                m_inferAcousticCacheProbeTasks.cancelIf(pred);
 
                 auto pipelines = Linq::where(m_inferPipelines, [piece](const InferPipeline *p) {
                     return p->pieceId() == piece->id();
@@ -443,6 +465,7 @@ void InferControllerPrivate::handleSpeakerMixChanged(SingingClip *clip) {
         m_inferPitchTasks.cancelIf(pred);
         m_inferVarianceTasks.cancelIf(pred);
         m_inferAcousticTasks.cancelIf(pred);
+        m_inferAcousticCacheProbeTasks.cancelIf(pred);
 
         auto pipelines = Linq::where(m_inferPipelines, [piece](const InferPipeline *p) {
             return p->pieceId() == piece->id();
@@ -853,6 +876,7 @@ void InferControllerPrivate::reset() {
     m_inferPitchTasks.cancelAll();
     m_inferVarianceTasks.cancelAll();
     m_inferAcousticTasks.cancelAll();
+    m_inferAcousticCacheProbeTasks.cancelAll();
 }
 
 void InferControllerPrivate::cancelAllInferTasks() {
@@ -882,6 +906,7 @@ void InferControllerPrivate::cancelPieceRelatedTasks(int pieceId) {
     m_inferPitchTasks.cancelIf(pred);
     m_inferVarianceTasks.cancelIf(pred);
     m_inferAcousticTasks.cancelIf(pred);
+    m_inferAcousticCacheProbeTasks.cancelIf(pred);
 }
 
 void InferControllerPrivate::notifyNextPipeline(const QList<InferPipeline *> &pipelines,

--- a/src/app/Modules/Inference/InferController.h
+++ b/src/app/Modules/Inference/InferController.h
@@ -16,6 +16,7 @@ class InferDurationTask;
 class InferPitchTask;
 class InferVarianceTask;
 class InferAcousticTask;
+class InferAcousticCacheProbeTask;
 class Task;
 
 class InferController final : public QObject {
@@ -40,6 +41,10 @@ public:
     void addInferAcousticTask(InferAcousticTask &task);
     void cancelInferAcousticTask(int taskId);
     bool finishCurrentInferAcousticTask(InferAcousticTask *task = nullptr);
+
+    void addInferAcousticCacheProbeTask(InferAcousticCacheProbeTask &task);
+    void cancelInferAcousticCacheProbeTask(int taskId);
+    bool finishCurrentInferAcousticCacheProbeTask(InferAcousticCacheProbeTask *task = nullptr);
 
 private:
     explicit InferController(QObject *parent = nullptr);

--- a/src/app/Modules/Inference/InferController_p.h
+++ b/src/app/Modules/Inference/InferController_p.h
@@ -13,6 +13,7 @@
 #include "Modules/Inference/Models/InferenceTaskContext.h"
 #include "Modules/Inference/Models/PhonemeNameResult.h"
 #include "Tasks/InferAcousticTask.h"
+#include "Tasks/InferAcousticCacheProbeTask.h"
 #include "Tasks/InferDurationTask.h"
 #include "Tasks/InferPitchTask.h"
 #include "Tasks/InferVarianceTask.h"
@@ -115,6 +116,7 @@ public:
     TaskQueue<InferPitchTask> m_inferPitchTasks;
     TaskQueue<InferVarianceTask> m_inferVarianceTasks;
     TaskQueue<InferAcousticTask> m_inferAcousticTasks;
+    TaskQueue<InferAcousticCacheProbeTask> m_inferAcousticCacheProbeTasks;
 
     QHash<int, PendingPronunciationApply> m_pendingPronunciationApplies;
     QHash<int, PendingPhonemeNameApply> m_pendingPhonemeNameApplies;

--- a/src/app/Modules/Inference/InferPipeline.cpp
+++ b/src/app/Modules/Inference/InferPipeline.cpp
@@ -11,6 +11,7 @@
 #include "States/UpdatePitchState.h"
 #include "States/InferVarianceState.h"
 #include "States/UpdateVarianceState.h"
+#include "States/ProbeAcousticCacheState.h"
 #include "States/AwaitingInferAcousticState.h"
 #include "States/InferAcousticState.h"
 #include "States/UpdateAcousticState.h"
@@ -158,6 +159,7 @@ void InferPipeline::initStates() {
     updateVarianceState = new UpdateVarianceState(*this);
     awaitingVarianceApplyState =
         new AwaitingEditSessionApplyState(*this, AwaitingEditSessionApplyState::Stage::Variance);
+    probeAcousticCacheState = new ProbeAcousticCacheState(*this);
     awaitingInferAcousticState = new AwaitingInferAcousticState(*this);
     inferAcousticState = new InferAcousticState(*this);
     updateAcousticState = new UpdateAcousticState(*this);
@@ -175,6 +177,7 @@ void InferPipeline::initStates() {
     stateMachine.addState(inferVarianceState);
     stateMachine.addState(updateVarianceState);
     stateMachine.addState(awaitingVarianceApplyState);
+    stateMachine.addState(probeAcousticCacheState);
     stateMachine.addState(awaitingInferAcousticState);
     stateMachine.addState(inferAcousticState);
     stateMachine.addState(updateAcousticState);
@@ -188,6 +191,7 @@ void InferPipeline::initTransitions() {
     initDurationTransitions();
     initPitchTransitions();
     initVarianceTransitions();
+    initProbeAcousticCacheTransitions();
     initAwaitingInferAcousticTransitions();
     initAcousticTransitions();
     initPlaybackReadyTransitions();
@@ -197,9 +201,10 @@ void InferPipeline::initTransitions() {
         awaitingDurationApplyState, inferPitchState,
         updatePitchState,           awaitingPitchApplyState,
         inferVarianceState,         updateVarianceState,
-        awaitingVarianceApplyState, awaitingInferAcousticState,
-        inferAcousticState,         updateAcousticState,
-        awaitingAcousticApplyState, playbackReadyState,
+        awaitingVarianceApplyState, probeAcousticCacheState,
+        awaitingInferAcousticState, inferAcousticState,
+        updateAcousticState,        awaitingAcousticApplyState,
+        playbackReadyState,
     };
     // Inference options are part of the task snapshot, so active pipelines restart with a new
     // snapshot instead of mixing old worker output with new apply-time options.
@@ -255,7 +260,7 @@ void InferPipeline::initVarianceTransitions() {
 
     updateVarianceState->addTransition(updateVarianceState,
                                        &UpdateVarianceState::updateSuccessWithLazyInference,
-                                       awaitingInferAcousticState);
+                                       probeAcousticCacheState);
     updateVarianceState->addTransition(updateVarianceState,
                                        &UpdateVarianceState::updateSuccessWithImmediateInference,
                                        inferAcousticState);
@@ -273,6 +278,31 @@ void InferPipeline::initVarianceTransitions() {
                                               inferVarianceState);
 }
 
+void InferPipeline::initProbeAcousticCacheTransitions() {
+    probeAcousticCacheState->addTransition(probeAcousticCacheState,
+                                           &ProbeAcousticCacheState::cacheHit,
+                                           updateAcousticState);
+    probeAcousticCacheState->addTransition(
+        probeAcousticCacheState, &ProbeAcousticCacheState::cacheMissWithLazyInference,
+        awaitingInferAcousticState);
+    probeAcousticCacheState->addTransition(
+        probeAcousticCacheState, &ProbeAcousticCacheState::cacheMissWithImmediateInference,
+        inferAcousticState);
+    probeAcousticCacheState->addTransition(probeAcousticCacheState,
+                                           &ProbeAcousticCacheState::dropped, finalState);
+    probeAcousticCacheState->addTransition(this, &InferPipeline::playbackStarted,
+                                           inferAcousticState);
+    probeAcousticCacheState->addTransition(this, &InferPipeline::lazyInferAcousticTurnedOff,
+                                           inferAcousticState);
+    probeAcousticCacheState->addTransition(this, &InferPipeline::pieceRemoved, finalState);
+    probeAcousticCacheState->addTransition(this, &InferPipeline::expressivenessChanged,
+                                           inferPitchState);
+    probeAcousticCacheState->addTransition(this, &InferPipeline::pitchChanged,
+                                           inferVarianceState);
+    probeAcousticCacheState->addTransition(this, &InferPipeline::varianceChanged,
+                                           probeAcousticCacheState);
+}
+
 void InferPipeline::initAwaitingInferAcousticTransitions() {
     awaitingInferAcousticState->addTransition(this, &InferPipeline::playbackStarted,
                                               inferAcousticState);
@@ -283,6 +313,8 @@ void InferPipeline::initAwaitingInferAcousticTransitions() {
                                               inferPitchState);
     awaitingInferAcousticState->addTransition(this, &InferPipeline::pitchChanged,
                                               inferVarianceState);
+    awaitingInferAcousticState->addTransition(this, &InferPipeline::varianceChanged,
+                                              probeAcousticCacheState);
 }
 
 void InferPipeline::initAcousticTransitions() {
@@ -324,7 +356,7 @@ void InferPipeline::initPlaybackReadyTransitions() {
     playbackReadyState->addTransition(immediateTransition);
 
     auto lazyTransition = new ConditionalTransition(this, SIGNAL(varianceChanged()));
-    lazyTransition->setTargetState(awaitingInferAcousticState);
+    lazyTransition->setTargetState(probeAcousticCacheState);
     lazyTransition->setGuardCondition([]() { return !appOptions->inference()->autoStartInfer; });
     playbackReadyState->addTransition(lazyTransition);
 }

--- a/src/app/Modules/Inference/InferPipeline.h
+++ b/src/app/Modules/Inference/InferPipeline.h
@@ -24,6 +24,7 @@ class InferPitchState;
 class UpdatePitchState;
 class InferVarianceState;
 class UpdateVarianceState;
+class ProbeAcousticCacheState;
 class AwaitingInferAcousticState;
 class AwaitingEditSessionApplyState;
 class InferAcousticState;
@@ -109,6 +110,7 @@ private:
     void initDurationTransitions();
     void initPitchTransitions();
     void initVarianceTransitions();
+    void initProbeAcousticCacheTransitions();
     void initAwaitingInferAcousticTransitions();
     void initAcousticTransitions();
     void initPlaybackReadyTransitions();
@@ -126,6 +128,7 @@ private:
     InferVarianceState *inferVarianceState{};
     UpdateVarianceState *updateVarianceState{};
     AwaitingEditSessionApplyState *awaitingVarianceApplyState{};
+    ProbeAcousticCacheState *probeAcousticCacheState{};
     AwaitingInferAcousticState *awaitingInferAcousticState{};
     InferAcousticState *inferAcousticState{};
     UpdateAcousticState *updateAcousticState{};

--- a/src/app/Modules/Inference/States/ProbeAcousticCacheState.cpp
+++ b/src/app/Modules/Inference/States/ProbeAcousticCacheState.cpp
@@ -1,0 +1,108 @@
+//
+// Created by OpenVPI on 2026/7/22.
+//
+
+#include "ProbeAcousticCacheState.h"
+
+#include "Controller/PlaybackController.h"
+#include "Model/AppOptions/AppOptions.h"
+#include "Modules/Inference/InferController.h"
+#include "Modules/Inference/InferControllerHelper.h"
+#include "Modules/Inference/InferPipeline.h"
+
+#include <QDebug>
+#include <QTimer>
+
+namespace Helper = InferControllerHelper;
+
+ProbeAcousticCacheState::ProbeAcousticCacheState(InferPipeline &pipeline, QState *parent)
+    : QState(parent), m_pipeline(pipeline) {
+}
+
+void ProbeAcousticCacheState::onEntry(QEvent *event) {
+    qDebug() << "ProbeAcousticCacheState::onEntry";
+    QState::onEntry(event);
+
+    cancelCurrentTask();
+
+    auto &piece = m_pipeline.piece();
+    piece.acousticInferStatus = Pending;
+    piece.state = QString("Acoustic.CacheProbe");
+    Helper::resetAcoustic(piece);
+    m_pipeline.setAcousticResult({});
+
+    const auto input = Helper::buildInferAcousticInput(piece, piece.clip->singerIdentifier());
+    auto *task = new InferAcousticCacheProbeTask(input);
+    connect(task, &InferAcousticCacheProbeTask::finished, this,
+            [this, task] { handleTaskFinished(*task); });
+    m_currentTask = task;
+    inferController->addInferAcousticCacheProbeTask(*task);
+}
+
+void ProbeAcousticCacheState::onExit(QEvent *event) {
+    qDebug() << "ProbeAcousticCacheState::onExit";
+    cancelCurrentTask();
+    QState::onExit(event);
+}
+
+void ProbeAcousticCacheState::handleTaskFinished(InferAcousticCacheProbeTask &task) {
+    if (!m_currentTask || m_currentTask != &task) {
+        qDebug() << "Ignoring acoustic cache probe that is no longer current";
+        return;
+    }
+
+    const auto finishCurrentTask = [this, &task] {
+        if (!inferController->finishCurrentInferAcousticCacheProbeTask(&task)) {
+            qWarning() << "Failed to finish acoustic cache probe because it is not current"
+                       << "taskId:" << task.id();
+        }
+        m_currentTask = nullptr;
+    };
+
+    if (task.terminated()) {
+        finishCurrentTask();
+        return;
+    }
+
+    if (!task.success()) {
+        m_pipeline.notifyDropped("cache-probe-failed");
+        finishCurrentTask();
+        QTimer::singleShot(0, this, [this] { emit dropped(); });
+        return;
+    }
+
+    m_pipeline.setApplyContext(task.inferenceContext());
+    const auto gate = m_pipeline.resolveApplyContext(-1, false);
+    if (gate.decision != InferenceApplyGate::Decision::Apply) {
+        m_pipeline.notifyDropped(gate.reason);
+        finishCurrentTask();
+        QTimer::singleShot(0, this, [this] { emit dropped(); });
+        return;
+    }
+
+    const bool hasCacheHit = task.cacheHit();
+    if (hasCacheHit)
+        m_pipeline.setAcousticResult(task.result());
+    const bool immediateInference = appOptions->inference()->autoStartInfer ||
+                                    playbackController->playbackStatus() ==
+                                        PlaybackStatus::Playing;
+    finishCurrentTask();
+
+    QTimer::singleShot(0, this, [this, hasCacheHit, immediateInference] {
+        if (hasCacheHit)
+            emit cacheHit();
+        else if (immediateInference)
+            emit cacheMissWithImmediateInference();
+        else
+            emit cacheMissWithLazyInference();
+    });
+}
+
+void ProbeAcousticCacheState::cancelCurrentTask() {
+    if (!m_currentTask)
+        return;
+
+    m_currentTask->disconnect(this);
+    inferController->cancelInferAcousticCacheProbeTask(m_currentTask->id());
+    m_currentTask = nullptr;
+}

--- a/src/app/Modules/Inference/States/ProbeAcousticCacheState.h
+++ b/src/app/Modules/Inference/States/ProbeAcousticCacheState.h
@@ -1,0 +1,37 @@
+//
+// Created by OpenVPI on 2026/7/22.
+//
+
+#ifndef DS_EDITOR_LITE_PROBEACOUSTICCACHESTATE_H
+#define DS_EDITOR_LITE_PROBEACOUSTICCACHESTATE_H
+
+#include "Modules/Inference/Tasks/InferAcousticCacheProbeTask.h"
+
+#include <QState>
+
+class InferPipeline;
+
+class ProbeAcousticCacheState final : public QState {
+    Q_OBJECT
+
+public:
+    explicit ProbeAcousticCacheState(InferPipeline &pipeline, QState *parent = nullptr);
+    ~ProbeAcousticCacheState() override = default;
+
+signals:
+    void cacheHit();
+    void cacheMissWithLazyInference();
+    void cacheMissWithImmediateInference();
+    void dropped();
+
+private:
+    void onEntry(QEvent *event) override;
+    void onExit(QEvent *event) override;
+    void handleTaskFinished(InferAcousticCacheProbeTask &task);
+    void cancelCurrentTask();
+
+    InferPipeline &m_pipeline;
+    InferAcousticCacheProbeTask *m_currentTask = nullptr;
+};
+
+#endif // DS_EDITOR_LITE_PROBEACOUSTICCACHESTATE_H

--- a/src/app/Modules/Inference/Tasks/InferAcousticCacheProbeTask.cpp
+++ b/src/app/Modules/Inference/Tasks/InferAcousticCacheProbeTask.cpp
@@ -1,0 +1,69 @@
+//
+// Created by OpenVPI on 2026/7/22.
+//
+
+#include "InferAcousticCacheProbeTask.h"
+
+#include <QDebug>
+
+#include <utility>
+
+InferAcousticCacheProbeTask::InferAcousticCacheProbeTask(
+    InferAcousticTask::InferAcousticInput input)
+    : m_input(std::move(input)) {
+    TaskStatus status;
+    status.title = tr("Probe Acoustic Cache");
+    status.message = tr("Pending acoustic cache probe");
+    status.isIndetermine = true;
+    setStatus(status);
+    qDebug() << "Acoustic cache probe created"
+             << "clipId:" << clipId() << "pieceId:" << pieceId() << "taskId:" << id();
+}
+
+int InferAcousticCacheProbeTask::clipId() const {
+    return m_input.clipId;
+}
+
+int InferAcousticCacheProbeTask::pieceId() const {
+    return m_input.pieceId;
+}
+
+InferenceTaskContext InferAcousticCacheProbeTask::inferenceContext() const {
+    auto context = m_input.toInferenceTaskContext("acoustic");
+    context.taskId = id();
+    context.inputSignature = m_input.semanticSignature();
+    return context;
+}
+
+bool InferAcousticCacheProbeTask::success() const {
+    return m_success.load(std::memory_order_acquire);
+}
+
+bool InferAcousticCacheProbeTask::cacheHit() const {
+    return m_cacheHit.load(std::memory_order_acquire);
+}
+
+QString InferAcousticCacheProbeTask::result() const {
+    return m_result;
+}
+
+void InferAcousticCacheProbeTask::runTask() {
+    if (isTerminateRequested())
+        return;
+
+    auto newStatus = status();
+    newStatus.message = tr("Probing acoustic cache");
+    setStatus(newStatus);
+
+    const auto cache = InferAcousticTask::lookupCache(m_input);
+    if (isTerminateRequested())
+        return;
+
+    if (cache.hit)
+        m_result = cache.outputCachePath;
+    m_cacheHit.store(cache.hit, std::memory_order_release);
+    m_success.store(true, std::memory_order_release);
+    qDebug() << "Acoustic cache probe finished"
+             << "hit:" << cache.hit << "clipId:" << clipId() << "pieceId:" << pieceId()
+             << "taskId:" << id();
+}

--- a/src/app/Modules/Inference/Tasks/InferAcousticCacheProbeTask.h
+++ b/src/app/Modules/Inference/Tasks/InferAcousticCacheProbeTask.h
@@ -1,0 +1,35 @@
+//
+// Created by OpenVPI on 2026/7/22.
+//
+
+#ifndef DS_EDITOR_LITE_INFERACOUSTICCACHEPROBETASK_H
+#define DS_EDITOR_LITE_INFERACOUSTICCACHEPROBETASK_H
+
+#include <atomic>
+
+#include "IInferTask.h"
+#include "InferAcousticTask.h"
+
+class InferAcousticCacheProbeTask final : public IInferTask {
+    Q_OBJECT
+
+public:
+    [[nodiscard]] int clipId() const override;
+    [[nodiscard]] int pieceId() const override;
+    [[nodiscard]] InferenceTaskContext inferenceContext() const override;
+    [[nodiscard]] bool success() const override;
+
+    explicit InferAcousticCacheProbeTask(InferAcousticTask::InferAcousticInput input);
+    [[nodiscard]] bool cacheHit() const;
+    [[nodiscard]] QString result() const;
+
+private:
+    void runTask() override;
+
+    InferAcousticTask::InferAcousticInput m_input;
+    QString m_result;
+    std::atomic<bool> m_cacheHit{false};
+    std::atomic<bool> m_success{false};
+};
+
+#endif // DS_EDITOR_LITE_INFERACOUSTICCACHEPROBETASK_H

--- a/src/app/Modules/Inference/Tasks/InferAcousticTask.cpp
+++ b/src/app/Modules/Inference/Tasks/InferAcousticTask.cpp
@@ -23,6 +23,7 @@
 #include <QCryptographicHash>
 #include <QDebug>
 #include <QDir>
+#include <QFile>
 
 namespace Ac = srt::svs::Api::Acoustic::L1;
 namespace Vo = srt::svs::Api::Vocoder::L1;
@@ -75,6 +76,30 @@ QString InferAcousticTask::result() const {
     return m_result;
 }
 
+InferAcousticTask::AcousticCacheLookup
+InferAcousticTask::lookupCache(const InferAcousticInput &input) {
+    AcousticCacheLookup lookup;
+    lookup.model = input.toEngineModel();
+    lookup.inputHash = lookup.model.hashData();
+
+    const QDir cacheDir(appOptions->inference()->cacheDirectory);
+    lookup.inputCachePath =
+        cacheDir.filePath(QString("infer-acoustic-input-%1.json").arg(lookup.inputHash));
+    lookup.outputCachePath =
+        cacheDir.filePath(QString("infer-acoustic-output-%1.wav").arg(lookup.inputHash));
+
+    if (!QFile::exists(lookup.outputCachePath))
+        return lookup;
+
+    const auto nativeOutputPath = StringUtils::qstr_to_native(lookup.outputCachePath);
+    const SndfileHandle outputFile(nativeOutputPath.c_str());
+    lookup.hit = outputFile.error() == SF_ERR_NO_ERROR &&
+                 (outputFile.format() & SF_FORMAT_TYPEMASK) == SF_FORMAT_WAV &&
+                 outputFile.channels() == 1 && outputFile.samplerate() == 44100 &&
+                 outputFile.frames() > 0;
+    return lookup;
+}
+
 void InferAcousticTask::runTask() {
     qDebug() << "Running task..."
              << "pieceId:" << pieceId() << " clipId:" << clipId() << "taskId:" << id();
@@ -83,32 +108,23 @@ void InferAcousticTask::runTask() {
     newStatus.isIndetermine = true;
     setStatus(newStatus);
 
-    GenericInferModel model;
-    const auto input = m_input.toEngineModel();
-    m_inputHash = input.hashData();
-    const auto cacheDir = QDir(appOptions->inference()->cacheDirectory);
-    const auto inputCachePath =
-        cacheDir.filePath(QString("infer-acoustic-input-%1.json").arg(m_inputHash));
-    if (!QFile(inputCachePath).exists())
-        JsonUtils::save(inputCachePath, input.serialize());
-    bool useCache = false;
-    const auto outputCachePath =
-        cacheDir.filePath(QString("infer-acoustic-output-%1.wav").arg(m_inputHash));
-    if (QFile(outputCachePath).exists())
-        useCache = true;
+    const auto cache = lookupCache(m_input);
+    m_inputHash = cache.inputHash;
+    if (!QFile::exists(cache.inputCachePath))
+        JsonUtils::save(cache.inputCachePath, cache.model.serialize());
 
     QString errorMessage;
-    if (useCache) {
-        qInfo() << "Use cached acoustic inference result:" << outputCachePath;
-        m_result = outputCachePath;
+    if (cache.hit) {
+        qInfo() << "Use cached acoustic inference result:" << cache.outputCachePath;
+        m_result = cache.outputCachePath;
     } else {
         qDebug() << "acoustic inference cache not found. Running inference...";
         if (isTerminateRequested()) {
             abort();
             return;
         }
-        if (runInference(input, outputCachePath, errorMessage)) {
-            m_result = outputCachePath;
+        if (runInference(cache.model, cache.outputCachePath, errorMessage)) {
+            m_result = cache.outputCachePath;
         } else {
             qCritical() << "Task failed:" << errorMessage;
             return;

--- a/src/app/Modules/Inference/Tasks/InferAcousticTask.h
+++ b/src/app/Modules/Inference/Tasks/InferAcousticTask.h
@@ -40,6 +40,14 @@ public:
         [[nodiscard]] GenericInferModel toEngineModel() const;
     };
 
+    struct AcousticCacheLookup {
+        GenericInferModel model;
+        QString inputHash;
+        QString inputCachePath;
+        QString outputCachePath;
+        bool hit = false;
+    };
+
     [[nodiscard]] int clipId() const override;
     [[nodiscard]] int pieceId() const override;
     [[nodiscard]] InferenceTaskContext inferenceContext() const override;
@@ -48,6 +56,7 @@ public:
     explicit InferAcousticTask(InferAcousticInput input);
     InferAcousticInput input() const;
     QString result() const;
+    [[nodiscard]] static AcousticCacheLookup lookupCache(const InferAcousticInput &input);
 
 private:
     void runTask() override;


### PR DESCRIPTION
<!-- codex-worker issue=51 kind=initial-pr head=c34768ae86294c131ee531b6f36feb3ab313fe52 -->
Closes #51

已批准计划：`plan-v3`

## 变更内容

- 将声学推理缓存哈希、路径解析及 WAV 有效性检查集中到同一个只读解析器；仅把可读取、单声道、44.1 kHz 且包含帧的 WAV 认作命中。
- 新增独立的异步声学缓存探测任务与单队列调度，按播放位置排序，并在推理选项、模型、参数、歌手混合、片段等语义变化时取消过期任务。
- 新增 `ProbeAcousticCacheState` 并接入推理状态机；以任务身份和语义签名拒绝过期结果，按缓存命中、惰性缺失、立即推理三种结果路由。

## 验证结果

- 构建或自动检查：PASS — 使用项目 VS DevShell/CMake preset 脚本完成 `debug` configure 和 build；`DsEditorLite.exe` 链接成功；`git diff --check` 通过。
- 针对改动的 Computer Use 自测：SKIPPED — Computer Use 能力限制：已可靠覆盖单片段有效缓存命中（关闭自动推理后重启并重新打开工程，无需播放即可恢复波形且界面可操作），但无法在不越过真实应用边界的前提下批量构造多片段大工程、损坏/格式错误缓存及任务取消竞态；未观察到业务异常；需要人工补测。
- CTest: SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基本功能回归冒烟测试（用于确认基本功能未发生回归）：PASS — 从无遗留进程的全新 debug 实例加载真实声库 Jun Ninghua，绘制音符并观察到音素、音高曲线与非平坦波形；播放计时和播放头推进后可停止；保存 DSPX，并导出可解析的 44.1 kHz、双声道、PCM float WAV（8.000 秒，2,822,488 字节）。
- Computer Use：分别使用两个全新应用实例执行定向缓存恢复与完整回归流程；窗口 ID 为 `1120606`（定向重载）和 `530436`（冒烟），冒烟进程 PID 为 `32752`；结束后确认无 `DsEditorLite` 窗口或进程残留。
- 人工补测：REQUIRED — 前置条件：在候选提交的 debug 构建中安装可用的 Jun Ninghua 声库，并保留定向工程 `C:\Users\yqzhishen\AppData\Local\Temp\ds-editor-lite-targeted-926af434dfae47e8b931a9cd620c1fdf\acoustic-cache-targeted.dspx`。操作：① 关闭自动推理后打开该工程，确认不播放即可恢复缓存波形且界面响应；② 扩展为多片段大工程，连续修改方差/声学参数、歌手混合与推理选项，并在探测期间删除片段或再次修改；③ 在“选项 → 推理”所示缓存目录中分别删除输出、写入零字节/非 WAV/错误采样率或声道数的同名输出，再重开工程并触发播放。预期：有效缓存命中不阻塞 UI；过期探测结果不回写；缺失或无效缓存按惰性/立即策略转入等待或重新推理，不崩溃、不挂起，最终产生可读取的 44.1 kHz 单声道缓存。
- 候选提交：`c34768ae86294c131ee531b6f36feb3ab313fe52`

## 已知限制

- 上述多片段负载、无效缓存矩阵和快速取消竞态仍需人工补测。
- 冒烟功能断言已通过，但主机策略拒绝递归删除已验证且无进程占用的临时目录；保留路径为 `C:\Users\yqzhishen\AppData\Local\Temp\ds-editor-lite-gui-smoke-b31207d8528d4a058915da444f9f0908`。
- 未运行 CTest，原因见验证结果中的固定说明。