### PR TITLE
Fix developer options UI overflow

### DIFF
--- a/src/libs/GUI/Controls/OptionsCardItem.cpp
+++ b/src/libs/GUI/Controls/OptionsCardItem.cpp
@@ -14,8 +14,8 @@ OptionsCardItem::OptionsCardItem(QWidget *parent) : QWidget(parent) {
     m_lbDesc = new QLabel;
     m_lbDesc->setObjectName("desc");
     m_lbDesc->setVisible(false);
-    m_lbDesc->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    // TODO: word warp
+    m_lbDesc->setWordWrap(true);
+    m_lbDesc->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
     const auto titleDescLayout = new QVBoxLayout;
     titleDescLayout->addWidget(m_lbTitle);

--- a/src/libs/GUI/Controls/OptionsCardItem.cpp
+++ b/src/libs/GUI/Controls/OptionsCardItem.cpp
@@ -14,8 +14,8 @@ OptionsCardItem::OptionsCardItem(QWidget *parent) : QWidget(parent) {
     m_lbDesc = new QLabel;
     m_lbDesc->setObjectName("desc");
     m_lbDesc->setVisible(false);
-    m_lbDesc->setWordWrap(true);
     m_lbDesc->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    m_lbDesc->setWordWrap(true);
 
     const auto titleDescLayout = new QVBoxLayout;
     titleDescLayout->addWidget(m_lbTitle);


### PR DESCRIPTION
## Summary

- wrap option-card descriptions to the available content width
- let description labels grow vertically when wrapping
- keep developer-option switches and the rendering-backend selector inside the visible card area

## Root cause

`OptionsCardItem` rendered descriptions as a fixed-height, single-line label. The long developer-option description therefore enlarged the scroll area's minimum content width, producing a horizontal scrollbar and clipping controls at the right edge.

## User impact

The Developer Options page now fits its default 900 × 600 dialog: long text wraps, the horizontal scrollbar is gone, and all right-side controls remain visible. The shared option-card control also handles future long or localized descriptions safely.

## Validation

- Debug build: `cmake --build --preset debug --target all` passed
- UI regression check: reproduced the overflow before the fix, then verified the same dialog size has no horizontal scroll container and no clipped controls
- GUI smoke test with `Jun Ninghua`: pitch curve, phonemes, and non-flat waveform rendered; playback advanced from `001:01:000` to at least `002:02:037`; a 6,921-byte DSPX saved successfully; the isolated process and temporary directory were cleaned up
- Audio export skipped per the project's current GUI smoke-test limitation
- CTest: 19/20 passed; the unrelated `TestAnimationSettings` test still reports six animation timing assertions when run alone
