### PR TITLE
fix: MIDI 工程首次保存预填 DSPX 文件名

### DIFF
--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.cpp
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.cpp
@@ -1,6 +1,7 @@
 #include "DocumentWorkflowController.h"
 
 #include "DspxLoadSession.h"
+#include "DocumentWorkflowPathUtils.h"
 #include "IDocumentWorkflowUi.h"
 #include "IProjectLoadSession.h"
 #include "LegacyMidiLoadSession.h"
@@ -643,7 +644,8 @@ void DocumentWorkflowController::addRecentProjectFile(const QString &path) {
 }
 
 QString DocumentWorkflowController::suggestedSavePath() const {
-    return m_projectPath.isEmpty() ? m_lastProjectFolder + "/" + projectName() : m_projectPath;
+    return DocumentWorkflowPathUtils::suggestedSavePath(m_projectPath, m_lastProjectFolder,
+                                                        projectName());
 }
 
 void DocumentWorkflowController::rejectBusyRequest() {

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowPathUtils.cpp
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowPathUtils.cpp
@@ -1,0 +1,17 @@
+#include "DocumentWorkflowPathUtils.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+namespace DocumentWorkflowPathUtils {
+    QString suggestedSavePath(const QString &projectPath, const QString &lastProjectFolder,
+                              const QString &projectName) {
+        if (!projectPath.isEmpty())
+            return projectPath;
+
+        auto fileName = projectName;
+        if (QFileInfo(fileName).suffix().compare(QStringLiteral("dspx"), Qt::CaseInsensitive) != 0)
+            fileName += QStringLiteral(".dspx");
+        return QDir(lastProjectFolder).filePath(fileName);
+    }
+}

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowPathUtils.h
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowPathUtils.h
@@ -1,0 +1,11 @@
+#ifndef DOCUMENTWORKFLOWPATHUTILS_H
+#define DOCUMENTWORKFLOWPATHUTILS_H
+
+#include <QString>
+
+namespace DocumentWorkflowPathUtils {
+    QString suggestedSavePath(const QString &projectPath, const QString &lastProjectFolder,
+                              const QString &projectName);
+}
+
+#endif // DOCUMENTWORKFLOWPATHUTILS_H

