### PR TITLE
修复主窗口状态恢复与多显示器放置

### DIFF
--- a/src/app/Bootstrap/WindowPlacement.cpp
+++ b/src/app/Bootstrap/WindowPlacement.cpp
@@ -1,0 +1,209 @@
+#include "WindowPlacement.h"
+
+#include <QApplication>
+#include <QCursor>
+#include <QEvent>
+#include <QScreen>
+#include <QWidget>
+
+#include <algorithm>
+#include <utility>
+
+namespace {
+    constexpr QSize largeDefaultSize{1536, 816};
+    constexpr QSize compactDefaultSize{1366, 768};
+
+    QRect availableGeometry(const QScreen *screen) {
+        if (!screen)
+            return {};
+        const auto available = screen->availableGeometry();
+        return available.isValid() ? available : screen->geometry();
+    }
+
+    qint64 intersectionArea(const QRect &first, const QRect &second) {
+        const auto intersection = first.intersected(second);
+        if (intersection.isEmpty())
+            return 0;
+        return static_cast<qint64>(intersection.width()) * intersection.height();
+    }
+}
+
+WindowPlacement::WindowPlacement(QWidget &window) : m_window(window) {
+    m_correctionTimer.setSingleShot(true);
+    connect(&m_correctionTimer, &QTimer::timeout, this, &WindowPlacement::ensureVisible);
+
+    connect(qApp, &QGuiApplication::screenAdded, this, [this](QScreen *screen) {
+        connectScreen(screen);
+        scheduleCorrection();
+    });
+    connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *screen) {
+        QObject::disconnect(screen, nullptr, this, nullptr);
+        m_connectedScreens.remove(screen);
+        syncScreens();
+        scheduleCorrection();
+    });
+
+    syncScreens();
+    m_window.installEventFilter(this);
+}
+
+WindowPlacement::~WindowPlacement() {
+    m_window.removeEventFilter(this);
+}
+
+void WindowPlacement::restoreOrPlace(const QByteArray &geometry) {
+    const bool restored = !geometry.isEmpty() && m_window.restoreGeometry(geometry);
+    m_window.setWindowState(m_window.windowState() & ~Qt::WindowMinimized);
+
+    if (!restored)
+        placeDefault();
+    ensureVisible();
+    scheduleCorrection();
+}
+
+QByteArray WindowPlacement::saveGeometry() const {
+    return m_window.saveGeometry();
+}
+
+bool WindowPlacement::eventFilter(QObject *watched, QEvent *event) {
+    if (watched == &m_window &&
+        (event->type() == QEvent::Show || event->type() == QEvent::WindowStateChange)) {
+        scheduleCorrection();
+    }
+    return QObject::eventFilter(watched, event);
+}
+
+void WindowPlacement::connectScreen(QScreen *screen) {
+    if (!screen || m_connectedScreens.contains(screen))
+        return;
+
+    m_connectedScreens.insert(screen);
+    connect(screen, &QScreen::geometryChanged, this,
+            [this] { scheduleCorrection(); });
+    connect(screen, &QScreen::availableGeometryChanged, this,
+            [this] { scheduleCorrection(); });
+    connect(screen, &QObject::destroyed, this, [this, screen] {
+        m_connectedScreens.remove(screen);
+        scheduleCorrection();
+    });
+}
+
+void WindowPlacement::syncScreens() {
+    const auto screens = QApplication::screens();
+    const QSet<QScreen *> currentScreens(screens.cbegin(), screens.cend());
+    const auto connectedScreens = m_connectedScreens;
+
+    for (auto *screen : connectedScreens) {
+        if (currentScreens.contains(screen))
+            continue;
+        QObject::disconnect(screen, nullptr, this, nullptr);
+        m_connectedScreens.remove(screen);
+    }
+    for (auto *screen : screens)
+        connectScreen(screen);
+}
+
+void WindowPlacement::scheduleCorrection() {
+    m_correctionTimer.start(0);
+}
+
+void WindowPlacement::ensureVisible() {
+    syncScreens();
+    if (m_window.isMinimized()) {
+        return;
+    }
+
+    const auto geometry = placementGeometry();
+    if (!geometry.isValid())
+        return;
+
+    for (auto *screen : QApplication::screens()) {
+        if (availableGeometry(screen).contains(geometry))
+            return;
+    }
+
+    auto *screen = screenForGeometry(geometry);
+    const auto available = availableGeometry(screen);
+    if (!available.isValid())
+        return;
+
+    const auto constrained = constrainedGeometry(geometry, available);
+    const auto state = m_window.windowState();
+    const bool wasFullScreen = state.testFlag(Qt::WindowFullScreen);
+    const bool wasMaximized = state.testFlag(Qt::WindowMaximized);
+    const bool wasVisible = m_window.isVisible();
+
+    if (wasFullScreen || wasMaximized)
+        m_window.setWindowState(state & ~(Qt::WindowFullScreen | Qt::WindowMaximized));
+    m_window.setGeometry(constrained);
+
+    if (wasVisible && wasFullScreen)
+        m_window.showFullScreen();
+    else if (wasVisible && wasMaximized)
+        m_window.showMaximized();
+    else if (wasFullScreen)
+        m_window.setWindowState(m_window.windowState() | Qt::WindowFullScreen);
+    else if (wasMaximized)
+        m_window.setWindowState(m_window.windowState() | Qt::WindowMaximized);
+}
+
+void WindowPlacement::placeDefault() {
+    auto *screen = QApplication::screenAt(QCursor::pos());
+    if (!screen)
+        screen = QApplication::primaryScreen();
+
+    const auto available = availableGeometry(screen);
+    if (!available.isValid()) {
+        m_window.resize(compactDefaultSize);
+        return;
+    }
+
+    const auto preferred =
+        available.width() > largeDefaultSize.width() &&
+                available.height() > largeDefaultSize.height()
+            ? largeDefaultSize
+            : compactDefaultSize;
+    const auto size = preferred.boundedTo(available.size());
+    const auto topLeft =
+        available.topLeft() +
+        QPoint((available.width() - size.width()) / 2, (available.height() - size.height()) / 2);
+    m_window.setGeometry(QRect(topLeft, size));
+}
+
+QRect WindowPlacement::placementGeometry() const {
+    const auto state = m_window.windowState();
+    if (state.testFlag(Qt::WindowMaximized) || state.testFlag(Qt::WindowFullScreen)) {
+        const auto normal = m_window.normalGeometry();
+        if (normal.isValid())
+            return normal;
+    }
+    return m_window.geometry();
+}
+
+QScreen *WindowPlacement::screenForGeometry(const QRect &geometry) const {
+    QScreen *bestScreen = nullptr;
+    qint64 bestArea = 0;
+    for (auto *screen : QApplication::screens()) {
+        const auto area = intersectionArea(geometry, availableGeometry(screen));
+        if (area > bestArea) {
+            bestArea = area;
+            bestScreen = screen;
+        }
+    }
+    if (bestScreen)
+        return bestScreen;
+
+    if (auto *screen = QApplication::screenAt(QCursor::pos()))
+        return screen;
+    return QApplication::primaryScreen();
+}
+
+QRect WindowPlacement::constrainedGeometry(const QRect &geometry,
+                                           const QRect &availableGeometry) {
+    const auto size = geometry.size().boundedTo(availableGeometry.size());
+    const auto maxLeft = availableGeometry.right() - size.width() + 1;
+    const auto maxTop = availableGeometry.bottom() - size.height() + 1;
+    const auto left = std::clamp(geometry.left(), availableGeometry.left(), maxLeft);
+    const auto top = std::clamp(geometry.top(), availableGeometry.top(), maxTop);
+    return {QPoint(left, top), size};
+}

