### PR TITLE
feat: 按编辑模式聚焦音高曲线显示

### DIFF
--- a/src/app/Modules/Inference/States/BaseInferState.h
+++ b/src/app/Modules/Inference/States/BaseInferState.h
@@ -5,6 +5,7 @@
 #ifndef DS_EDITOR_LITE_BASEINFERSTATE_H
 #define DS_EDITOR_LITE_BASEINFERSTATE_H
 
+#include <QPointer>
 #include <QState>
 
 class InferPipeline;
@@ -46,7 +47,7 @@ protected:
     virtual bool validateTaskResult(IInferTask *task, SingingClip *clip) = 0;
 
     InferPipeline &m_pipeline;
-    IInferTask *currentTask = nullptr;
+    QPointer<IInferTask> currentTask;
     int m_preparationEpoch = 0;
 
     QState *m_runningInferenceState;

--- a/src/app/Modules/Inference/States/ProbeAcousticCacheState.h
+++ b/src/app/Modules/Inference/States/ProbeAcousticCacheState.h
@@ -7,6 +7,7 @@
 
 #include "Modules/Inference/Tasks/InferAcousticCacheProbeTask.h"
 
+#include <QPointer>
 #include <QState>
 
 class InferPipeline;
@@ -31,7 +32,7 @@ private:
     void cancelCurrentTask();
 
     InferPipeline &m_pipeline;
-    InferAcousticCacheProbeTask *m_currentTask = nullptr;
+    QPointer<InferAcousticCacheProbeTask> m_currentTask;
 };
 
 #endif // DS_EDITOR_LITE_PROBEACOUSTICCACHESTATE_H

--- a/src/app/UI/Views/ClipEditor/CommonParamEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/CommonParamEditorView.cpp
@@ -63,6 +63,10 @@ const QList<DrawCurve *> &CommonParamEditorView::editedCurves() const {
     return m_drawCurvesEdited;
 }
 
+const QList<DrawCurve *> &CommonParamEditorView::originalCurves() const {
+    return m_drawCurvesOriginal;
+}
+
 QColor CommonParamEditorView::graduateColor() const {
     return m_graduateColor;
 }

--- a/src/app/UI/Views/ClipEditor/CommonParamEditorView.h
+++ b/src/app/UI/Views/ClipEditor/CommonParamEditorView.h
@@ -51,6 +51,8 @@ protected:
     [[nodiscard]] virtual double sceneYToValue(double y) const;
     virtual void drawGraduates(QPainter *painter, const QStyleOptionGraphicsItem *option,
                                QWidget *widget);
+    [[nodiscard]] const QList<DrawCurve *> &originalCurves() const;
+    void drawCurveBorder(QPainter *painter, const QList<DrawCurve *> &curves) const;
 
 private:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
@@ -59,7 +61,6 @@ private:
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
     void updateRectAndPos() override;
     bool cancelEditState();
-    void drawCurveBorder(QPainter *painter, const QList<DrawCurve *> &curves) const;
     void drawCurvePolygon(QPainter *painter, const QList<DrawCurve *> &curves) const;
     static void drawLine(const QPoint &p1, const QPoint &p2, DrawCurve &curve);
 