--- a/src/app/Controller/DocumentWorkflow/LegacyMidiLoadSession.cpp
+++ b/src/app/Controller/DocumentWorkflow/LegacyMidiLoadSession.cpp
@@ -47,7 +47,7 @@ void LegacyMidiLoadSession::start() {
         payload.loopSettings = LoopSettings();
         payload.sourceKind = ProjectSourceKind::Foreign;
         payload.sourcePath = m_filePath;
-        payload.displayName = QFileInfo(m_filePath).baseName();
+        payload.displayName = QFileInfo(m_filePath).completeBaseName();
         m_result = std::move(payload);
     } else {
         AppendProjectPayload payload;

--- a/src/app/UI/Window/MainWindow.cpp
+++ b/src/app/UI/Window/MainWindow.cpp
@@ -276,8 +276,8 @@ void MainWindow::updateWindowTitle() {
         setWindowTitle(appName);
     else {
         auto projectPath = documentWorkflowController->projectPath();
-        auto displayName = projectPath.isEmpty() ? QFileInfo(projectName).completeBaseName()
-                                                 : QFileInfo(projectPath).completeBaseName();
+        auto displayName =
+            projectPath.isEmpty() ? projectName : QFileInfo(projectPath).completeBaseName();
         auto indicator = saved ? "" : "● ";
         setWindowTitle(indicator + displayName);
     }

--- a/src/tests/TestDocumentWorkflow/CMakeLists.txt
+++ b/src/tests/TestDocumentWorkflow/CMakeLists.txt
@@ -3,6 +3,7 @@ project(TestDocumentWorkflow)
 lite_add_test(${PROJECT_NAME}
         SOURCES
         main.cpp
+        ../../app/Controller/DocumentWorkflow/DocumentWorkflowPathUtils.cpp
         ../../libs/ProjectModel/AppModel/LoopSettings.cpp
         ../../app/Model/AppStatus/AppStatus.cpp
         ../../app/Utils/ConditionalTransition.cpp

--- a/src/tests/TestDocumentWorkflow/main.cpp
+++ b/src/tests/TestDocumentWorkflow/main.cpp
@@ -1,3 +1,4 @@
+#include "Controller/DocumentWorkflow/DocumentWorkflowPathUtils.h"
 #include "Model/AppStatus/AppStatus.h"
 #include <lite/History/ActionSequence.h>
 #include "AppContext.h"
@@ -5,6 +6,7 @@
 #include "Utils/ConditionalTransition.h"
 
 #include <QCoreApplication>
+#include <QDir>
 #include <QState>
 #include <QStateMachine>
 #include <QTextStream>
@@ -103,6 +105,35 @@ namespace {
         QCoreApplication::processEvents();
         return condition ? whenTrue->active() : whenFalse->active();
     }
+
+    bool verifySuggestedSavePaths() {
+        const auto sourceFolder = QDir::cleanPath(QDir::tempPath() + "/midi-source");
+        bool ok = true;
+        ok &= expect(DocumentWorkflowPathUtils::suggestedSavePath({}, sourceFolder,
+                                                                  QStringLiteral("test")) ==
+                         QDir(sourceFolder).filePath(QStringLiteral("test.dspx")),
+                     "MIDI save path must replace the source extension with .dspx");
+        ok &= expect(DocumentWorkflowPathUtils::suggestedSavePath({}, sourceFolder,
+                                                                  QStringLiteral("song.v1")) ==
+                         QDir(sourceFolder).filePath(QStringLiteral("song.v1.dspx")),
+                     "MIDI save path must preserve every part of a multi-dot base name");
+        ok &= expect(DocumentWorkflowPathUtils::suggestedSavePath(
+                         {}, sourceFolder, QStringLiteral("New Project")) ==
+                         QDir(sourceFolder).filePath(QStringLiteral("New Project.dspx")),
+                     "new project save path must include a .dspx file name");
+        ok &= expect(DocumentWorkflowPathUtils::suggestedSavePath(
+                         {}, sourceFolder, QStringLiteral("draft.dspx")) ==
+                         QDir(sourceFolder).filePath(QStringLiteral("draft.dspx")),
+                     "suggested save path must not duplicate an existing .dspx extension");
+
+        const auto existingProject =
+            QDir(sourceFolder).filePath(QStringLiteral("existing.project.dspx"));
+        ok &= expect(DocumentWorkflowPathUtils::suggestedSavePath(
+                         existingProject, QStringLiteral("ignored"), QStringLiteral("ignored")) ==
+                         existingProject,
+                     "existing DSPX project path must remain unchanged");
+        return ok;
+    }
 }
 
 int main(int argc, char *argv[]) {
@@ -169,6 +200,7 @@ int main(int argc, char *argv[]) {
     ok &= expect(manager->isOnSavePoint(), "saved reset after import must be clean");
     ok &= expect(verifyGuardedBranch(true), "true guard must select the true target state");
     ok &= expect(verifyGuardedBranch(false), "false guard must select the false target state");
+    ok &= verifySuggestedSavePaths();
 
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
<!-- codex-worker issue=66 kind=initial-pr head=71e3cfa611cee370b81676334dc36a994e6a24c0 -->
Closes #66

已批准计划：`plan-v1`

## 变更内容
- MIDI 导入时使用完整基础文件名，保留 `song.v1.mid` 中的 `.v1`。
- 未保存工程首次保存时，在源目录预填 `<工程名>.dspx`，并避免重复追加扩展名。
- 路径逻辑抽为可编译断言覆盖的工具函数；原生 DSPX 工程路径保持不变。
- 路径为空时窗口标题直接使用工程显示名，避免对外来工程名二次剥离后缀。

## 验证结果
- 构建或自动检查：PASS — Debug preset 完整 ConfigureAndBuild 成功；修复多点标题后再次执行 Debug preset Build 成功。新增断言源码已编译，但未运行测试可执行文件。
- 针对改动的 Computer Use 自测：PASS — Python 标准库生成最小合法 MIDI；`test.mid` 显示 `● test` 并在源目录预填 `test.dspx`；`song.v1.mid` 显示 `● song.v1` 并预填 `song.v1.dspx`；新工程预填 `新工程.dspx`；既有 `existing.project.dspx` 保留完整路径与文件名（保存文件 1219 字节）。实例窗口 ID `13310836`，结束后窗口与临时目录均已清理。
- CTest：SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基本功能回归冒烟测试（用于确认基本功能未发生回归）：PASS — Debug 可执行文件 `D:\OpenVPI\ds-editor-lite\build\Debug\out\bin\DsEditorLite.exe`；窗口 ID `175708382`、进程 ID `27816`；加载真实歌手 `Jun Ninghua`，在一拍空白后绘制 C4 音符，观察到默认歌词/音素 `啦`/`la`、音高曲线和非平坦合成波形；播放位置由 `001:01:000` 前进至 `004:02:170`；保存 DSPX 为 6461 字节；窗口、进程和临时目录均已清理。
- Computer Use：PASS — 定向验证和独立基础功能冒烟门禁均通过。
- 人工补测：NONE
- 候选提交：`71e3cfa611cee370b81676334dc36a994e6a24c0`

## 已知限制
- 按基本功能冒烟技能的临时限制未执行音频导出；该项不在 Issue #66 范围内。