--- a/src/app/Bootstrap/WindowPlacement.h
+++ b/src/app/Bootstrap/WindowPlacement.h
@@ -1,28 +1,41 @@
 #ifndef WINDOWPLACEMENT_H
 #define WINDOWPLACEMENT_H
 
-#include <QApplication>
-#include <QCursor>
-#include <QScreen>
-#include <QWidget>
+#include <QByteArray>
+#include <QObject>
+#include <QRect>
+#include <QSet>
+#include <QTimer>
 
-namespace WindowPlacement {
+class QEvent;
+class QScreen;
+class QWidget;
 
-    // Centers the widget on the screen under the mouse cursor,
-    // falling back to the primary screen.
-    inline void centerOnScreenAtCursor(QWidget &widget) {
-        auto scr = QApplication::screenAt(QCursor::pos());
-        if (!scr) {
-            scr = QApplication::primaryScreen();
-        }
-        if (scr) {
-            auto availableRect = scr->availableGeometry();
-            auto left = (availableRect.width() - widget.width()) / 2;
-            auto top = (availableRect.height() - widget.height()) / 2;
-            widget.move(left, top);
-        }
-    }
+class WindowPlacement final : public QObject {
+public:
+    explicit WindowPlacement(QWidget &window);
+    ~WindowPlacement() override;
 
-} // namespace WindowPlacement
+    void restoreOrPlace(const QByteArray &geometry);
+    [[nodiscard]] QByteArray saveGeometry() const;
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    void connectScreen(QScreen *screen);
+    void syncScreens();
+    void scheduleCorrection();
+    void ensureVisible();
+    void placeDefault();
+    [[nodiscard]] QRect placementGeometry() const;
+    [[nodiscard]] QScreen *screenForGeometry(const QRect &geometry) const;
+    [[nodiscard]] static QRect constrainedGeometry(const QRect &geometry,
+                                                    const QRect &availableGeometry);
+
+    QWidget &m_window;
+    QSet<QScreen *> m_connectedScreens;
+    QTimer m_correctionTimer;
+};
 
 #endif // WINDOWPLACEMENT_H

