### PR TITLE
AppModel 数据变更通知机制需重构

### DIFF
--- a/src/app/Controller/Actions/AppModel/Track/AppendTrackAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Track/AppendTrackAction.cpp
@@ -18,11 +18,20 @@ AppendTrackAction *AppendTrackAction::build(Track *track, AppModel *model) {
 AppendTrackAction::~AppendTrackAction() = default;
 
 void AppendTrackAction::execute() {
-    if (m_ownedTrack)
-        m_ownedTrack.release();
-    m_model->appendTrack(m_track);
+    const auto index = m_model->tracks().size();
+    if (!m_model->appendTrack(m_track))
+        return;
+    m_ownedTrack.release();
+    m_model->notifyTrackChanged(AppModel::Insert, index, m_track);
 }
 
 void AppendTrackAction::undo() {
-    m_ownedTrack.reset(m_model->takeTrack(m_track));
+    const auto index = m_model->tracks().indexOf(m_track);
+    if (index < 0)
+        return;
+    const auto track = m_model->takeTrack(m_track);
+    if (!track)
+        return;
+    m_ownedTrack.reset(track);
+    m_model->notifyTrackChanged(AppModel::Remove, index, track);
 }

--- a/src/app/Controller/Actions/AppModel/Track/InsertTrackAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Track/InsertTrackAction.cpp
@@ -20,8 +20,10 @@ InsertTrackAction *InsertTrackAction::build(Track *track, const qsizetype index,
 InsertTrackAction::~InsertTrackAction() = default;
 
 void InsertTrackAction::execute() {
-    if (m_ownedTrack)
-        m_ownedTrack.release();
+    if (!m_track || m_index < 0 || m_index > m_model->tracks().size() ||
+        m_model->tracks().contains(m_track))
+        return;
+
     // Imported tracks may carry audio clips whose ticks are authoritative;
     // establish the realtime anchor under the timeline in effect now
     for (const auto clip : m_track->clips()) {
@@ -31,9 +33,19 @@ void InsertTrackAction::execute() {
         if (!audioClip->hasRealTimeAnchor())
             audioClip->syncTruthFromTicks(m_model->timeline());
     }
-    m_model->insertTrack(m_track, m_index);
+    if (!m_model->insertTrack(m_track, m_index))
+        return;
+    m_ownedTrack.release();
+    m_model->notifyTrackChanged(AppModel::Insert, m_index, m_track);
 }
 
 void InsertTrackAction::undo() {
-    m_ownedTrack.reset(m_model->takeTrack(m_track));
+    const auto index = m_model->tracks().indexOf(m_track);
+    if (index < 0)
+        return;
+    const auto track = m_model->takeTrack(m_track);
+    if (!track)
+        return;
+    m_ownedTrack.reset(track);
+    m_model->notifyTrackChanged(AppModel::Remove, index, track);
 }

--- a/src/app/Controller/Actions/AppModel/Track/MoveTrackAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Track/MoveTrackAction.cpp
@@ -16,22 +16,33 @@ MoveTrackAction *MoveTrackAction::build(const qsizetype fromIndex, const qsizety
 }
 
 void MoveTrackAction::execute() {
-    if (m_fromIndex == m_toIndex)
-        return;
+    if (!m_track) {
+        const auto size = m_model->tracks().size();
+        if (m_fromIndex < 0 || m_fromIndex >= size || m_toIndex < 0 || m_toIndex > size)
+            return;
 
-    const auto size = m_model->tracks().size();
-    if (m_fromIndex < 0 || m_fromIndex >= size || m_toIndex < 0 || m_toIndex > size)
-        return;
+        // 拖拽给出的 toIndex 是「插入到该位置之前」的语义；moveTrack 需要的是移动后的
+        // 最终下标，因此当目标位于源之后时要向前修正一位。
+        m_actualToIndex = m_toIndex > m_fromIndex ? m_toIndex - 1 : m_toIndex;
+        if (m_fromIndex == m_actualToIndex)
+            return;
+        m_track = m_model->tracks().at(m_fromIndex);
+    }
 
-    // 拖拽给出的 toIndex 是「插入到该位置之前」的语义；moveTrack 需要的是移动后的
-    // 最终下标，因此当目标位于源之后时要向前修正一位
-    m_actualToIndex = m_toIndex > m_fromIndex ? m_toIndex - 1 : m_toIndex;
-    m_model->moveTrack(m_fromIndex, m_actualToIndex);
+    const auto currentIndex = m_model->tracks().indexOf(m_track);
+    if (currentIndex < 0 || currentIndex == m_actualToIndex)
+        return;
+    if (m_model->moveTrack(currentIndex, m_actualToIndex))
+        m_model->notifyTrackMoved(currentIndex, m_actualToIndex);
 }
 
 void MoveTrackAction::undo() {
-    if (m_fromIndex == m_toIndex || m_actualToIndex < 0)
+    if (!m_track || m_actualToIndex < 0)
         return;
 
-    m_model->moveTrack(m_actualToIndex, m_fromIndex);
+    const auto currentIndex = m_model->tracks().indexOf(m_track);
+    if (currentIndex < 0 || currentIndex == m_fromIndex)
+        return;
+    if (m_model->moveTrack(currentIndex, m_fromIndex))
+        m_model->notifyTrackMoved(currentIndex, m_fromIndex);
 }

--- a/src/app/Controller/Actions/AppModel/Track/MoveTrackAction.h
+++ b/src/app/Controller/Actions/AppModel/Track/MoveTrackAction.h
@@ -10,6 +10,7 @@
 #include <QtTypes>
 
 class AppModel;
+class Track;
 
 class MoveTrackAction final : public IAction {
 public:
@@ -21,6 +22,7 @@ private:
     qsizetype m_fromIndex = -1;
     qsizetype m_toIndex = -1;
     qsizetype m_actualToIndex = -1; // The actual index after adjustment
+    Track *m_track = nullptr;
     AppModel *m_model = nullptr;
 };
 

--- a/src/app/Controller/Actions/AppModel/Track/RemoveTrackAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Track/RemoveTrackAction.cpp
@@ -18,11 +18,23 @@ RemoveTrackAction *RemoveTrackAction::build(Track *track, AppModel *model) {
 RemoveTrackAction::~RemoveTrackAction() = default;
 
 void RemoveTrackAction::execute() {
-    m_ownedTrack.reset(m_model->takeTrack(m_track));
+    const auto index = m_model->tracks().indexOf(m_track);
+    if (index < 0)
+        return;
+    const auto track = m_model->takeTrack(m_track);
+    if (!track)
+        return;
+    m_index = index;
+    m_ownedTrack.reset(track);
+    m_model->notifyTrackChanged(AppModel::Remove, index, track);
 }
 
 void RemoveTrackAction::undo() {
     if (!m_ownedTrack)
         return;
-    m_model->insertTrack(m_ownedTrack.release(), m_index);
+    const auto track = m_ownedTrack.get();
+    if (!m_model->insertTrack(track, m_index))
+        return;
+    m_ownedTrack.release();
+    m_model->notifyTrackChanged(AppModel::Insert, m_index, track);
 }

--- a/src/app/Controller/ProjectStatusController.cpp
+++ b/src/app/Controller/ProjectStatusController.cpp
@@ -10,22 +10,6 @@
 
 LITE_SINGLETON_IMPLEMENT_INSTANCE(ProjectStatusController)
 
-void ProjectStatusController::handleTrackRemoved(Track *track) {
-    ModelChangeHandler::handleTrackRemoved(track);
-    bool trackContainsActiveClip = false;
-    for (const auto clip : track->clips()) {
-        if (clip->id() == appStatus->activeClipId) {
-            trackContainsActiveClip = true;
-            break;
-        }
-    }
-    // 若该剪辑仍能在模型中找到，说明这是轨道重排（移动）而非删除，保留当前编辑状态
-    if (trackContainsActiveClip && !appModel->findClipById(appStatus->activeClipId)) {
-        appStatus->selectedNotes = QList<int>();
-        appStatus->activeClipId = -1;
-    }
-}
-
 void ProjectStatusController::handleTempoChanged() {
     updateProjectEditableLength();
 }

--- a/src/app/Controller/ProjectStatusController.h
+++ b/src/app/Controller/ProjectStatusController.h
@@ -20,7 +20,6 @@ public:
     Q_DISABLE_COPY_MOVE(ProjectStatusController)
 
 private:
-    void handleTrackRemoved(Track *track) override;
     void handleTempoChanged() override;
     void handleClipInserted(Clip *clip) override;
     void handleClipRemoved(Clip *clip) override;

--- a/src/app/Modules/Audio/AudioContext.cpp
+++ b/src/app/Modules/Audio/AudioContext.cpp
@@ -134,6 +134,11 @@ AudioContext::AudioContext(QObject *parent) : DspxProjectContext(parent) {
                         break;
                 }
             });
+    connect(appModel, &AppModel::trackMoved, this, [this](const qsizetype from,
+                                                          const qsizetype to) {
+        DEVICE_LOCKER;
+        handleTrackMoved(static_cast<int>(from), static_cast<int>(to));
+    });
 
     connect(appModel, &AppModel::timelineChanged, this, [this] {
         DEVICE_LOCKER;
@@ -435,6 +440,16 @@ void AudioContext::handleTrackRemoved(const int index, Track *track) {
     m_trackInferDict.remove(track);
     m_trackModelDict.remove(track);
     m_trackLevelMeterValue.remove(track);
+}
+
+void AudioContext::handleTrackMoved(const int from, const int to) {
+    const auto trackCount = tracks().size();
+    if (from == to || from < 0 || from >= trackCount || to < 0 || to >= trackCount)
+        return;
+
+    // talcs 的 dest 是从原列表移除前的插入位置；AppModel 的 to 是最终下标。
+    const auto destination = to > from ? to + 1 : to;
+    talcs::DspxProjectContext::moveTrack(from, 1, destination);
 }
 
 void AudioContext::handleMasterControlChanged(const TrackControl &control) const {

--- a/src/app/Modules/Audio/AudioContext.h
+++ b/src/app/Modules/Audio/AudioContext.h
@@ -88,6 +88,7 @@ private:
     void handleModelChanged();
     void handleTrackInserted(int index, Track *track);
     void handleTrackRemoved(int index, Track *track);
+    void handleTrackMoved(int from, int to);
 
     void handleMasterControlChanged(const TrackControl &control) const;
     void handleTrackControlChanged(Track *track) const;

--- a/src/app/UI/Controls/LevelMeterManager.cpp
+++ b/src/app/UI/Controls/LevelMeterManager.cpp
@@ -13,6 +13,10 @@ LevelMeterManager::LevelMeterManager(AppModel *model, QObject *parent)
             [this](AppModel::TrackChangeType type, qsizetype index, Track *track) {
                 onTrackChanged(static_cast<int>(type), static_cast<int>(index), track);
             });
+    connect(m_appModel, &AppModel::trackMoved, this, [this](const qsizetype from,
+                                                           const qsizetype to) {
+        moveModel(static_cast<int>(from), static_cast<int>(to));
+    });
 }
 
 LevelMeterViewModel *LevelMeterManager::viewModelForTrack(const Track *track) const {
@@ -65,6 +69,13 @@ void LevelMeterManager::removeModelAt(int index) {
     if (index < 0 || index >= m_viewModels.size())
         return;
     delete m_viewModels.takeAt(index);
+}
+
+void LevelMeterManager::moveModel(const int from, const int to) {
+    if (from == to || from < 0 || from >= m_viewModels.size() || to < 0 ||
+        to >= m_viewModels.size())
+        return;
+    m_viewModels.move(from, to);
 }
 
 void LevelMeterManager::clearAll() {

--- a/src/app/UI/Controls/LevelMeterManager.h
+++ b/src/app/UI/Controls/LevelMeterManager.h
@@ -26,6 +26,7 @@ private:
     void syncAll();
     void insertModel(int index);
     void removeModelAt(int index);
+    void moveModel(int from, int to);
     void clearAll();
 
     AppModel *m_appModel = nullptr;

--- a/src/app/UI/Views/MixConsole/MixConsoleView.cpp
+++ b/src/app/UI/Views/MixConsole/MixConsoleView.cpp
@@ -113,6 +113,7 @@ MixConsoleView::MixConsoleView(QWidget *parent) : TabPanelPage(parent) {
     onModelChanged();
     connect(appModel, &AppModel::modelChanged, this, &MixConsoleView::onModelChanged);
     connect(appModel, &AppModel::trackChanged, this, &MixConsoleView::onTrackChanged);
+    connect(appModel, &AppModel::trackMoved, this, &MixConsoleView::onTrackMoved);
     connect(appModel, &AppModel::masterControlChanged, this,
             &MixConsoleView::onMasterControlChanged);
 
@@ -151,6 +152,28 @@ void MixConsoleView::onTrackChanged(AppModel::TrackChangeType type, qsizetype in
         onTrackInserted(track, index);
     else if (type == AppModel::Remove)
         onTrackRemoved(index);
+}
+
+void MixConsoleView::onTrackMoved(const qsizetype from, const qsizetype to) {
+    const auto count = m_channelListView->count();
+    if (from == to || from < 0 || from >= count || to < 0 || to >= count)
+        return;
+
+    const auto sourceItem = m_channelListView->item(from);
+    const auto sourceWidget = m_channelListView->itemWidget(sourceItem);
+    m_channelListView->removeItemWidget(sourceItem);
+    const auto movedItem = m_channelListView->takeItem(from);
+    m_channelListView->insertItem(to, movedItem);
+    m_channelListView->setItemWidget(movedItem, sourceWidget);
+
+    const auto firstChangedIndex = qMin(from, to);
+    const auto lastChangedIndex = qMax(from, to);
+    for (auto i = firstChangedIndex; i <= lastChangedIndex; ++i) {
+        const auto item = m_channelListView->item(i);
+        const auto channelView =
+            qobject_cast<ChannelView *>(m_channelListView->itemWidget(item));
+        channelView->setChannelIndex(i + 1);
+    }
 }
 
 void MixConsoleView::onMasterControlChanged(const TrackControl &control) {

--- a/src/app/UI/Views/MixConsole/MixConsoleView.cpp
+++ b/src/app/UI/Views/MixConsole/MixConsoleView.cpp
@@ -159,12 +159,9 @@ void MixConsoleView::onTrackMoved(const qsizetype from, const qsizetype to) {
     if (from == to || from < 0 || from >= count || to < 0 || to >= count)
         return;
 
-    const auto sourceItem = m_channelListView->item(from);
-    const auto sourceWidget = m_channelListView->itemWidget(sourceItem);
-    m_channelListView->removeItemWidget(sourceItem);
-    const auto movedItem = m_channelListView->takeItem(from);
-    m_channelListView->insertItem(to, movedItem);
-    m_channelListView->setItemWidget(movedItem, sourceWidget);
+    const auto destination = to > from ? to + 1 : to;
+    if (!m_channelListView->model()->moveRow({}, from, {}, destination))
+        return;
 
     const auto firstChangedIndex = qMin(from, to);
     const auto lastChangedIndex = qMax(from, to);

--- a/src/app/UI/Views/MixConsole/MixConsoleView.h
+++ b/src/app/UI/Views/MixConsole/MixConsoleView.h
@@ -32,6 +32,7 @@ public:
 public slots:
     void onModelChanged();
     void onTrackChanged(AppModel::TrackChangeType type, qsizetype index, Track *track);
+    void onTrackMoved(qsizetype from, qsizetype to);
     void onMasterControlChanged(const TrackControl &control);
 
 private slots:

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
@@ -203,6 +203,7 @@ TrackEditorView::TrackEditorView(QWidget *parent) : PanelView(AppGlobal::TracksE
             &TrackEditorView::onLastPositionChanged);
     connect(appModel, &AppModel::modelChanged, this, &TrackEditorView::onModelChanged);
     connect(appModel, &AppModel::trackChanged, this, &TrackEditorView::onTrackChanged);
+    connect(appModel, &AppModel::trackMoved, this, &TrackEditorView::onTrackMoved);
 
     connect(appStatus, &AppStatus::projectEditableLengthChanged, m_graphicsView,
             &TracksGraphicsView::setSceneLength);
@@ -347,6 +348,44 @@ void TrackEditorView::onTrackChanged(const AppModel::TrackChangeType type, const
     else if (type == AppModel::Remove)
         onTrackRemoved(track, index);
     emit trackCountChanged(m_viewModel.tracks.count());
+}
+
+void TrackEditorView::onTrackMoved(const qsizetype from, const qsizetype to) {
+    const auto count = m_viewModel.tracks.size();
+    if (from == to || from < 0 || from >= count || to < 0 || to >= count)
+        return;
+
+    const auto previousSelectedTrackIndex = static_cast<int>(appStatus->selectedTrackIndex);
+    const QSignalBlocker listBlocker(m_trackListView);
+
+    const auto sourceItem = m_trackListView->item(from);
+    const auto sourceWidget = m_trackListView->itemWidget(sourceItem);
+    m_trackListView->removeItemWidget(sourceItem);
+    const auto movedItem = m_trackListView->takeItem(from);
+    m_trackListView->insertItem(to, movedItem);
+    m_trackListView->setItemWidget(movedItem, sourceWidget);
+    m_viewModel.tracks.move(from, to);
+
+    const auto firstChangedIndex = qMin(from, to);
+    const auto lastChangedIndex = qMax(from, to);
+    for (auto i = firstChangedIndex; i <= lastChangedIndex; ++i) {
+        const auto trackVm = m_viewModel.tracks.at(i);
+        trackVm->controlView->setTrackIndex(i + 1);
+        for (const auto clipItem : trackVm->clips)
+            clipItem->setTrackIndex(i);
+    }
+
+    auto selectedTrackIndex = previousSelectedTrackIndex;
+    if (previousSelectedTrackIndex == from) {
+        selectedTrackIndex = static_cast<int>(to);
+    } else if (from < to && previousSelectedTrackIndex > from &&
+               previousSelectedTrackIndex <= to) {
+        selectedTrackIndex = previousSelectedTrackIndex - 1;
+    } else if (to < from && previousSelectedTrackIndex >= to &&
+               previousSelectedTrackIndex < from) {
+        selectedTrackIndex = previousSelectedTrackIndex + 1;
+    }
+    setSelectedTrackIndex(selectedTrackIndex);
 }
 
 void TrackEditorView::onClipChanged(const Track::ClipChangeType type, Clip *clip,

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
@@ -358,12 +358,9 @@ void TrackEditorView::onTrackMoved(const qsizetype from, const qsizetype to) {
     const auto previousSelectedTrackIndex = static_cast<int>(appStatus->selectedTrackIndex);
     const QSignalBlocker listBlocker(m_trackListView);
 
-    const auto sourceItem = m_trackListView->item(from);
-    const auto sourceWidget = m_trackListView->itemWidget(sourceItem);
-    m_trackListView->removeItemWidget(sourceItem);
-    const auto movedItem = m_trackListView->takeItem(from);
-    m_trackListView->insertItem(to, movedItem);
-    m_trackListView->setItemWidget(movedItem, sourceWidget);
+    const auto destination = to > from ? to + 1 : to;
+    if (!m_trackListView->model()->moveRow({}, from, {}, destination))
+        return;
     m_viewModel.tracks.move(from, to);
 
     const auto firstChangedIndex = qMin(from, to);

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.h
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.h
@@ -45,6 +45,7 @@ public:
 public slots:
     void onModelChanged();
     void onTrackChanged(AppModel::TrackChangeType type, qsizetype index, Track *track);
+    void onTrackMoved(qsizetype from, qsizetype to);
     void onClipChanged(Track::ClipChangeType type, Clip *clip, const Track *dsTrack);
     void onPositionChanged(double tick) const;
     void onLastPositionChanged(double tick) const;

--- a/src/libs/ProjectModel/AppModel/AppModel.cpp
+++ b/src/libs/ProjectModel/AppModel/AppModel.cpp
@@ -100,8 +100,11 @@ const QList<Track *> &AppModel::tracks() const {
     return d->m_tracks;
 }
 
-void AppModel::insertTrack(Track *track, const qsizetype index) {
+bool AppModel::insertTrack(Track *track, const qsizetype index) {
     Q_D(AppModel);
+    if (!track || index < 0 || index > d->m_tracks.size() || d->m_tracks.contains(track))
+        return false;
+
     if (track->colorIndex() == 0) {
         int prev = -1;
         if (index > 0 && index - 1 < d->m_tracks.size())
@@ -112,29 +115,24 @@ void AppModel::insertTrack(Track *track, const qsizetype index) {
         track->setColorIndex(newIdx);
     }
     d->m_tracks.insert(index, track);
-
-    emit trackChanged(Insert, index, track);
+    return true;
 }
 
-void AppModel::appendTrack(Track *track) {
+bool AppModel::appendTrack(Track *track) {
     Q_D(AppModel);
-    insertTrack(track, d->m_tracks.count());
+    return insertTrack(track, d->m_tracks.count());
 }
 
-void AppModel::moveTrack(const qsizetype from, const qsizetype to) {
+bool AppModel::moveTrack(const qsizetype from, const qsizetype to) {
     Q_D(AppModel);
     if (from == to)
-        return;
+        return false;
     const auto size = d->m_tracks.size();
     if (from < 0 || from >= size || to < 0 || to >= size)
-        return;
+        return false;
 
-    const auto track = d->m_tracks.at(from);
     d->m_tracks.move(from, to);
-
-    // 先重排、后通知：发信号时模型已处于一致状态，监听者据此判定这是移动而非删除
-    emit trackChanged(Remove, from, track);
-    emit trackChanged(Insert, to, track);
+    return true;
 }
 
 void AppModel::removeTrackAt(const qsizetype index) {
@@ -149,9 +147,7 @@ Track *AppModel::takeTrackAt(const qsizetype index) {
     Q_D(AppModel);
     if (index < 0 || index >= d->m_tracks.count())
         return nullptr;
-    const auto track = d->m_tracks.takeAt(index);
-    emit trackChanged(Remove, index, track);
-    return track;
+    return d->m_tracks.takeAt(index);
 }
 
 Track *AppModel::takeTrack(Track *track) {
@@ -163,6 +159,18 @@ void AppModel::clearTracks() {
     Q_D(AppModel);
     while (d->m_tracks.count() > 0)
         delete takeTrackAt(0);
+}
+
+void AppModel::notifyTrackChanged(const TrackChangeType type, const qsizetype index, Track *track) {
+    emit trackChanged(type, index, track);
+}
+
+void AppModel::notifyTrackMoved(const qsizetype from, const qsizetype to) {
+    Q_D(const AppModel);
+    const auto size = d->m_tracks.size();
+    if (from == to || from < 0 || from >= size || to < 0 || to >= size)
+        return;
+    emit trackMoved(from, to);
 }
 
 ProjectModelData AppModel::takeProjectData() {

--- a/src/libs/ProjectModel/AppModel/AppModel.h
+++ b/src/libs/ProjectModel/AppModel/AppModel.h
@@ -45,19 +45,18 @@ public:
     void setDefaultSingingLanguage(const QString &language);
     void setPaletteColorCount(int count);
     const QList<Track *> &tracks() const;
-    void insertTrack(Track *track, qsizetype index);
-    void appendTrack(Track *track);
-    // 重排轨道顺序（to 为移动完成后的最终下标，语义同 QList::move）。
-    // 与「takeTrackAt + insertTrack」不同：列表先完成重排，之后才发出
-    // Remove/Insert 通知，因此监听者在处理 Remove 时仍能通过
-    // findTrackById / findClipById 查到该轨道及其剪辑，从而把「移动」
-    // 与「删除」区分开，不会误清空 activeClipId、推理管线等状态。
-    void moveTrack(qsizetype from, qsizetype to);
+    bool insertTrack(Track *track, qsizetype index);
+    bool appendTrack(Track *track);
+    // 轨道集合操作只修改数据；Action 在复合编辑完成后显式发布通知。
+    // to 为移动完成后的最终下标，语义同 QList::move。
+    bool moveTrack(qsizetype from, qsizetype to);
     void removeTrackAt(qsizetype index);
     void removeTrack(Track *track);
     Track *takeTrackAt(qsizetype index);
     Track *takeTrack(Track *track);
     void clearTracks();
+    void notifyTrackChanged(TrackChangeType type, qsizetype index, Track *track);
+    void notifyTrackMoved(qsizetype from, qsizetype to);
     ProjectModelData takeProjectData();
     void replaceProject(ProjectModelData &&data);
 
@@ -81,6 +80,7 @@ signals:
     void timelineChanged();
     void masterControlChanged(const TrackControl &control);
     void trackChanged(AppModel::TrackChangeType type, qsizetype index, Track *track);
+    void trackMoved(qsizetype from, qsizetype to);
 
 private:
     Q_DECLARE_PRIVATE(AppModel);


### PR DESCRIPTION
<!-- codex-worker issue=72 kind=initial-pr head=f24a1478a66e76070fcabcc8ddf43c5d5711f209 -->
Closes #72

已批准计划：plan-v1

## 变更内容

- 将 AppModel 的轨道集合变更与通知拆分：集合操作返回是否发生有效变更，由 Action 显式发送成员变化或顺序变化事件。
- 重构 MoveTrackAction，使 execute/undo 按逻辑轨道追踪当前位置与最终索引；非法、越界及无操作移动保持静默。
- TrackEditor、MixConsole、LevelMeter 与 AudioContext 原位重排现有对象，移除 ProjectStatus 对“移动伪装成删除”的推断。

## 验证结果

- 构建或自动检查: PASS — 使用项目标准 VS DevShell + CMake debug preset 完成 configure，并仅构建 DsEditorLite 目标；候选程序成功链接和部署。
- 针对改动的 Computer Use 自测: PASS — 在真实 Debug 程序中验证多轨上移/下移/边界操作、撤销/重做、编辑器与混音器对象保持、音频轨移动播放、轨道删除恢复以及工程保存。
- CTest: SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基本功能回归冒烟测试（用于确认基本功能未发生回归）: PASS — 独立启动候选程序，完成声库加载、至少一拍后绘制音符、音素/音高/非平坦合成结果检查、播放时间与播放头推进、DSPX 保存和重新打开，并正常退出。
- Computer Use: PASS — 两个 GUI 验证均针对 `build/Debug/out/bin/DsEditorLite.exe`；未保留截图或录屏，临时工程已清理。
- 人工补测: NONE — 已覆盖本次改动的关键交互和独立基础功能回归路径。
- 候选提交: f24a1478a66e76070fcabcc8ddf43c5d5711f209

## 已知限制

- 音频导出按现行 GUI 冒烟规范未执行。