### PR TITLE
fix(settings): CPU 模式下隐藏 GPU 设备行

### DIFF
--- a/src/app/UI/Controls/OptionListCard.cpp
+++ b/src/app/UI/Controls/OptionListCard.cpp
@@ -21,9 +21,13 @@ OptionListCard::OptionListCard(QString title, QWidget *parent)
 }
 
 OptionsCardItem *OptionListCard::addItem(OptionsCardItem *item) {
-    if (m_itemCount > 0)
-        m_cardLayout->addWidget(new DividerLine(Qt::Horizontal));
+    DividerLine *divider = nullptr;
+    if (m_itemCount > 0) {
+        divider = new DividerLine(Qt::Horizontal);
+        m_cardLayout->addWidget(divider);
+    }
     m_cardLayout->addWidget(item);
+    m_itemDividers.insert(item, divider);
     m_itemCount++;
     return item;
 }
@@ -67,6 +71,16 @@ OptionsCardItem *OptionListCard::addItem(const QString &title, const QString &de
     for (const auto control : controls)
         item->addWidget(control);
     return addItem(item);
+}
+
+void OptionListCard::setItemVisible(OptionsCardItem *item, bool visible) {
+    const auto divider = m_itemDividers.constFind(item);
+    if (divider == m_itemDividers.cend())
+        return;
+
+    if (*divider)
+        (*divider)->setVisible(visible);
+    item->setVisible(visible);
 }
 
 void OptionListCard::initUi() {

--- a/src/app/UI/Controls/OptionListCard.h
+++ b/src/app/UI/Controls/OptionListCard.h
@@ -7,6 +7,9 @@
 
 #include "OptionsCard.h"
 
+#include <QHash>
+
+class DividerLine;
 class OptionsCardItem;
 class QVBoxLayout;
 
@@ -24,12 +27,14 @@ public:
     OptionsCardItem *addItem(const QString &title, const QString &description, QWidget *control);
     OptionsCardItem *addItem(const QString &title, const QString &description,
                              const QList<QWidget *> &controls);
+    void setItemVisible(OptionsCardItem *item, bool visible);
 
 private:
     using OptionsCard::card;
     void initUi();
     QString m_title = "Card Title";
     QVBoxLayout *m_cardLayout = nullptr;
+    QHash<OptionsCardItem *, DividerLine *> m_itemDividers;
     int m_itemCount = 0;
 };
 

--- a/src/app/UI/Dialogs/Options/Pages/InferencePage.cpp
+++ b/src/app/UI/Dialogs/Options/Pages/InferencePage.cpp
@@ -126,16 +126,24 @@ QWidget *InferencePage::createContentWidget() {
     const auto deviceCard = new OptionListCard(tr("Device"));
     deviceCard->addItem(tr("Execution Provider"), tr("App needs a restart to take effect"),
                         m_cbExecutionProvider);
+    OptionsCardItem *gpuItem;
     if (hasAvailableGpu) {
-        deviceCard->addItem(tr("GPU"),
-                            tr("GPUs with less than %1 GiB VRAM are hidden")
-                                .arg(static_cast<double>(kMinGpuVramBytes) / (1024 * 1024 * 1024), 0, 'f', 0),
-                            m_cbDeviceList);
+        gpuItem = deviceCard->addItem(
+            tr("GPU"),
+            tr("GPUs with less than %1 GiB VRAM are hidden")
+                .arg(static_cast<double>(kMinGpuVramBytes) / (1024 * 1024 * 1024), 0, 'f', 0),
+            m_cbDeviceList);
     } else {
-        deviceCard->addItem(
+        gpuItem = deviceCard->addItem(
             tr("GPU"),
             tr("No available GPU found. Please switch the Execution Provider above to CPU."));
     }
+    const auto updateGpuItemVisibility = [this, deviceCard, gpuItem] {
+        deviceCard->setItemVisible(gpuItem, m_cbExecutionProvider->currentText() != "CPU");
+    };
+    connect(m_cbExecutionProvider, &ComboBox::currentIndexChanged, this,
+            updateGpuItemVisibility);
+    updateGpuItemVisibility();
 
     // Render - Sampling Steps
     m_cbSamplingSteps = new ComboBox();


### PR DESCRIPTION
<!-- codex-worker issue=53 kind=initial-pr head=bed3f458c881ffcd12b7f4fb2c59ce7f03851a50 -->
Closes #53

## 变更

- 为 `OptionListCard` 增加条目可见性控制，并同步隐藏或显示条目前的分隔线。
- 推理设置保留 GPU 条目引用；执行提供程序为 CPU 时隐藏 GPU 行，切换到 DirectML/CUDA 时恢复显示。
- 按已批准计划 `plan-v1` 的两个提交边界实现。

## 验证

- 构建或自动检查: PASS
  - `powershell -NoProfile -ExecutionPolicy Bypass -File .agents/skills/scripts/run-cmake-preset.ps1 -Mode ConfigureAndBuild -Preset debug`
  - Debug 配置与构建完成，`DsEditorLite.exe` 链接及依赖部署成功。
- 针对改动的 Computer Use 自测: SKIPPED — 已在真实 Debug 程序中确认 CPU 初始状态不显示 GPU 行及其前置分隔线；切换到 DirectML 后 GPU 行、分隔线和“未找到可用的 GPU”提示立即出现；切回 CPU 后三者立即消失。Computer Use 在重启提示框输入上反复超时，未能可靠完成关闭并重开设置及重启后的持久化/枚举断言，因此不能报告完整通过。
- CTest: SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基本功能回归冒烟测试（用于确认基本功能未发生回归）: PASS
  - 独立启动 `build/Debug/bin/DsEditorLite.exe`，选择 `Jun Ninghua`，绘制 C4 音符并观察到歌词 `啦`、音素 `la`、非平直音高曲线和非空合成波形。
  - 播放时间从 `001:01:000` 前进到 `002:01:087`，播放头同步前进。
  - DSPX 保存成功（6,859 字节）；WAV 导出成功（2,822,488 字节，RIFF/WAVE，`pcm_f32le`，44,100 Hz，双声道，8.000000 秒，`max_volume: -16.9 dB`）。
  - 独立测试进程已退出，精确验证的临时目录已清理。

## 人工补测

REQUIRED（针对改动的 Computer Use 自测存在工具限制）

前置条件：使用本 PR 的 Debug/Release 构建；执行提供程序列表包含 CPU 和可用的 DirectML/CUDA 项。若需验证设备枚举，准备至少一张满足显存门槛的受支持 GPU。

1. 打开“选项 → 推理”，选择 CPU；确认设备卡片只显示执行提供程序，GPU 行及其前置分隔线均不可见。
2. 切换到 DirectML 或 CUDA，并在重启提示中选择稍后重启；确认 GPU 行和分隔线立即出现，内容为实际设备下拉列表，或在无可用设备时显示对应提示。
3. 切回 CPU，并在重启提示中选择稍后重启；确认 GPU 行、提示和分隔线立即消失。
4. 关闭并重新打开设置，再重启应用；确认 CPU 状态持续隐藏 GPU 行。
5. 切换到可用的 GPU 提供程序并重启；确认 GPU 行恢复，设备枚举内容正确。

## 风险与限制

- 自动化环境没有可用 GPU，实际 GPU 设备枚举需按上述步骤人工确认。
- 重启提示框的 Computer Use 超时仅影响自动化覆盖范围；动态显示/隐藏行为和独立基本功能烟测未发现业务异常。

候选提交：`bed3f458c881ffcd12b7f4fb2c59ce7f03851a50`