--- a/src/app/Global/AppOptionsGlobal.h
+++ b/src/app/Global/AppOptionsGlobal.h
@@ -18,6 +18,7 @@ namespace AppOptionsGlobal {
         // Hidden options
         G2pLanguage,
         FillLyric,
+        Window,
         // PreviewFunctions,
     };
 };

--- a/src/app/Model/AppOptions/AppOptions.cpp
+++ b/src/app/Model/AppOptions/AppOptions.cpp
@@ -33,6 +33,7 @@ AppOptions::AppOptions(QObject *parent) : QObject(parent) {
             m_fillLyricOption.load(obj.value(m_fillLyricOption.key()).toObject());
             m_inferenceOption.load(obj.value(m_inferenceOption.key()).toObject());
             m_developerOption.load(obj.value(m_developerOption.key()).toObject());
+            m_windowOption.load(obj.value(m_windowOption.key()).toObject());
         }
     saveAndNotify(AppOptionsGlobal::All);
 }
@@ -53,7 +54,8 @@ bool AppOptions::saveAndNotify(const AppOptionsGlobal::Option option) {
         {m_g2pLanguageOption.key(), m_g2pLanguageOption.value()},
         {m_fillLyricOption.key(),  m_fillLyricOption.value() },
         {m_inferenceOption.key(),  m_inferenceOption.value() },
-        {m_developerOption.key(), m_developerOption.value()}
+        {m_developerOption.key(),  m_developerOption.value() },
+        {m_windowOption.key(),     m_windowOption.value()    }
     };
 
     const auto success = JsonUtils::save(m_configPath, obj);
