### PR TITLE
fix: 修正相邻音高锚点的最近命中

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/EditPitchAnchorHandler.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/EditPitchAnchorHandler.cpp
@@ -413,17 +413,23 @@ void EditPitchAnchorHandler::loadFromModel(const QList<AnchorCurve *> &curves) {
 }
 
 AnchorNode *EditPitchAnchorHandler::anchorNodeAt(const QPointF &scenePos) const {
+    AnchorNode *nearestNode = nullptr;
+    double nearestDistanceSquared = kAnchorHitRadius * kAnchorHitRadius;
     for (auto *curve : anchorCurves()) {
         for (auto *node : curve->nodes().toList()) {
             const auto x = q->tickToSceneX(node->pos());
             const auto y = d->m_anchorEditor->valueToSceneY(node->value());
             const auto dx = scenePos.x() - x;
             const auto dy = scenePos.y() - y;
-            if (dx * dx + dy * dy <= kAnchorHitRadius * kAnchorHitRadius)
-                return node;
+            const auto distanceSquared = dx * dx + dy * dy;
+            if (distanceSquared <= kAnchorHitRadius * kAnchorHitRadius &&
+                (!nearestNode || distanceSquared < nearestDistanceSquared)) {
+                nearestNode = node;
+                nearestDistanceSquared = distanceSquared;
+            }
         }
     }
-    return nullptr;
+    return nearestNode;
 }
 
 AnchorCurve *EditPitchAnchorHandler::anchorCurveAt(int tick, AnchorCurve *exclude) const {


### PR DESCRIPTION
<!-- codex-worker issue=83 kind=initial-pr head=905aa079dc7158a79f621f32dcb806f518979ac7 -->
Closes #83

已批准计划：`plan-v1`

## 变更内容

- 调整 `EditPitchAnchorHandler::anchorNodeAt()`，在命中半径内遍历全部音高锚点并按场景坐标平方距离选择最近锚点。
- 距离完全相同时保留原遍历顺序，维持稳定行为；命中半径以及悬停、左键拖动、右键菜单共用的命中路径不变。
- 未改动音高曲线模型与 RHI 渲染后端，符合批准范围。

## 验证结果

- 构建或自动检查：PASS — 使用项目 VS DevShell + CMake debug preset 完成 ConfigureAndBuild，323/323 成功并链接 `build/Debug/out/bin/DsEditorLite.exe`。
- 针对改动的 Computer Use 自测：PASS — 在真实 GraphicsView 后端构造两个命中圆重叠的相邻端点；重叠区左右两侧分别验证悬停与拖动命中最近端点，端点中心拖动保持正确，右键选择最近端点，跨曲线合并路径正常，孤立锚点右键菜单正常；各操作后撤销恢复。
- CTest: SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基本功能回归冒烟测试（用于确认基本功能未发生回归）：PASS — 选择 Jun Ninghua / 普通话，绘制约 1.5 拍 C4 音符，确认歌词“啦”、音素 `la`、合成状态 Ready、可见音高曲线和非空波形；播放位置由 001:01:000 前进至约 005:03:289；保存 DSPX 成功（6748 字节），随后关闭测试实例并清理唯一临时目录。
- Computer Use：使用独立测试实例操作 `build/Debug/out/bin/DsEditorLite.exe`；定向命中测试与完整 GUI 冒烟均观察到预期结果，无崩溃、挂起或业务异常。
- 人工补测：NONE
- 候选提交：`905aa079dc7158a79f621f32dcb806f518979ac7`

## 已知限制

- 按批准计划未覆盖 RHI 渲染后端；本次改动位于 GraphicsView 专用锚点处理器。
- GUI 冒烟测试按当前测试协议暂不覆盖音频导出。