--- a/src/app/UI/Views/ClipEditor/PianoRoll/EditPitchAnchorHandler.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/EditPitchAnchorHandler.cpp
@@ -677,6 +677,7 @@ void EditPitchAnchorHandler::createAnchorAt(const QPointF &scenePos) {
 
 void EditPitchAnchorHandler::updatePreview(const QPointF &scenePos) {
     m_state.previewPos = q->mapFromScene(scenePos.toPoint());
+    m_state.previewTick = static_cast<int>(q->sceneXToTick(scenePos.x()));
     m_state.showPreview = m_state.editing && m_state.currentCurve != nullptr &&
                           m_state.hoveredNode == nullptr && !m_state.showMergePreview;
 

--- a/src/app/UI/Views/ClipEditor/PianoRoll/EditPitchAnchorHandler.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/EditPitchAnchorHandler.cpp
@@ -7,6 +7,7 @@
 #include "PianoRollGraphicsView.h"
 #include "PianoRollGraphicsView_p.h"
 #include "PitchAnchorEditorView.h"
+#include "PitchEditorView.h"
 
 #include <lite/ProjectModel/AppModel/AnchorCurve.h>
 #include <lite/ProjectModel/AppModel/DrawCurve.h>
@@ -769,6 +770,8 @@ void EditPitchAnchorHandler::mergeCurves(AnchorCurve *target) {
 
 void EditPitchAnchorHandler::triggerRepaint() {
     m_state.visibleCurves = anchorCurves();
+    if (d->m_pitchEditor)
+        d->m_pitchEditor->update();
     if (d->m_anchorEditor)
         d->m_anchorEditor->update();
 }

--- a/src/app/UI/Views/ClipEditor/PianoRoll/EditPitchAnchorHandler.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/EditPitchAnchorHandler.h
@@ -34,6 +34,7 @@ struct AnchorOverlayState {
     QList<AnchorNode *> selectedNodes;
     AnchorNode *hoveredNode = nullptr;
     QPointF previewPos;
+    int previewTick = 0;
     bool showPreview = false;
     AnchorCurve *previewCurve = nullptr;
 

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -177,6 +177,7 @@ PianoRollGraphicsView::PianoRollGraphicsView(PianoRollGraphicsScene *scene, QWid
     editPitchAnchorHandler->setContext(this, d);
     d->m_handlers.insert(EditPitchAnchor, editPitchAnchorHandler);
     d->m_anchorEditor->setOverlayState(&editPitchAnchorHandler->overlayState());
+    d->m_pitchEditor->setAnchorOverlayState(&editPitchAnchorHandler->overlayState());
     editPitchAnchorHandler->setAlwaysVisible(true);
 
     connect(scene, &QGraphicsScene::selectionChanged, this,
@@ -1033,6 +1034,14 @@ void PianoRollGraphicsView::setEditMode(const PianoRollEditMode mode) {
 
     d->m_editMode = mode;
     d->m_currentHandler = d->m_handlers.value(mode, nullptr);
+
+    auto displayMode = PitchDisplayMode::Final;
+    if (mode == DrawPitch || mode == ErasePitch || mode == FreezePitch)
+        displayMode = PitchDisplayMode::Draw;
+    else if (mode == EditPitchAnchor)
+        displayMode = PitchDisplayMode::Anchor;
+    d->m_pitchEditor->setDisplayMode(displayMode);
+    d->m_anchorEditor->setDisplayMode(displayMode);
 
     if (d->m_currentHandler) {
         d->m_currentHandler->activate();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PitchAnchorEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PitchAnchorEditorView.cpp
@@ -377,6 +377,7 @@ QPainterPath PitchAnchorEditorView::interpolatedPath(const QList<AnchorNode *> &
     const auto dpr = std::max(1.0, devicePixelRatio);
     const auto visibleLeft = rect().left() - 2.0 / dpr;
     const auto visibleRight = rect().right() + 2.0 / dpr;
+    bool hasPoint = false;
     for (int i = 0; i < nodes.size() - 1; ++i) {
         const auto *firstNode = nodes.at(i);
         const auto *secondNode = nodes.at(i + 1);
@@ -395,10 +396,12 @@ QPainterPath PitchAnchorEditorView::interpolatedPath(const QList<AnchorNode *> &
             const auto tick = sceneXToTick(x + pos().x());
             const auto value = interpolator.evaluate(tick);
             const QPointF point(x, sceneYToItemY(valueToSceneY(value)));
-            if (path.isEmpty())
+            if (!hasPoint) {
                 path.moveTo(point);
-            else if (QLineF(path.currentPosition(), point).length() > 0.001)
+                hasPoint = true;
+            } else if (QLineF(path.currentPosition(), point).length() > 0.001) {
                 path.lineTo(point);
+            }
             return point.y();
         };
 

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PitchAnchorEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PitchAnchorEditorView.cpp
@@ -9,8 +9,10 @@
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
 #include <lite/Support/MathUtils.h>
 
+#include <QLineF>
 #include <QPainter>
 #include <QSet>
+#include <algorithm>
 #include <cmath>
 
 PitchAnchorEditorView::PitchAnchorEditorView() {
@@ -20,6 +22,13 @@ PitchAnchorEditorView::PitchAnchorEditorView() {
 
 void PitchAnchorEditorView::setOverlayState(const AnchorOverlayState *state) {
     m_state = state;
+}
+
+void PitchAnchorEditorView::setDisplayMode(const PitchDisplayMode mode) {
+    if (m_displayMode == mode)
+        return;
+    m_displayMode = mode;
+    update();
 }
 
 QColor PitchAnchorEditorView::anchorColor() const {
@@ -112,10 +121,18 @@ void PitchAnchorEditorView::drawAnchorCurves(QPainter *painter) const {
     constexpr double anchorRadius = 2.0;
     constexpr double hoverRadius = 6.0;
     QColor normalColor = m_anchorColor;
-    normalColor.setAlpha(active ? 255 : 80);
-    const QColor selectedColor = m_anchorSelectedColor;
     QColor curveColor = m_anchorCurveColor;
-    curveColor.setAlpha(active ? 200 : 60);
+    if (m_displayMode == PitchDisplayMode::Final) {
+        normalColor.setAlpha(std::min(normalColor.alpha(), 220));
+        curveColor.setAlpha(std::min(curveColor.alpha(), 180));
+    } else if (m_displayMode == PitchDisplayMode::Draw) {
+        normalColor.setAlpha(std::min(normalColor.alpha(), 80));
+        curveColor.setAlpha(std::min(curveColor.alpha(), 60));
+    } else {
+        normalColor.setAlpha(std::min(normalColor.alpha(), 255));
+        curveColor.setAlpha(std::min(curveColor.alpha(), 200));
+    }
+    const QColor selectedColor = m_anchorSelectedColor;
 
     auto drawNodeAt = [&](double x, double y, AnchorNode *node) {
         const bool isSelected = active && m_state->selectedNodes.contains(node);
@@ -173,13 +190,7 @@ void PitchAnchorEditorView::drawAnchorCurves(QPainter *painter) const {
         painter->setPen(pen);
         painter->setBrush(Qt::NoBrush);
 
-        for (int i = 0; i < nodes.size() - 1; i++) {
-            auto *n1 = nodes[i];
-            auto *n2 = nodes[i + 1];
-            auto *ref1 = (i > 0) ? nodes[i - 1] : nullptr;
-            auto *ref2 = (i + 2 < nodes.size()) ? nodes[i + 2] : nullptr;
-            interpolateSegment(painter, n1, n2, ref1, ref2);
-        }
+        painter->drawPath(interpolatedPath(nodes, painter->device()->devicePixelRatioF()));
 
         for (auto *node : nodes) {
             const double x = tickToLocalX(node->pos());
@@ -250,13 +261,7 @@ void PitchAnchorEditorView::drawPreviewCurve(QPainter *painter) const {
     painter->setPen(pen);
     painter->setBrush(Qt::NoBrush);
 
-    for (int i = 0; i < allNodes.size() - 1; i++) {
-        auto *n1 = allNodes[i];
-        auto *n2 = allNodes[i + 1];
-        auto *ref1 = (i > 0) ? allNodes[i - 1] : nullptr;
-        auto *ref2 = (i + 2 < allNodes.size()) ? allNodes[i + 2] : nullptr;
-        interpolateSegment(painter, n1, n2, ref1, ref2);
-    }
+    painter->drawPath(interpolatedPath(allNodes, painter->device()->devicePixelRatioF()));
 
     const double cx = tickToItemX(virtualNode.pos());
     const double cy = sceneYToItemY(valueToSceneY(virtualNode.value()));
@@ -287,13 +292,7 @@ void PitchAnchorEditorView::drawMergePreviewCurve(QPainter *painter) const {
     painter->setPen(pen);
     painter->setBrush(Qt::NoBrush);
 
-    for (int i = 0; i < allNodes.size() - 1; i++) {
-        auto *n1 = allNodes[i];
-        auto *n2 = allNodes[i + 1];
-        auto *ref1 = (i > 0) ? allNodes[i - 1] : nullptr;
-        auto *ref2 = (i + 2 < allNodes.size()) ? allNodes[i + 2] : nullptr;
-        interpolateSegment(painter, n1, n2, ref1, ref2);
-    }
+    painter->drawPath(interpolatedPath(allNodes, painter->device()->devicePixelRatioF()));
 }
 
 void PitchAnchorEditorView::drawDragPreviewCurve(QPainter *painter) const {
@@ -334,13 +333,7 @@ void PitchAnchorEditorView::drawDragPreviewCurve(QPainter *painter) const {
         if (allNodes.size() < 2)
             continue;
 
-        for (int i = 0; i < allNodes.size() - 1; i++) {
-            auto *n1 = allNodes[i];
-            auto *n2 = allNodes[i + 1];
-            auto *ref1 = (i > 0) ? allNodes[i - 1] : nullptr;
-            auto *ref2 = (i + 2 < allNodes.size()) ? allNodes[i + 2] : nullptr;
-            interpolateSegment(painter, n1, n2, ref1, ref2);
-        }
+        painter->drawPath(interpolatedPath(allNodes, painter->device()->devicePixelRatioF()));
 
         painter->setPen(Qt::NoPen);
         painter->setBrush(dragPreviewColor);
@@ -375,38 +368,50 @@ void PitchAnchorEditorView::drawSelectionRect(QPainter *painter) const {
     painter->drawRoundedRect(localRect, radius, radius);
 }
 
-void PitchAnchorEditorView::interpolateSegment(QPainter *painter, AnchorNode *n1, AnchorNode *n2,
-                                               AnchorNode *ref1, AnchorNode *ref2) const {
-    auto interp = AnchorCurve::createInterpolator(n1, n2, ref1, ref2);
-
-    const double startX = tickToItemX(n1->pos());
-    const double endX = tickToItemX(n2->pos());
-
+QPainterPath PitchAnchorEditorView::interpolatedPath(const QList<AnchorNode *> &nodes,
+                                                     const double devicePixelRatio) const {
     QPainterPath path;
-    bool first = true;
-    double prevLy = 0;
-    double step = 2.0;
-    const double dir = (endX < startX) ? -1.0 : 1.0;
-    double px = startX;
-    while ((dir > 0) ? (px <= endX) : (px >= endX)) {
-        const double tick = sceneXToTick(px + pos().x());
-        const double val = interp.evaluate(tick);
-        const double ly = sceneYToItemY(valueToSceneY(static_cast<int>(val)));
-        if (first) {
-            path.moveTo(px, ly);
-            first = false;
-        } else {
-            path.lineTo(px, ly);
-            double dy = std::abs(ly - prevLy);
-            step = (dy > 4.0) ? 0.5 : (dy > 2.0) ? 1.0 : 2.0;
+    if (nodes.size() < 2)
+        return path;
+
+    const auto dpr = std::max(1.0, devicePixelRatio);
+    const auto visibleLeft = rect().left() - 2.0 / dpr;
+    const auto visibleRight = rect().right() + 2.0 / dpr;
+    for (int i = 0; i < nodes.size() - 1; ++i) {
+        const auto *firstNode = nodes.at(i);
+        const auto *secondNode = nodes.at(i + 1);
+        const auto segmentLeft = tickToItemX(firstNode->pos());
+        const auto segmentRight = tickToItemX(secondNode->pos());
+        const auto startX = std::max(segmentLeft, visibleLeft);
+        const auto endX = std::min(segmentRight, visibleRight);
+        if (endX < startX)
+            continue;
+
+        const auto *previousNode = i > 0 ? nodes.at(i - 1) : nullptr;
+        const auto *nextNode = i + 2 < nodes.size() ? nodes.at(i + 2) : nullptr;
+        const auto interpolator =
+            AnchorCurve::createInterpolator(firstNode, secondNode, previousNode, nextNode);
+        auto appendPoint = [&](const double x) {
+            const auto tick = sceneXToTick(x + pos().x());
+            const auto value = interpolator.evaluate(tick);
+            const QPointF point(x, sceneYToItemY(valueToSceneY(value)));
+            if (path.isEmpty())
+                path.moveTo(point);
+            else if (QLineF(path.currentPosition(), point).length() > 0.001)
+                path.lineTo(point);
+            return point.y();
+        };
+
+        auto x = startX;
+        auto previousY = appendPoint(x);
+        auto physicalStep = 2.0;
+        while (x < endX) {
+            x = std::min(endX, x + physicalStep / dpr);
+            const auto y = appendPoint(x);
+            const auto physicalDeltaY = std::abs(y - previousY) * dpr;
+            physicalStep = physicalDeltaY > 4.0 ? 0.5 : physicalDeltaY > 2.0 ? 1.0 : 2.0;
+            previousY = y;
         }
-        prevLy = ly;
-        px += dir * step;
     }
-    if (!first) {
-        const double tick = sceneXToTick(endX + pos().x());
-        const double val = interp.evaluate(tick);
-        path.lineTo(endX, sceneYToItemY(valueToSceneY(static_cast<int>(val))));
-    }
-    painter->drawPath(path);
+    return path;
 }

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PitchAnchorEditorView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PitchAnchorEditorView.h
@@ -5,12 +5,14 @@
 #ifndef PITCHANCHOREDITORVIEW_H
 #define PITCHANCHOREDITORVIEW_H
 
+#include "PitchDisplayStrategy.h"
 #include "UI/Views/Common/TimeOverlayView.h"
 
 #include <QColor>
 
 struct AnchorOverlayState;
 class AnchorNode;
+class QPainterPath;
 
 class PitchAnchorEditorView : public TimeOverlayView {
     Q_OBJECT
@@ -19,6 +21,7 @@ public:
     PitchAnchorEditorView();
 
     void setOverlayState(const AnchorOverlayState *state);
+    void setDisplayMode(PitchDisplayMode mode);
     [[nodiscard]] double valueToSceneY(double value) const;
     [[nodiscard]] double sceneYToValue(double y) const;
 
@@ -41,10 +44,11 @@ private:
     void drawDragPreviewCurve(QPainter *painter) const;
     void drawSelectionRect(QPainter *painter) const;
 
-    void interpolateSegment(QPainter *painter, AnchorNode *n1, AnchorNode *n2,
-                            AnchorNode *ref1, AnchorNode *ref2) const;
+    [[nodiscard]] QPainterPath interpolatedPath(const QList<AnchorNode *> &nodes,
+                                                double devicePixelRatio) const;
 
     const AnchorOverlayState *m_state = nullptr;
+    PitchDisplayMode m_displayMode = PitchDisplayMode::Final;
 
     // Base colors; state-dependent alphas (active/preview tiers) are applied in draw methods
     QColor m_anchorColor = {220, 220, 220};

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PitchDisplayStrategy.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PitchDisplayStrategy.cpp
@@ -1,0 +1,136 @@
+//
+// Created by Codex on 26-8-1.
+//
+
+#include "PitchDisplayStrategy.h"
+
+#include "EditPitchAnchorHandler.h"
+
+#include <lite/ProjectModel/AppModel/AnchorCurve.h>
+#include <lite/ProjectModel/AppModel/DrawCurve.h>
+
+#include <QSet>
+
+#include <algorithm>
+
+namespace {
+    void appendNodeCoverage(QList<PitchDisplayInterval> &result,
+                            const QList<AnchorNode *> &nodes) {
+        if (nodes.size() < 2)
+            return;
+        result.append({static_cast<double>(nodes.first()->pos()),
+                       static_cast<double>(nodes.last()->pos())});
+    }
+
+    QList<AnchorNode *> sourceNodesForDisplay(AnchorCurve *curve,
+                                               const AnchorOverlayState &state) {
+        auto nodes = curve->nodes().toList();
+        if (!state.dragging)
+            return nodes;
+
+        for (const auto &info : state.dragNodeInfos) {
+            if (info.sourceCurve == curve && info.targetCurve)
+                nodes.removeOne(info.node);
+        }
+        return nodes;
+    }
+
+    QList<PitchDisplayInterval> normalized(QList<PitchDisplayInterval> intervals) {
+        for (auto &interval : intervals) {
+            if (interval.endTick < interval.startTick)
+                std::swap(interval.startTick, interval.endTick);
+        }
+        intervals.erase(std::remove_if(intervals.begin(), intervals.end(),
+                                       [](const PitchDisplayInterval &interval) {
+                                           return interval.endTick <= interval.startTick;
+                                       }),
+                        intervals.end());
+        std::sort(intervals.begin(), intervals.end(),
+                  [](const PitchDisplayInterval &left, const PitchDisplayInterval &right) {
+                      if (left.startTick != right.startTick)
+                          return left.startTick < right.startTick;
+                      return left.endTick < right.endTick;
+                  });
+
+        QList<PitchDisplayInterval> result;
+        for (const auto &interval : intervals) {
+            if (result.isEmpty() || interval.startTick > result.last().endTick) {
+                result.append(interval);
+            } else {
+                result.last().endTick = std::max(result.last().endTick, interval.endTick);
+            }
+        }
+        return result;
+    }
+}
+
+QList<PitchDisplayInterval>
+PitchDisplayStrategy::drawCurveCoverage(const QList<DrawCurve *> &curves) {
+    QList<PitchDisplayInterval> result;
+    for (const auto *curve : curves) {
+        if (!curve || curve->values().size() < 2)
+            continue;
+        result.append({static_cast<double>(curve->localStart()),
+                       static_cast<double>(curve->localEndTick())});
+    }
+    return normalized(result);
+}
+
+QList<PitchDisplayInterval>
+PitchDisplayStrategy::anchorCoverage(const AnchorOverlayState &state) {
+    QList<PitchDisplayInterval> result;
+    for (auto *curve : state.visibleCurves) {
+        if (curve)
+            appendNodeCoverage(result, sourceNodesForDisplay(curve, state));
+    }
+
+    if (state.dragging) {
+        QSet<AnchorCurve *> targets;
+        for (const auto &info : state.dragNodeInfos) {
+            if (info.targetCurve)
+                targets.insert(info.targetCurve);
+        }
+        for (auto *target : targets) {
+            auto nodes = target->nodes().toList();
+            for (const auto &info : state.dragNodeInfos) {
+                if (info.targetCurve == target) {
+                    auto it = std::lower_bound(
+                        nodes.begin(), nodes.end(), info.node,
+                        [](const AnchorNode *left, const AnchorNode *right) {
+                            return left->pos() < right->pos();
+                        });
+                    nodes.insert(it, info.node);
+                }
+            }
+            appendNodeCoverage(result, nodes);
+        }
+    }
+
+    if (state.showMergePreview && state.currentCurve && state.mergeCandidateCurve) {
+        auto nodes = state.currentCurve->nodes().toList();
+        nodes.append(state.mergeCandidateCurve->nodes().toList());
+        std::sort(nodes.begin(), nodes.end(), [](const AnchorNode *left, const AnchorNode *right) {
+            return left->pos() < right->pos();
+        });
+        appendNodeCoverage(result, nodes);
+    } else if (state.showPreview && state.previewCurve && state.cursorInView) {
+        auto nodes = state.previewCurve->nodes().toList();
+        AnchorNode previewNode(state.previewTick, 0);
+        auto it = std::lower_bound(nodes.begin(), nodes.end(), &previewNode,
+                                   [](const AnchorNode *left, const AnchorNode *right) {
+                                       return left->pos() < right->pos();
+                                   });
+        nodes.insert(it, &previewNode);
+        appendNodeCoverage(result, nodes);
+    }
+
+    return normalized(result);
+}
+
+QList<PitchDisplayInterval>
+PitchDisplayStrategy::combineCoverage(const QList<PitchDisplayInterval> &first,
+                                      const QList<PitchDisplayInterval> &second) {
+    auto result = first;
+    result.append(second);
+    return normalized(result);
+}

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PitchDisplayStrategy.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PitchDisplayStrategy.h
@@ -1,0 +1,34 @@
+//
+// Created by Codex on 26-8-1.
+//
+
+#ifndef PITCHDISPLAYSTRATEGY_H
+#define PITCHDISPLAYSTRATEGY_H
+
+#include <QList>
+
+class DrawCurve;
+struct AnchorOverlayState;
+
+enum class PitchDisplayMode {
+    Final,
+    Draw,
+    Anchor,
+};
+
+struct PitchDisplayInterval {
+    double startTick = 0;
+    double endTick = 0;
+};
+
+namespace PitchDisplayStrategy {
+    [[nodiscard]] QList<PitchDisplayInterval>
+        drawCurveCoverage(const QList<DrawCurve *> &curves);
+    [[nodiscard]] QList<PitchDisplayInterval>
+        anchorCoverage(const AnchorOverlayState &state);
+    [[nodiscard]] QList<PitchDisplayInterval>
+        combineCoverage(const QList<PitchDisplayInterval> &first,
+                        const QList<PitchDisplayInterval> &second);
+}
+
+#endif // PITCHDISPLAYSTRATEGY_H

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PitchEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PitchEditorView.cpp
@@ -4,16 +4,154 @@
 
 #include "PitchEditorView.h"
 
+#include "EditPitchAnchorHandler.h"
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
+#include <lite/ProjectModel/Utils/AppModelUtils.h>
 #include <lite/Support/MathUtils.h>
+
+#include <QPainter>
+#include <QPainterPath>
+
+#include <algorithm>
 
 PitchEditorView::PitchEditorView()
     : CommonParamEditorView(m_properties) {
     setPixelsPerQuarterNote(ClipEditorGlobal::pixelsPerQuarterNote);
 }
 
+PitchEditorView::~PitchEditorView() {
+    qDeleteAll(m_mergedCurves);
+}
+
+void PitchEditorView::setDisplayMode(const PitchDisplayMode mode) {
+    if (m_displayMode == mode)
+        return;
+    m_displayMode = mode;
+    rebuildMergedCurves();
+    update();
+}
+
+void PitchEditorView::setAnchorOverlayState(const AnchorOverlayState *state) {
+    m_anchorState = state;
+    update();
+}
+
+void PitchEditorView::loadOriginal(const QList<DrawCurve *> &curves) {
+    CommonParamEditorView::loadOriginal(curves);
+    rebuildMergedCurves();
+}
+
+void PitchEditorView::loadEdited(const QList<DrawCurve *> &curves) {
+    CommonParamEditorView::loadEdited(curves);
+    rebuildMergedCurves();
+}
+
+void PitchEditorView::clearParams() {
+    CommonParamEditorView::clearParams();
+    qDeleteAll(m_mergedCurves);
+    m_mergedCurves.clear();
+}
+
+void PitchEditorView::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+                            QWidget *widget) {
+    Q_UNUSED(option)
+    Q_UNUSED(widget)
+
+    painter->setRenderHint(QPainter::Antialiasing, true);
+    painter->setBrush(Qt::NoBrush);
+
+    const auto editedCoverage = PitchDisplayStrategy::drawCurveCoverage(editedCurves());
+    const auto anchorCoverage = m_anchorState
+                                    ? PitchDisplayStrategy::anchorCoverage(*m_anchorState)
+                                    : QList<PitchDisplayInterval>();
+    const auto editedOrAnchorCoverage =
+        PitchDisplayStrategy::combineCoverage(editedCoverage, anchorCoverage);
+
+    if (m_displayMode == PitchDisplayMode::Final) {
+        auto finalColor = editedCurveColor();
+        finalColor.setAlpha(std::min(finalColor.alpha(), 210));
+        drawCurveLayer(painter, m_mergedCurves, finalColor, anchorCoverage, {});
+        return;
+    }
+
+    if (m_displayMode == PitchDisplayMode::Draw) {
+        drawCurveLayer(painter, originalCurves(), originalCurveColor(), {},
+                       editedOrAnchorCoverage);
+        auto focusColor = editedCurveColor();
+        focusColor.setAlpha(std::min(focusColor.alpha(), 230));
+        drawCurveLayer(painter, editedCurves(), focusColor, {}, anchorCoverage);
+        return;
+    }
+
+    auto baseColor = editedCurveColor();
+    baseColor.setAlpha(std::min(baseColor.alpha(), 80));
+    drawCurveLayer(painter, m_mergedCurves, baseColor, {}, anchorCoverage);
+}
+
 void PitchEditorView::drawGraduates(QPainter *painter, const QStyleOptionGraphicsItem *option,
                                     QWidget *widget) {
+}
+
+QPainterPath
+PitchEditorView::coveragePath(const QList<PitchDisplayInterval> &coverage) const {
+    QPainterPath path;
+    const auto verticalMargin = 4.0;
+    const auto top = rect().top() - verticalMargin;
+    const auto height = rect().height() + verticalMargin * 2.0;
+    for (const auto &interval : coverage) {
+        const auto left = tickToItemX(interval.startTick);
+        const auto right = tickToItemX(interval.endTick);
+        if (right <= rect().left() || left >= rect().right())
+            continue;
+        path.addRect(QRectF(std::max(left, rect().left()), top,
+                            std::min(right, rect().right()) - std::max(left, rect().left()),
+                            height));
+    }
+    return path;
+}
+
+void PitchEditorView::drawCurveLayer(
+    QPainter *painter, const QList<DrawCurve *> &curves, const QColor &color,
+    const QList<PitchDisplayInterval> &hiddenCoverage,
+    const QList<PitchDisplayInterval> &dashedCoverage) const {
+    if (curves.isEmpty())
+        return;
+
+    QPainterPath fullPath;
+    fullPath.addRect(rect().adjusted(-2, -2, 2, 2));
+    auto visiblePath = fullPath;
+    if (!hiddenCoverage.isEmpty())
+        visiblePath = visiblePath.subtracted(coveragePath(hiddenCoverage));
+    if (visiblePath.isEmpty())
+        return;
+
+    const auto dashedPath = visiblePath.intersected(coveragePath(dashedCoverage));
+    const auto solidPath = visiblePath.subtracted(dashedPath);
+
+    QPen pen(color, 1.5);
+    pen.setCapStyle(Qt::FlatCap);
+    pen.setJoinStyle(Qt::RoundJoin);
+    if (!solidPath.isEmpty()) {
+        painter->save();
+        painter->setClipPath(solidPath, Qt::IntersectClip);
+        painter->setPen(pen);
+        drawCurveBorder(painter, curves);
+        painter->restore();
+    }
+    if (!dashedPath.isEmpty()) {
+        painter->save();
+        painter->setClipPath(dashedPath, Qt::IntersectClip);
+        pen.setStyle(Qt::CustomDashLine);
+        pen.setDashPattern({4.0, 3.0});
+        painter->setPen(pen);
+        drawCurveBorder(painter, curves);
+        painter->restore();
+    }
+}
+
+void PitchEditorView::rebuildMergedCurves() {
+    qDeleteAll(m_mergedCurves);
+    m_mergedCurves = AppModelUtils::mergeCurves(originalCurves(), editedCurves());
 }
 
 double PitchEditorView::valueToSceneY(const double value) const {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PitchEditorView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PitchEditorView.h
@@ -5,21 +5,41 @@
 #ifndef PITCHEDITORVIEW_H
 #define PITCHEDITORVIEW_H
 
+#include "PitchDisplayStrategy.h"
 #include <lite/ProjectModel/AppModel/ParamProperties.h>
 #include "UI/Views/ClipEditor/CommonParamEditorView.h"
+
+struct AnchorOverlayState;
+class QPainterPath;
 
 class PitchEditorView final : public CommonParamEditorView {
     Q_OBJECT
 public:
     PitchEditorView();
+    ~PitchEditorView() override;
 
+    void setDisplayMode(PitchDisplayMode mode);
+    void setAnchorOverlayState(const AnchorOverlayState *state);
+    void loadOriginal(const QList<DrawCurve *> &curves);
+    void loadEdited(const QList<DrawCurve *> &curves);
+    void clearParams();
     [[nodiscard]] double valueToSceneY(double value) const override;
     [[nodiscard]] double sceneYToValue(double y) const override;
 
 private:
-    void drawGraduates(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    void drawGraduates(QPainter *painter, const QStyleOptionGraphicsItem *option,
+                       QWidget *widget) override;
+    [[nodiscard]] QPainterPath coveragePath(const QList<PitchDisplayInterval> &coverage) const;
+    void drawCurveLayer(QPainter *painter, const QList<DrawCurve *> &curves, const QColor &color,
+                        const QList<PitchDisplayInterval> &hiddenCoverage,
+                        const QList<PitchDisplayInterval> &dashedCoverage) const;
+    void rebuildMergedCurves();
 
     PitchParamProperties m_properties;
+    QList<DrawCurve *> m_mergedCurves;
+    const AnchorOverlayState *m_anchorState = nullptr;
+    PitchDisplayMode m_displayMode = PitchDisplayMode::Final;
 };
 
 #endif // PITCHEDITORVIEW_H


### PR DESCRIPTION
<!-- codex-worker issue=86 kind=initial-pr head=c557fdfc10a07faff15c07f4beb78593bbb9627a -->
Closes #86

## 实现摘要

按 approved Plan `plan-v2` 完成：

- 新增 Legacy `GraphicsView` 音高显示策略，分别处理最终、手绘与锚点编辑模式。
- 最终模式按 `自动 < 手绘 < 锚点` 合成，锚点覆盖区不再把 `toDrawCurve()` 结果作为显示曲线。
- 手绘模式保留自动、手绘、锚点三层，并用虚线和淡化标识被更高优先级曲线覆盖的区间。
- 锚点模式显示淡化的自动+手绘基线、覆盖区虚线，以及原生锚点插值前景。
- 锚点正常显示、创建预览、拖动预览与合并预览统一使用 `AnchorCurve::createInterpolator()`；Linear 保持直线，Hermite 使用按物理像素自适应采样。
- 未修改推理、模型语义、DSPX 序列化或 RHI 后端。

## 验证报告

- Debug 配置/构建：PASS — 使用项目标准 VS DevShell + CMake preset 脚本完成 configure，并成功构建 `DsEditorLite`。
- 定向 Computer Use：SKIPPED（部分可观察项已通过）— 在真实 Legacy `PianoRollGraphicsView` 中加载 Jun Ninghua、生成自动音高，绘制手绘曲线并创建/拖动 3 个锚点；已观察模式切换、覆盖区虚线/淡化分层、锚点编辑后刷新，以及 Hermite/Linear 菜单切换。Computer Use 的拖拽是原子操作，无法截取按住鼠标期间的实时中间帧；本轮也未更改 Windows 缩放到 200%，因此这两项不宣称已自动验证。
- CTest: SKIPPED — 无人值守运行中可能触发弹窗并阻塞主循环；使用 Computer Use 操作真实程序验证正确运行。
- 基础功能 GUI 冒烟：PASS — 独立启动 Debug 程序，加载 Jun Ninghua，绘制 2 拍音符且前置至少 1 拍空白；观察到 Ready、自动音高曲线、音素和非平直波形；连续播放超过 2 秒并确认时间与播放头推进；保存 7,779 字节 `gui-smoke.dspx`。随后关闭实例并清理经核验的临时目录。未执行 WAV 导出。

## 人工补测

REQUIRED：

1. 在 Windows 显示缩放 200% 下打开同类工程，放大检查高曲率 Hermite 锚点段无明显折线或断裂，并确认 Linear 段保持直线。
2. 在锚点模式按住并拖动中间锚点，确认鼠标按住期间锚点前景与基线覆盖边界持续实时更新；再覆盖手绘区，确认自动/手绘基线只在锚点覆盖区显示虚线。

## 候选信息

- Approved Plan：`plan-v2`
- Planned base：`14538913cc0b6518f671990a2ef84c958040ffa7`
- Latest validated main：`fc277f2709419462af4951e1c0b75ee01f13602c`
- Candidate head：`c557fdfc10a07faff15c07f4beb78593bbb9627a`