@@ -91,4 +93,8 @@ InferenceOption *AppOptions::inference() {
 
 DeveloperOption *AppOptions::developer() {
     return &m_developerOption;
+}
+
+WindowOption *AppOptions::window() {
+    return &m_windowOption;
 }

--- a/src/app/Model/AppOptions/AppOptions.h
+++ b/src/app/Model/AppOptions/AppOptions.h
@@ -15,6 +15,7 @@
 #include "Options/FillLyricOption.h"
 #include "Options/GeneralOption.h"
 #include "Options/InferenceOption.h"
+#include "Options/WindowOption.h"
 #include "Global/AppOptionsGlobal.h"
 
 class AppOptions : public QObject {
@@ -39,6 +40,7 @@ public:
     FillLyricOption *fillLyric();
     InferenceOption *inference();
     DeveloperOption *developer();
+    WindowOption *window();
 
 signals:
     void optionsChanged(AppOptionsGlobal::Option option);
@@ -51,6 +53,7 @@ private:
     FillLyricOption m_fillLyricOption;
     InferenceOption m_inferenceOption;
     DeveloperOption m_developerOption;
+    WindowOption m_windowOption;
 
     QString fileName = "appConfig.json";
     QString m_configPath;

--- a/src/app/Model/AppOptions/Options/WindowOption.cpp
+++ b/src/app/Model/AppOptions/Options/WindowOption.cpp
@@ -1,0 +1,33 @@
+#include "WindowOption.h"
+
+void WindowOption::load(const QJsonObject &object) {
+    m_mainWindowGeometry.clear();
+
+    const auto value = object.value(m_mainWindowGeometryKey);
+    if (!value.isString())
+        return;
+
+    const auto encoded = value.toString().toLatin1();
+    if (encoded.isEmpty() || encoded.size() % 4 != 0)
+        return;
+
+    const auto decoded = QByteArray::fromBase64(encoded);
+    if (decoded.isEmpty() || decoded.toBase64() != encoded)
+        return;
+
+    m_mainWindowGeometry = decoded;
+}
+
+void WindowOption::save(QJsonObject &object) {
+    object = {};
+    if (!m_mainWindowGeometry.isEmpty())
+        object.insert(m_mainWindowGeometryKey, QString::fromLatin1(m_mainWindowGeometry.toBase64()));
+}
+
+const QByteArray &WindowOption::mainWindowGeometry() const {
+    return m_mainWindowGeometry;
+}
+
+void WindowOption::setMainWindowGeometry(QByteArray geometry) {
+    m_mainWindowGeometry = std::move(geometry);
+}

--- a/src/app/Model/AppOptions/Options/WindowOption.h
+++ b/src/app/Model/AppOptions/Options/WindowOption.h
@@ -1,0 +1,24 @@
+#ifndef WINDOWOPTION_H
+#define WINDOWOPTION_H
+
+#include "Model/AppOptions/IOption.h"
+
+#include <QByteArray>
+
+class WindowOption final : public IOption {
+public:
+    explicit WindowOption() : IOption("window") {
+    }
+
+    void load(const QJsonObject &object) override;
+    void save(QJsonObject &object) override;
+
+    [[nodiscard]] const QByteArray &mainWindowGeometry() const;
+    void setMainWindowGeometry(QByteArray geometry);
+
+private:
+    const QString m_mainWindowGeometryKey = "mainWindowGeometry";
+    QByteArray m_mainWindowGeometry;
+};
+
+#endif // WINDOWOPTION_H

--- a/src/app/UI/Window/MainWindow.cpp
+++ b/src/app/UI/Window/MainWindow.cpp
@@ -189,21 +189,6 @@ MainWindow::MainWindow() {
     this->setCentralWidget(mainWidget);
     editorViewController->setView(this);
 
-    auto scr = QApplication::screenAt(QCursor::pos());
-    if (!scr) {
-        scr = QApplication::primaryScreen();
-    }
-    if (scr) {
-        auto availableRect = scr->availableGeometry();
-        if (availableRect.width() > 1536 && availableRect.height() > 816)
-            resize(1536, 816);
-        else
-            resize(1366, 768);
-    } else {
-        // Fallback if no screen is available
-        resize(1366, 768);
-    }
-
     QTimer::singleShot(0, this, [this] {
         const auto sizes = m_splitter->sizes();
         if (sizes.size() >= 2 && sizes.at(0) > 0 && sizes.at(1) > 0)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -61,7 +61,8 @@ int main(int argc, char *argv[]) {
     packageManager->initialize(appOptions->general()->packageSearchPaths);
 
     MainWindow w;
-    WindowPlacement::centerOnScreenAtCursor(w);
+    WindowPlacement windowPlacement(w);
+    windowPlacement.restoreOrPlace(appOptions->window()->mainWindowGeometry());
     w.show();
 #if defined(WITH_DIRECT_MANIPULATION)
     w.registerDirectManipulation();
@@ -76,5 +77,9 @@ int main(int argc, char *argv[]) {
     qInfo() << "App launched in" << time << "ms";
 
     CrashHandler crashHandler;
-    return Restarter(QDir::currentPath()).restartOrExit(a.exec());
+    const auto result = a.exec();
+    appOptions->window()->setMainWindowGeometry(windowPlacement.saveGeometry());
+    if (!appOptions->saveAndNotify(AppOptionsGlobal::Window))
+        qWarning("Failed to save main-window placement");
+    return Restarter(QDir::currentPath()).restartOrExit(result);
 }


### PR DESCRIPTION
<!-- codex-worker issue=77 kind=initial-pr head=b98bab42a93a8298896040fce8a324a64c9aceb9 -->
Closes #77

已批准计划：`plan-v2`

## 变更内容

- 在现有 `AppOptions` / `appConfig.json` 链路中新增隐藏的窗口放置选项，以规范 Base64 保存和恢复 Qt 主窗口几何；缺失、类型错误、非法编码和空数据均安全视为无记录。
- 新增主窗口放置生命周期组件：恢复普通、最大化或全屏状态，清除最小化标志；无有效记录时在鼠标所在屏幕的全局可用区内按工作区限制默认大小并居中。
- 按窗口与当前屏幕可用区的最大交叠选择目标屏幕，把普通几何完整夹入单块可用区；动态监听屏幕增删、屏幕几何和可用区变化，并排队合并可见性修正，同时保留最大化/全屏模式。
- 在主事件循环正常结束后统一保存窗口几何，覆盖正常退出和应用内重启路径；移除 `MainWindow` 构造函数中的固定尺寸逻辑。

## 验证结果

- 构建或自动检查：PASS — 通过仓库脚本完成 debug preset 的 configure/build；`DsEditorLite.exe` 编译、链接与 Qt 部署成功。
- 针对改动的 Computer Use 自测：SKIPPED — Computer Use 能力限制：当前仅连接一块显示器，应用没有可由用户界面触发的全屏入口，自动化在最小化状态下重新定向输入会激活窗口；因此无法验证显示器热插拔/布局变化、全屏恢复和最小化状态下正常退出后的恢复；未观察到业务异常；需要人工补测。已实测普通窗口移动/缩放后重启精确恢复、最大化后重启保持最大化，以及损坏 Base64 配置安全回退并完整显示标题栏与窗口控制按钮。
- CTest: SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基本功能回归冒烟测试（用于确认基本功能未发生回归）：PASS — 使用 `Jun Ninghua` 声库，在 C4 附近且起点前留空绘制“啦”音符；观察到音高曲线、`l/a` 音素和非平直合成波形，播放 3 秒后运输时间与播放头均前进，成功保存 6700 字节 DSPX 并清理测试产物。音频导出按临时限制跳过。
- Computer Use：操作真实 debug 候选程序；普通恢复实测窗口为 `(766, 582), 1339 × 817`，最大化恢复实测为 `(0, 0), 2560 × 1392`；损坏配置回退和完整基础功能流程均无崩溃、挂起或错误结果。
- 人工补测：REQUIRED — 前置条件为 Windows 双屏环境且可切换全屏/从最小化状态正常退出。依次执行：副屏保存后退出并断开副屏再启动；运行时拔除窗口所在屏；交换主屏并改变左右/上下相对位置；改变任务栏占用的可用工作区；以普通、最大化、全屏和最小化状态分别正常退出后重启。每一步预期主窗口完整进入仍连接屏幕的可用区，标题栏与控制按钮可操作，普通尺寸合理保留，最大化/全屏模式恢复且不以最小化状态启动。
- 候选提交：`b98bab42a93a8298896040fce8a324a64c9aceb9`

## 已知限制

- 当前自动化环境只有一块 `2560 × 1440` 显示器，多屏热插拔、负坐标与纵向屏幕排列尚需上述人工补测。
- 应用没有可由当前 GUI 操作触发的全屏入口，且 Computer Use 无法在不改变窗口状态的前提下关闭最小化窗口；对应恢复断言未自动验证。
- 按 GUI 冒烟测试临时限制，不打开音频导出对话框，不验证 WAV 导出。