### PR TITLE
Match RHI audio waveform rendering

### DIFF
--- a/src/app/UI/Views/Common/EditorRhiGeometry.cpp
+++ b/src/app/UI/Views/Common/EditorRhiGeometry.cpp
@@ -112,6 +112,76 @@ namespace {
                            0.0f, 0.0f);
         }
     }
+
+    enum class ClipEdge { Left, Right, Top, Bottom };
+
+    bool isInside(const EditorRhiSolidVertex &value, const ClipEdge edge, const QRectF &rect) {
+        switch (edge) {
+            case ClipEdge::Left:
+                return value.x >= rect.left();
+            case ClipEdge::Right:
+                return value.x <= rect.right();
+            case ClipEdge::Top:
+                return value.y >= rect.top();
+            case ClipEdge::Bottom:
+                return value.y <= rect.bottom();
+        }
+        return false;
+    }
+
+    EditorRhiSolidVertex interpolate(const EditorRhiSolidVertex &from,
+                                     const EditorRhiSolidVertex &to, const double amount) {
+        const auto t = static_cast<float>(std::clamp(amount, 0.0, 1.0));
+        const auto mix = [t](const float a, const float b) { return a + (b - a) * t; };
+        return {
+            mix(from.x, to.x),
+            mix(from.y, to.y),
+            mix(from.r, to.r),
+            mix(from.g, to.g),
+            mix(from.b, to.b),
+            mix(from.a, to.a),
+            mix(from.coverage, to.coverage),
+        };
+    }
+
+    EditorRhiSolidVertex intersection(const EditorRhiSolidVertex &from,
+                                      const EditorRhiSolidVertex &to, const ClipEdge edge,
+                                      const QRectF &rect) {
+        const auto vertical = edge == ClipEdge::Left || edge == ClipEdge::Right;
+        const auto boundary = vertical ? (edge == ClipEdge::Left ? rect.left() : rect.right())
+                                       : (edge == ClipEdge::Top ? rect.top() : rect.bottom());
+        const auto fromCoordinate = vertical ? from.x : from.y;
+        const auto toCoordinate = vertical ? to.x : to.y;
+        const auto delta = toCoordinate - fromCoordinate;
+        const auto amount = std::abs(delta) > 0.000001 ? (boundary - fromCoordinate) / delta : 0.0;
+        auto result = interpolate(from, to, amount);
+        if (vertical)
+            result.x = static_cast<float>(boundary);
+        else
+            result.y = static_cast<float>(boundary);
+        return result;
+    }
+
+    qsizetype clipPolygon(const std::array<EditorRhiSolidVertex, 8> &polygon,
+                          const qsizetype polygonSize, const ClipEdge edge, const QRectF &rect,
+                          std::array<EditorRhiSolidVertex, 8> &result) {
+        if (polygonSize == 0)
+            return 0;
+        auto resultSize = qsizetype(0);
+        auto previous = polygon[polygonSize - 1];
+        auto previousInside = isInside(previous, edge, rect);
+        for (qsizetype index = 0; index < polygonSize; ++index) {
+            const auto &current = polygon[index];
+            const auto currentInside = isInside(current, edge, rect);
+            if (currentInside != previousInside)
+                result[resultSize++] = intersection(previous, current, edge, rect);
+            if (currentInside)
+                result[resultSize++] = current;
+            previous = current;
+            previousInside = currentInside;
+        }
+        return resultSize;
+    }
 }
 
 void EditorRhiGeometry::appendRect(QVector<EditorRhiSolidVertex> &vertices,
@@ -125,6 +195,36 @@ void EditorRhiGeometry::appendRect(QVector<EditorRhiSolidVertex> &vertices,
     const auto bottomRight = physicalRect.bottomRight();
     appendTriangle(vertices, topLeft, topRight, bottomRight, color, coverage, coverage, coverage);
     appendTriangle(vertices, topLeft, bottomRight, bottomLeft, color, coverage, coverage, coverage);
+}
+
+void EditorRhiGeometry::appendClippedTriangles(QVector<EditorRhiSolidVertex> &vertices,
+                                               const QVector<EditorRhiSolidVertex> &triangles,
+                                               const QRectF &physicalClipRect) {
+    const auto clipRect = physicalClipRect.normalized();
+    if (clipRect.isEmpty() || triangles.size() < 3)
+        return;
+
+    vertices.reserve(vertices.size() + triangles.size());
+    for (qsizetype index = 0; index + 2 < triangles.size(); index += 3) {
+        std::array<EditorRhiSolidVertex, 8> buffers[2];
+        auto *polygon = &buffers[0];
+        auto *clipped = &buffers[1];
+        (*polygon)[0] = triangles[index];
+        (*polygon)[1] = triangles[index + 1];
+        (*polygon)[2] = triangles[index + 2];
+        auto polygonSize = qsizetype(3);
+        for (const auto edge : {ClipEdge::Left, ClipEdge::Right, ClipEdge::Top, ClipEdge::Bottom}) {
+            polygonSize = clipPolygon(*polygon, polygonSize, edge, clipRect, *clipped);
+            std::swap(polygon, clipped);
+            if (polygonSize < 3)
+                break;
+        }
+        for (qsizetype vertexIndex = 1; vertexIndex + 1 < polygonSize; ++vertexIndex) {
+            vertices.append((*polygon)[0]);
+            vertices.append((*polygon)[vertexIndex]);
+            vertices.append((*polygon)[vertexIndex + 1]);
+        }
+    }
 }
 
 void EditorRhiGeometry::appendRoundedRect(QVector<EditorRhiSolidVertex> &vertices,

--- a/src/app/UI/Views/Common/EditorRhiGeometry.cpp
+++ b/src/app/UI/Views/Common/EditorRhiGeometry.cpp
@@ -10,10 +10,13 @@
 namespace {
     EditorRhiSolidVertex vertex(const QPointF &point, const QColor &color, const float coverage) {
         const auto alpha = static_cast<float>(color.alphaF());
-        return {static_cast<float>(point.x()), static_cast<float>(point.y()),
+        return {static_cast<float>(point.x()),
+                static_cast<float>(point.y()),
                 static_cast<float>(color.redF()) * alpha,
                 static_cast<float>(color.greenF()) * alpha,
-                static_cast<float>(color.blueF()) * alpha, alpha, coverage};
+                static_cast<float>(color.blueF()) * alpha,
+                alpha,
+                coverage};
     }
 
     QPointF normalized(const QPointF &value) {
@@ -26,9 +29,9 @@ namespace {
         return {-direction.y(), direction.x()};
     }
 
-    void appendTriangle(QVector<EditorRhiSolidVertex> &vertices, const QPointF &a,
-                        const QPointF &b, const QPointF &c, const QColor &color,
-                        const float coverageA, const float coverageB, const float coverageC) {
+    void appendTriangle(QVector<EditorRhiSolidVertex> &vertices, const QPointF &a, const QPointF &b,
+                        const QPointF &c, const QColor &color, const float coverageA,
+                        const float coverageB, const float coverageC) {
         vertices.append(vertex(a, color, coverageA));
         vertices.append(vertex(b, color, coverageB));
         vertices.append(vertex(c, color, coverageC));
@@ -50,18 +53,16 @@ namespace {
         result.reserve(centers.size() * (segmentsPerCorner + 1));
         for (qsizetype corner = 0; corner < centers.size(); ++corner) {
             for (int segment = 0; segment <= segmentsPerCorner; ++segment) {
-                const auto angle =
-                    startAngles[corner] + segment * pi * 0.5 / segmentsPerCorner;
+                const auto angle = startAngles[corner] + segment * pi * 0.5 / segmentsPerCorner;
                 result.append(centers[corner] + QPointF(std::cos(angle), std::sin(angle)) * r);
             }
         }
         return result;
     }
 
-    void appendContourBand(QVector<EditorRhiSolidVertex> &vertices,
-                           const QVector<QPointF> &outer, const QVector<QPointF> &inner,
-                           const QColor &color, const float outerCoverage,
-                           const float innerCoverage) {
+    void appendContourBand(QVector<EditorRhiSolidVertex> &vertices, const QVector<QPointF> &outer,
+                           const QVector<QPointF> &inner, const QColor &color,
+                           const float outerCoverage, const float innerCoverage) {
         if (outer.size() != inner.size() || outer.size() < 3)
             return;
         for (qsizetype index = 0; index < outer.size(); ++index) {
@@ -70,6 +71,45 @@ namespace {
                            outerCoverage, innerCoverage);
             appendTriangle(vertices, outer[index], inner[next], inner[index], color, outerCoverage,
                            innerCoverage, innerCoverage);
+        }
+    }
+
+    QVector<QPointF> offsetPolyline(const QVector<QPointF> &points, const double distance,
+                                    const double normalSign, const QRectF &clipRect) {
+        QVector<QPointF> result;
+        result.reserve(points.size());
+        for (qsizetype index = 0; index < points.size(); ++index) {
+            QPointF normal;
+            if (index == 0) {
+                normal = normalForSegment(points[0], points[1]) * normalSign;
+            } else if (index + 1 == points.size()) {
+                normal = normalForSegment(points[index - 1], points[index]) * normalSign;
+            } else {
+                const auto previous =
+                    normalForSegment(points[index - 1], points[index]) * normalSign;
+                const auto next = normalForSegment(points[index], points[index + 1]) * normalSign;
+                normal = normalized(previous + next);
+                const auto denominator = QPointF::dotProduct(normal, next);
+                if (normal.isNull() || std::abs(denominator) < 0.0001) {
+                    normal = next;
+                } else {
+                    normal *= std::min(3.0, 1.0 / std::abs(denominator));
+                }
+            }
+            const auto point = points[index] + normal * distance;
+            result.append({std::clamp(point.x(), clipRect.left(), clipRect.right()),
+                           std::clamp(point.y(), clipRect.top(), clipRect.bottom())});
+        }
+        return result;
+    }
+
+    void appendOpenBand(QVector<EditorRhiSolidVertex> &vertices, const QVector<QPointF> &inner,
+                        const QVector<QPointF> &outer, const QColor &color) {
+        for (qsizetype index = 0; index + 1 < inner.size(); ++index) {
+            appendTriangle(vertices, inner[index], inner[index + 1], outer[index + 1], color, 1.0f,
+                           1.0f, 0.0f);
+            appendTriangle(vertices, inner[index], outer[index + 1], outer[index], color, 1.0f,
+                           0.0f, 0.0f);
         }
     }
 }
@@ -92,8 +132,8 @@ void EditorRhiGeometry::appendRoundedRect(QVector<EditorRhiSolidVertex> &vertice
                                           const QColor &color) {
     if (physicalRect.isEmpty() || color.alpha() == 0)
         return;
-    const auto r = std::clamp(radius, 0.0,
-                              std::min(physicalRect.width(), physicalRect.height()) * 0.5);
+    const auto r =
+        std::clamp(radius, 0.0, std::min(physicalRect.width(), physicalRect.height()) * 0.5);
     if (r <= 0.0) {
         appendRect(vertices, physicalRect, color);
         return;
@@ -105,8 +145,8 @@ void EditorRhiGeometry::appendRoundedRect(QVector<EditorRhiSolidVertex> &vertice
         return;
     }
     const auto inner = roundedRectContour(innerRect, std::max(0.0, r - feather));
-    const auto outer = roundedRectContour(physicalRect.adjusted(-feather, -feather, feather, feather),
-                                          r + feather);
+    const auto outer = roundedRectContour(
+        physicalRect.adjusted(-feather, -feather, feather, feather), r + feather);
     const auto center = innerRect.center();
     for (qsizetype index = 0; index < inner.size(); ++index) {
         const auto next = (index + 1) % inner.size();
@@ -123,14 +163,13 @@ void EditorRhiGeometry::appendRoundedRectStroke(QVector<EditorRhiSolidVertex> &v
         return;
     const auto halfWidth = width * 0.5;
     const auto fadeWidth = std::max(0.5, feather);
-    const auto outerFade = roundedRectContour(
-        physicalRect.adjusted(-halfWidth - fadeWidth, -halfWidth - fadeWidth,
-                              halfWidth + fadeWidth, halfWidth + fadeWidth),
-        radius + halfWidth + fadeWidth);
+    const auto outerFade =
+        roundedRectContour(physicalRect.adjusted(-halfWidth - fadeWidth, -halfWidth - fadeWidth,
+                                                 halfWidth + fadeWidth, halfWidth + fadeWidth),
+                           radius + halfWidth + fadeWidth);
     const auto outer = roundedRectContour(
         physicalRect.adjusted(-halfWidth, -halfWidth, halfWidth, halfWidth), radius + halfWidth);
-    const auto innerRect =
-        physicalRect.adjusted(halfWidth, halfWidth, -halfWidth, -halfWidth);
+    const auto innerRect = physicalRect.adjusted(halfWidth, halfWidth, -halfWidth, -halfWidth);
     if (innerRect.isEmpty()) {
         appendRoundedRect(vertices, physicalRect, radius, color);
         return;
@@ -171,7 +210,7 @@ void EditorRhiGeometry::appendAntialiasedStroke(QVector<EditorRhiSolidVertex> &v
                                                 const QVector<QPointF> &physicalPoints,
                                                 const double width, const QColor &color,
                                                 const double feather, const double miterLimit) {
-    if (physicalPoints.size() < 2 || width <= 0.0 || color.alpha() == 0)
+    if (physicalPoints.size() < 2 || width < 0.0 || color.alpha() == 0)
         return;
 
     QVector<QPointF> points;
@@ -218,14 +257,13 @@ void EditorRhiGeometry::appendAntialiasedStroke(QVector<EditorRhiSolidVertex> &v
         QPointF innerRight;
         QPointF outerRight;
     };
+
     QVector<Section> sections;
     sections.reserve(points.size());
     for (qsizetype i = 0; i < points.size(); ++i) {
         const auto normal = joins[i] * joinScales[i];
-        sections.append({points[i] + normal * outerHalfWidth,
-                         points[i] + normal * innerHalfWidth,
-                         points[i] - normal * innerHalfWidth,
-                         points[i] - normal * outerHalfWidth});
+        sections.append({points[i] + normal * outerHalfWidth, points[i] + normal * innerHalfWidth,
+                         points[i] - normal * innerHalfWidth, points[i] - normal * outerHalfWidth});
     }
 
     for (qsizetype i = 0; i + 1 < sections.size(); ++i) {
@@ -249,14 +287,14 @@ void EditorRhiGeometry::appendAntialiasedStroke(QVector<EditorRhiSolidVertex> &v
         for (int i = 0; i < segmentCount; ++i) {
             const auto angleA = firstAngle + i * angleStep;
             const auto angleB = angleA + angleStep;
-            const QPointF innerA = center + QPointF(std::cos(angleA), std::sin(angleA)) *
-                                                innerHalfWidth;
-            const QPointF innerB = center + QPointF(std::cos(angleB), std::sin(angleB)) *
-                                                innerHalfWidth;
-            const QPointF outerA = center + QPointF(std::cos(angleA), std::sin(angleA)) *
-                                                outerHalfWidth;
-            const QPointF outerB = center + QPointF(std::cos(angleB), std::sin(angleB)) *
-                                                outerHalfWidth;
+            const QPointF innerA =
+                center + QPointF(std::cos(angleA), std::sin(angleA)) * innerHalfWidth;
+            const QPointF innerB =
+                center + QPointF(std::cos(angleB), std::sin(angleB)) * innerHalfWidth;
+            const QPointF outerA =
+                center + QPointF(std::cos(angleA), std::sin(angleA)) * outerHalfWidth;
+            const QPointF outerB =
+                center + QPointF(std::cos(angleB), std::sin(angleB)) * outerHalfWidth;
             appendTriangle(vertices, center, innerA, innerB, color, 1.0f, 1.0f, 1.0f);
             appendTriangle(vertices, innerA, outerA, outerB, color, 1.0f, 0.0f, 0.0f);
             appendTriangle(vertices, innerA, outerB, innerB, color, 1.0f, 0.0f, 1.0f);
@@ -264,4 +302,62 @@ void EditorRhiGeometry::appendAntialiasedStroke(QVector<EditorRhiSolidVertex> &v
     };
     appendRoundCap(points.first(), normalized(points.first() - points.at(1)), true);
     appendRoundCap(points.last(), normalized(points.last() - points.at(points.size() - 2)), false);
+}
+
+void EditorRhiGeometry::appendAntialiasedHairline(QVector<EditorRhiSolidVertex> &vertices,
+                                                  const QVector<QPointF> &physicalPoints,
+                                                  const QColor &color, const double feather,
+                                                  const double miterLimit) {
+    auto hairlineColor = color;
+    hairlineColor.setAlphaF(color.alphaF() * 0.75);
+    appendAntialiasedStroke(vertices, physicalPoints, 0.0, hairlineColor, feather, miterLimit);
+}
+
+void EditorRhiGeometry::appendAntialiasedWaveform(QVector<EditorRhiSolidVertex> &vertices,
+                                                  const QVector<QPointF> &physicalTop,
+                                                  const QVector<QPointF> &physicalBottom,
+                                                  const QRectF &physicalClipRect,
+                                                  const QColor &color, const double feather) {
+    if (physicalTop.size() != physicalBottom.size() || physicalTop.size() < 2 ||
+        physicalClipRect.isEmpty() || color.alpha() == 0) {
+        return;
+    }
+
+    const auto fadeWidth = std::max(0.5, feather);
+    const auto halfFade = fadeWidth * 0.5;
+    auto innerTop = offsetPolyline(physicalTop, halfFade, 1.0, physicalClipRect);
+    auto innerBottom = offsetPolyline(physicalBottom, halfFade, -1.0, physicalClipRect);
+    const auto outerTop = offsetPolyline(physicalTop, halfFade, -1.0, physicalClipRect);
+    const auto outerBottom = offsetPolyline(physicalBottom, halfFade, 1.0, physicalClipRect);
+    for (qsizetype index = 0; index < innerTop.size(); ++index) {
+        if (innerTop[index].y() <= innerBottom[index].y())
+            continue;
+        const auto centerY = (physicalTop[index].y() + physicalBottom[index].y()) * 0.5;
+        innerTop[index].setY(centerY);
+        innerBottom[index].setY(centerY);
+    }
+
+    for (qsizetype index = 0; index + 1 < innerTop.size(); ++index) {
+        appendTriangle(vertices, innerTop[index], innerTop[index + 1], innerBottom[index + 1],
+                       color, 1.0f, 1.0f, 1.0f);
+        appendTriangle(vertices, innerTop[index], innerBottom[index + 1], innerBottom[index], color,
+                       1.0f, 1.0f, 1.0f);
+    }
+    appendOpenBand(vertices, innerTop, outerTop, color);
+    appendOpenBand(vertices, innerBottom, outerBottom, color);
+
+    const auto leftX = std::max(physicalClipRect.left(), physicalTop.first().x() - halfFade);
+    const QVector<QPointF> innerLeft{innerTop.first(), innerBottom.first()};
+    const QVector<QPointF> outerLeft{
+        {leftX, outerTop.first().y()   },
+        {leftX, outerBottom.first().y()}
+    };
+    appendOpenBand(vertices, innerLeft, outerLeft, color);
+    const auto rightX = std::min(physicalClipRect.right(), physicalTop.last().x() + halfFade);
+    const QVector<QPointF> innerRight{innerBottom.last(), innerTop.last()};
+    const QVector<QPointF> outerRight{
+        {rightX, outerBottom.last().y()},
+        {rightX, outerTop.last().y()   }
+    };
+    appendOpenBand(vertices, innerRight, outerRight, color);
 }

--- a/src/app/UI/Views/Common/EditorRhiGeometry.h
+++ b/src/app/UI/Views/Common/EditorRhiGeometry.h
@@ -26,13 +26,20 @@ namespace EditorRhiGeometry {
                                  const QColor &color, double feather = 1.0);
     void appendPixelAlignedVerticalLine(QVector<EditorRhiSolidVertex> &vertices, double physicalX,
                                         double top, double bottom, const QColor &color);
-    void appendPixelAlignedHorizontalLine(QVector<EditorRhiSolidVertex> &vertices,
-                                          double physicalY, double left, double right,
-                                          const QColor &color);
+    void appendPixelAlignedHorizontalLine(QVector<EditorRhiSolidVertex> &vertices, double physicalY,
+                                          double left, double right, const QColor &color);
     void appendAntialiasedStroke(QVector<EditorRhiSolidVertex> &vertices,
                                  const QVector<QPointF> &physicalPoints, double width,
                                  const QColor &color, double feather = 1.0,
                                  double miterLimit = 3.0);
+    void appendAntialiasedHairline(QVector<EditorRhiSolidVertex> &vertices,
+                                   const QVector<QPointF> &physicalPoints, const QColor &color,
+                                   double feather = 1.0, double miterLimit = 3.0);
+    void appendAntialiasedWaveform(QVector<EditorRhiSolidVertex> &vertices,
+                                   const QVector<QPointF> &physicalTop,
+                                   const QVector<QPointF> &physicalBottom,
+                                   const QRectF &physicalClipRect, const QColor &color,
+                                   double feather = 1.0);
 }
 
 #endif // EDITORRHIGEOMETRY_H

--- a/src/app/UI/Views/Common/EditorRhiGeometry.h
+++ b/src/app/UI/Views/Common/EditorRhiGeometry.h
@@ -19,6 +19,9 @@ struct EditorRhiSolidVertex {
 namespace EditorRhiGeometry {
     void appendRect(QVector<EditorRhiSolidVertex> &vertices, const QRectF &physicalRect,
                     const QColor &color, float coverage = 1.0f);
+    void appendClippedTriangles(QVector<EditorRhiSolidVertex> &vertices,
+                                const QVector<EditorRhiSolidVertex> &triangles,
+                                const QRectF &physicalClipRect);
     void appendRoundedRect(QVector<EditorRhiSolidVertex> &vertices, const QRectF &physicalRect,
                            double radius, const QColor &color);
     void appendRoundedRectStroke(QVector<EditorRhiSolidVertex> &vertices,

--- a/src/app/UI/Views/TrackEditor/AudioWaveformSampler.cpp
+++ b/src/app/UI/Views/TrackEditor/AudioWaveformSampler.cpp
@@ -1,0 +1,366 @@
+#include "AudioWaveformSampler.h"
+
+#include "Global/AppGlobal.h"
+#include "Modules/Audio/AudioContext.h"
+
+#include <TalcsFormat/AbstractAudioFormatIO.h>
+#include <TalcsFormat/FormatManager.h>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+namespace {
+    constexpr int kSincHalfKernel = 16;
+    constexpr double kCurveThreshold = 4.0;
+    constexpr int kCurveOversample = 3;
+}
+
+AudioWaveformSampler::~AudioWaveformSampler() {
+    resetIO();
+}
+
+void AudioWaveformSampler::setPath(const QString &path) {
+    if (m_path == path)
+        return;
+    resetIO();
+    m_path = path;
+}
+
+AudioWaveformSampler::Result AudioWaveformSampler::sample(const Request &request) {
+    if (!request.audioInfo || !request.timeline || request.previewSceneRect.isEmpty() ||
+        request.visibleSceneRect.isEmpty() || request.horizontalScale <= 0.0 ||
+        request.pixelsPerQuarterNote <= 0.0 || request.devicePixelRatio <= 0.0 ||
+        request.audioInfo->sampleRate <= 0 || request.audioInfo->chunkSize <= 0) {
+        return {};
+    }
+
+    const auto ticksPerScenePixel =
+        AppGlobal::ticksPerQuarterNote / (request.horizontalScale * request.pixelsPerQuarterNote);
+    const auto samplesPerTick = static_cast<double>(request.audioInfo->sampleRate) * 60.0 /
+                                request.timeline->tempoAt(request.visibleStartTick) /
+                                AppGlobal::ticksPerQuarterNote;
+    const auto samplesPerDevicePixel =
+        ticksPerScenePixel * samplesPerTick / request.devicePixelRatio;
+
+    Result result;
+    if (samplesPerDevicePixel > request.audioInfo->chunkSize)
+        result = samplePeakMode(request);
+    else if (samplesPerDevicePixel > kCurveThreshold)
+        result = sampleSubChunkPeakMode(request);
+    else
+        result = sampleCurveMode(request);
+    return result;
+}
+
+bool AudioWaveformSampler::ensureIO() {
+    if (m_io)
+        return true;
+    if (m_path.isEmpty())
+        return false;
+    const auto formatManager = AudioContext::instance()->formatManager();
+    if (!formatManager)
+        return false;
+    m_io = formatManager->getFormatLoad(m_path);
+    if (!m_io)
+        return false;
+    if (!m_io->open(talcs::AbstractAudioFormatIO::Read)) {
+        delete m_io;
+        m_io = nullptr;
+        return false;
+    }
+    return true;
+}
+
+void AudioWaveformSampler::resetIO() {
+    if (!m_io)
+        return;
+    m_io->close();
+    delete m_io;
+    m_io = nullptr;
+}
+
+double AudioWaveformSampler::tickToSamplePos(const Request &request, const double tick) const {
+    return (request.timeline->tickToMs(tick) -
+            request.timeline->tickToMs(request.materialStartTick)) *
+           request.audioInfo->sampleRate / 1000.0;
+}
+
+double AudioWaveformSampler::samplePosToTick(const Request &request, const double samplePos) const {
+    return request.timeline->msToTick(request.timeline->tickToMs(request.materialStartTick) +
+                                      samplePos * 1000.0 / request.audioInfo->sampleRate);
+}
+
+AudioWaveformSampler::Result AudioWaveformSampler::samplePeakMode(const Request &request) const {
+    const auto &info = *request.audioInfo;
+    if (info.peakCache.isEmpty() || info.peakCacheMipmap.isEmpty())
+        return {};
+
+    const auto useHighResolution = request.horizontalScale >= 0.2;
+    const auto &peakData = useHighResolution ? info.peakCache : info.peakCacheMipmap;
+    const auto framesPerChunk = useHighResolution
+                                    ? static_cast<double>(info.chunkSize)
+                                    : static_cast<double>(info.chunkSize) * info.mipmapScale;
+    const auto drawLeftScene =
+        std::max(request.visibleSceneRect.left(), request.previewSceneRect.left());
+    const auto drawRightScene =
+        std::min(request.visibleSceneRect.right(), request.previewSceneRect.right());
+    if (drawLeftScene >= drawRightScene)
+        return {};
+
+    const auto ticksPerScenePixel =
+        AppGlobal::ticksPerQuarterNote / (request.horizontalScale * request.pixelsPerQuarterNote);
+    const auto deviceScale = request.devicePixelRatio;
+    const auto drawLeftLocal = drawLeftScene - request.previewSceneRect.left();
+    const auto drawRightLocal = drawRightScene - request.previewSceneRect.left();
+    const auto deviceStart = static_cast<int>(std::floor(drawLeftLocal * deviceScale));
+    const auto deviceEnd = static_cast<int>(std::ceil(drawRightLocal * deviceScale));
+
+    Result result;
+    result.geometry = Geometry::FilledPeaks;
+    result.peaks.reserve(deviceEnd - deviceStart + 1);
+    const auto halfHeight = request.previewSceneRect.height() * 0.5;
+    const auto centerY = request.previewSceneRect.top() + halfHeight;
+    const auto peakCount = peakData.size();
+    auto previousChunkPos =
+        tickToSamplePos(request, (request.previewSceneRect.left() + deviceStart / deviceScale -
+                                  request.leftMarginPx) *
+                                     ticksPerScenePixel) /
+        framesPerChunk;
+
+    for (auto deviceX = deviceStart; deviceX <= deviceEnd; ++deviceX) {
+        const auto localX = deviceX / deviceScale;
+        const auto nextChunkPos =
+            tickToSamplePos(request, (request.previewSceneRect.left() +
+                                      (deviceX + 1) / deviceScale - request.leftMarginPx) *
+                                         ticksPerScenePixel) /
+            framesPerChunk;
+        const auto chunkPos = previousChunkPos;
+        previousChunkPos = nextChunkPos;
+        if (localX < 0.0 || localX > request.previewSceneRect.width())
+            continue;
+
+        short minimum = 0;
+        short maximum = 0;
+        const auto firstChunk = static_cast<int>(std::floor(chunkPos));
+        const auto lastChunk = std::max(firstChunk + 1, static_cast<int>(std::ceil(nextChunkPos)));
+        for (auto index = firstChunk; index < lastChunk; ++index) {
+            if (index < 0)
+                continue;
+            if (index >= peakCount)
+                break;
+            const auto &[frameMinimum, frameMaximum] = peakData.at(index);
+            minimum = std::min(minimum, frameMinimum);
+            maximum = std::max(maximum, frameMaximum);
+        }
+
+        result.peaks.append({request.previewSceneRect.left() + localX,
+                             centerY - minimum * halfHeight / 32767.0,
+                             centerY - maximum * halfHeight / 32767.0});
+    }
+    return result;
+}
+
+AudioWaveformSampler::Result AudioWaveformSampler::sampleSubChunkPeakMode(const Request &request) {
+    if (!ensureIO())
+        return {};
+
+    const auto drawLeftScene =
+        std::max(request.visibleSceneRect.left(), request.previewSceneRect.left());
+    const auto drawRightScene =
+        std::min(request.visibleSceneRect.right(), request.previewSceneRect.right());
+    if (drawLeftScene >= drawRightScene)
+        return {};
+
+    const auto &info = *request.audioInfo;
+    const auto ticksPerScenePixel =
+        AppGlobal::ticksPerQuarterNote / (request.horizontalScale * request.pixelsPerQuarterNote);
+    const auto deviceScale = request.devicePixelRatio;
+    const auto drawLeftLocal = drawLeftScene - request.previewSceneRect.left();
+    const auto drawRightLocal = drawRightScene - request.previewSceneRect.left();
+    const auto deviceStart = static_cast<int>(std::floor(drawLeftLocal * deviceScale));
+    const auto deviceEnd = static_cast<int>(std::ceil(drawRightLocal * deviceScale));
+
+    auto sampleStart = static_cast<qint64>(
+        std::floor(tickToSamplePos(request, (request.previewSceneRect.left() +
+                                             deviceStart / deviceScale - request.leftMarginPx) *
+                                                ticksPerScenePixel)));
+    auto sampleEnd = static_cast<qint64>(
+        std::ceil(tickToSamplePos(request, (request.previewSceneRect.left() +
+                                            (deviceEnd + 1) / deviceScale - request.leftMarginPx) *
+                                               ticksPerScenePixel)));
+    sampleStart = std::max(sampleStart, qint64(0));
+    sampleEnd = std::min(sampleEnd, info.frames);
+    if (sampleEnd <= sampleStart || info.channels <= 0)
+        return {};
+
+    const auto framesToRead = sampleEnd - sampleStart;
+    m_ioBuffer.resize(static_cast<int>(framesToRead * info.channels));
+    m_io->seek(sampleStart);
+    const auto framesRead = m_io->read(m_ioBuffer.data(), framesToRead);
+    if (framesRead <= 0)
+        return {};
+
+    Result result;
+    result.geometry = Geometry::VerticalPeaks;
+    result.peaks.reserve(deviceEnd - deviceStart + 1);
+    const auto halfHeight = request.previewSceneRect.height() * 0.5;
+    const auto centerY = request.previewSceneRect.top() + halfHeight;
+    auto previousSamplePos =
+        tickToSamplePos(request, (request.previewSceneRect.left() + deviceStart / deviceScale -
+                                  request.leftMarginPx) *
+                                     ticksPerScenePixel);
+
+    for (auto deviceX = deviceStart; deviceX <= deviceEnd; ++deviceX) {
+        const auto localX = deviceX / deviceScale;
+        const auto nextSamplePos =
+            tickToSamplePos(request, (request.previewSceneRect.left() +
+                                      (deviceX + 1) / deviceScale - request.leftMarginPx) *
+                                         ticksPerScenePixel);
+        const auto samplePos = previousSamplePos;
+        previousSamplePos = nextSamplePos;
+        if (localX < 0.0 || localX > request.previewSceneRect.width())
+            continue;
+
+        auto firstFrame = static_cast<qint64>(std::floor(samplePos));
+        auto lastFrame = static_cast<qint64>(std::ceil(nextSamplePos));
+        firstFrame = std::max(firstFrame, sampleStart);
+        lastFrame = std::min(lastFrame, sampleStart + framesRead);
+        float minimum = 0.0f;
+        float maximum = 0.0f;
+        for (auto frame = firstFrame; frame < lastFrame; ++frame) {
+            const auto offset = static_cast<int>((frame - sampleStart) * info.channels);
+            auto mono = 0.0f;
+            for (auto channel = 0; channel < info.channels; ++channel)
+                mono += m_ioBuffer[offset + channel];
+            mono /= info.channels;
+            minimum = std::min(minimum, mono);
+            maximum = std::max(maximum, mono);
+        }
+        result.peaks.append({request.previewSceneRect.left() + localX,
+                             centerY - minimum * halfHeight, centerY - maximum * halfHeight});
+    }
+    return result;
+}
+
+AudioWaveformSampler::Result AudioWaveformSampler::sampleCurveMode(const Request &request) {
+    if (!ensureIO())
+        return {};
+
+    const auto drawLeftScene =
+        std::max(request.visibleSceneRect.left(), request.previewSceneRect.left());
+    const auto drawRightScene =
+        std::min(request.visibleSceneRect.right(), request.previewSceneRect.right());
+    if (drawLeftScene >= drawRightScene)
+        return {};
+
+    const auto &info = *request.audioInfo;
+    if (info.channels <= 0)
+        return {};
+    const auto ticksPerScenePixel =
+        AppGlobal::ticksPerQuarterNote / (request.horizontalScale * request.pixelsPerQuarterNote);
+    const auto deviceScale = request.devicePixelRatio;
+    const auto drawLeftLocal = drawLeftScene - request.previewSceneRect.left();
+    const auto drawRightLocal = drawRightScene - request.previewSceneRect.left();
+    const auto deviceStart = static_cast<int>(std::floor(drawLeftLocal * deviceScale));
+    const auto deviceEnd = static_cast<int>(std::ceil(drawRightLocal * deviceScale));
+    const auto firstSamplePos =
+        tickToSamplePos(request, (request.previewSceneRect.left() + deviceStart / deviceScale -
+                                  request.leftMarginPx) *
+                                     ticksPerScenePixel);
+    const auto lastSamplePos =
+        tickToSamplePos(request, (request.previewSceneRect.left() + deviceEnd / deviceScale -
+                                  request.leftMarginPx) *
+                                     ticksPerScenePixel);
+    auto sampleStart = static_cast<qint64>(std::floor(firstSamplePos)) - kSincHalfKernel;
+    auto sampleEnd = static_cast<qint64>(std::ceil(lastSamplePos)) + kSincHalfKernel;
+    sampleStart = std::max(sampleStart, qint64(0));
+    sampleEnd = std::min(sampleEnd, info.frames);
+    if (sampleEnd <= sampleStart)
+        return {};
+
+    const auto framesToRead = sampleEnd - sampleStart;
+    m_ioBuffer.resize(static_cast<int>(framesToRead * info.channels));
+    m_io->seek(sampleStart);
+    const auto framesRead = m_io->read(m_ioBuffer.data(), framesToRead);
+    if (framesRead <= 0)
+        return {};
+
+    QVector<float> monoSamples(static_cast<int>(framesRead));
+    for (auto frame = 0; frame < framesRead; ++frame) {
+        auto mono = 0.0f;
+        const auto offset = frame * info.channels;
+        for (auto channel = 0; channel < info.channels; ++channel)
+            mono += m_ioBuffer[offset + channel];
+        monoSamples[frame] = mono / info.channels;
+    }
+
+    Result result;
+    result.geometry = Geometry::Curve;
+    const auto pointCount = (deviceEnd - deviceStart) * kCurveOversample + 1;
+    result.curve.reserve(pointCount);
+    const auto halfHeight = request.previewSceneRect.height() * 0.5;
+    const auto centerY = request.previewSceneRect.top() + halfHeight;
+    for (auto index = 0; index < pointCount; ++index) {
+        const auto deviceX = deviceStart + static_cast<double>(index) / kCurveOversample;
+        const auto localX = deviceX / deviceScale;
+        if (localX < 0.0 || localX > request.previewSceneRect.width())
+            continue;
+        const auto sceneX = request.previewSceneRect.left() + localX;
+        const auto samplePos =
+            tickToSamplePos(request, (sceneX - request.leftMarginPx) * ticksPerScenePixel);
+        const auto value = sincInterpolate(monoSamples, sampleStart, info.frames, samplePos);
+        result.curve.append({sceneX, centerY - value * halfHeight});
+    }
+
+    const auto samplesPerLogicalPixel =
+        deviceEnd > deviceStart
+            ? (lastSamplePos - firstSamplePos) / ((deviceEnd - deviceStart) / deviceScale)
+            : 0.0;
+    if (samplesPerLogicalPixel <= 0.0 || samplesPerLogicalPixel >= 1.0 / 6.0)
+        return result;
+
+    result.sampleDotRadius = std::min(3.0, 1.0 / samplesPerLogicalPixel * 0.3);
+    const auto firstSample = static_cast<qint64>(std::floor(firstSamplePos));
+    const auto lastSample = static_cast<qint64>(std::ceil(lastSamplePos));
+    for (auto sampleIndex = std::max(firstSample, qint64(0));
+         sampleIndex < std::min(lastSample, info.frames); ++sampleIndex) {
+        const auto bufferIndex = static_cast<int>(sampleIndex - sampleStart);
+        if (bufferIndex < 0 || bufferIndex >= monoSamples.size())
+            continue;
+        const auto sceneX =
+            samplePosToTick(request, static_cast<double>(sampleIndex)) / ticksPerScenePixel +
+            request.leftMarginPx;
+        if (sceneX < request.previewSceneRect.left() || sceneX > request.previewSceneRect.right()) {
+            continue;
+        }
+        result.sampleDots.append({sceneX, centerY - monoSamples[bufferIndex] * halfHeight});
+    }
+    return result;
+}
+
+double AudioWaveformSampler::sincInterpolate(const QVector<float> &samples, const qint64 offset,
+                                             const qint64 totalFrames, const double position) {
+    const auto center = static_cast<qint64>(std::floor(position));
+    const auto fraction = position - center;
+    auto result = 0.0;
+    constexpr auto pi = std::numbers::pi_v<double>;
+    for (auto index = -kSincHalfKernel; index <= kSincHalfKernel; ++index) {
+        const auto sampleIndex = center + index;
+        if (sampleIndex < 0 || sampleIndex >= totalFrames)
+            continue;
+        const auto bufferIndex = static_cast<int>(sampleIndex - offset);
+        if (bufferIndex < 0 || bufferIndex >= samples.size())
+            continue;
+        const auto x = fraction - index;
+        auto sinc = 1.0;
+        auto window = 1.0;
+        if (std::abs(x) >= 1e-9) {
+            sinc = std::sin(pi * x) / (pi * x);
+            const auto windowX = x / kSincHalfKernel;
+            window = std::abs(windowX) < 1.0 ? std::sin(pi * windowX) / (pi * windowX) : 0.0;
+        }
+        result += samples[bufferIndex] * sinc * window;
+    }
+    return result;
+}

--- a/src/app/UI/Views/TrackEditor/AudioWaveformSampler.cpp
+++ b/src/app/UI/Views/TrackEditor/AudioWaveformSampler.cpp
@@ -25,6 +25,12 @@ void AudioWaveformSampler::setPath(const QString &path) {
         return;
     resetIO();
     m_path = path;
+    invalidate();
+}
+
+void AudioWaveformSampler::invalidate() {
+    m_cacheKey.reset();
+    m_cachedResult = {};
 }
 
 AudioWaveformSampler::Result AudioWaveformSampler::sample(const Request &request) {
@@ -32,8 +38,13 @@ AudioWaveformSampler::Result AudioWaveformSampler::sample(const Request &request
         request.visibleSceneRect.isEmpty() || request.horizontalScale <= 0.0 ||
         request.pixelsPerQuarterNote <= 0.0 || request.devicePixelRatio <= 0.0 ||
         request.audioInfo->sampleRate <= 0 || request.audioInfo->chunkSize <= 0) {
+        invalidate();
         return {};
     }
+
+    const auto cacheKey = makeCacheKey(request);
+    if (m_cacheKey == cacheKey)
+        return m_cachedResult;
 
     const auto ticksPerScenePixel =
         AppGlobal::ticksPerQuarterNote / (request.horizontalScale * request.pixelsPerQuarterNote);
@@ -50,7 +61,34 @@ AudioWaveformSampler::Result AudioWaveformSampler::sample(const Request &request
         result = sampleSubChunkPeakMode(request);
     else
         result = sampleCurveMode(request);
+    m_cacheKey = cacheKey;
+    m_cachedResult = result;
     return result;
+}
+
+AudioWaveformSampler::CacheKey AudioWaveformSampler::makeCacheKey(const Request &request) {
+    const auto &info = *request.audioInfo;
+    return {
+        .audioInfo = request.audioInfo,
+        .timeline = request.timeline,
+        .peakCacheData = info.peakCache.constData(),
+        .peakCacheMipmapData = info.peakCacheMipmap.constData(),
+        .materialStartTick = request.materialStartTick,
+        .visibleStartTick = request.visibleStartTick,
+        .chunkSize = info.chunkSize,
+        .mipmapScale = info.mipmapScale,
+        .sampleRate = info.sampleRate,
+        .channels = info.channels,
+        .frames = info.frames,
+        .peakCacheSize = info.peakCache.size(),
+        .peakCacheMipmapSize = info.peakCacheMipmap.size(),
+        .previewSceneRect = request.previewSceneRect,
+        .visibleSceneRect = request.visibleSceneRect,
+        .horizontalScale = request.horizontalScale,
+        .pixelsPerQuarterNote = request.pixelsPerQuarterNote,
+        .leftMarginPx = request.leftMarginPx,
+        .devicePixelRatio = request.devicePixelRatio,
+    };
 }
 
 bool AudioWaveformSampler::ensureIO() {

--- a/src/app/UI/Views/TrackEditor/AudioWaveformSampler.h
+++ b/src/app/UI/Views/TrackEditor/AudioWaveformSampler.h
@@ -11,6 +11,8 @@
 #include <QString>
 #include <QVector>
 
+#include <optional>
+
 namespace talcs {
     class AbstractAudioFormatIO;
 }
@@ -47,9 +49,35 @@ public:
     AudioWaveformSampler &operator=(const AudioWaveformSampler &) = delete;
 
     void setPath(const QString &path);
+    void invalidate();
     [[nodiscard]] Result sample(const Request &request);
 
 private:
+    struct CacheKey {
+        const AudioInfoModel *audioInfo = nullptr;
+        const Timeline *timeline = nullptr;
+        const void *peakCacheData = nullptr;
+        const void *peakCacheMipmapData = nullptr;
+        int materialStartTick = 0;
+        int visibleStartTick = 0;
+        int chunkSize = 0;
+        int mipmapScale = 0;
+        int sampleRate = 0;
+        int channels = 0;
+        long long frames = 0;
+        qsizetype peakCacheSize = 0;
+        qsizetype peakCacheMipmapSize = 0;
+        QRectF previewSceneRect;
+        QRectF visibleSceneRect;
+        double horizontalScale = 1.0;
+        double pixelsPerQuarterNote = 64.0;
+        double leftMarginPx = 0.0;
+        double devicePixelRatio = 1.0;
+
+        bool operator==(const CacheKey &) const = default;
+    };
+
+    [[nodiscard]] static CacheKey makeCacheKey(const Request &request);
     [[nodiscard]] bool ensureIO();
     void resetIO();
     [[nodiscard]] double tickToSamplePos(const Request &request, double tick) const;
@@ -64,6 +92,8 @@ private:
     QString m_path;
     talcs::AbstractAudioFormatIO *m_io = nullptr;
     QVector<float> m_ioBuffer;
+    std::optional<CacheKey> m_cacheKey;
+    Result m_cachedResult;
 };
 
 #endif // AUDIOWAVEFORMSAMPLER_H

--- a/src/app/UI/Views/TrackEditor/AudioWaveformSampler.h
+++ b/src/app/UI/Views/TrackEditor/AudioWaveformSampler.h
@@ -1,0 +1,69 @@
+#ifndef AUDIOWAVEFORMSAMPLER_H
+#define AUDIOWAVEFORMSAMPLER_H
+
+#include "UI/Utils/WaveformRenderUtils.h"
+
+#include <lite/MusicBase/Timeline.h>
+#include <lite/ProjectModel/AppModel/AudioInfoModel.h>
+
+#include <QPointF>
+#include <QRectF>
+#include <QString>
+#include <QVector>
+
+namespace talcs {
+    class AbstractAudioFormatIO;
+}
+
+class AudioWaveformSampler final {
+public:
+    enum class Geometry { None, FilledPeaks, VerticalPeaks, Curve };
+
+    struct Result {
+        Geometry geometry = Geometry::None;
+        QVector<WaveformRenderUtils::PeakPoint> peaks;
+        QVector<QPointF> curve;
+        QVector<QPointF> sampleDots;
+        double sampleDotRadius = 0.0;
+    };
+
+    struct Request {
+        const AudioInfoModel *audioInfo = nullptr;
+        const Timeline *timeline = nullptr;
+        int materialStartTick = 0;
+        int visibleStartTick = 0;
+        QRectF previewSceneRect;
+        QRectF visibleSceneRect;
+        double horizontalScale = 1.0;
+        double pixelsPerQuarterNote = 64.0;
+        double leftMarginPx = 0.0;
+        double devicePixelRatio = 1.0;
+    };
+
+    AudioWaveformSampler() = default;
+    ~AudioWaveformSampler();
+
+    AudioWaveformSampler(const AudioWaveformSampler &) = delete;
+    AudioWaveformSampler &operator=(const AudioWaveformSampler &) = delete;
+
+    void setPath(const QString &path);
+    [[nodiscard]] Result sample(const Request &request);
+
+private:
+    [[nodiscard]] bool ensureIO();
+    void resetIO();
+    [[nodiscard]] double tickToSamplePos(const Request &request, double tick) const;
+    [[nodiscard]] double samplePosToTick(const Request &request, double samplePos) const;
+    [[nodiscard]] Result samplePeakMode(const Request &request) const;
+    [[nodiscard]] Result sampleSubChunkPeakMode(const Request &request);
+    [[nodiscard]] Result sampleCurveMode(const Request &request);
+
+    static double sincInterpolate(const QVector<float> &samples, qint64 offset, qint64 totalFrames,
+                                  double position);
+
+    QString m_path;
+    talcs::AbstractAudioFormatIO *m_io = nullptr;
+    QVector<float> m_ioBuffer;
+};
+
+#endif // AUDIOWAVEFORMSAMPLER_H

--- a/src/app/UI/Views/TrackEditor/GraphicsItem/AudioClipView.cpp
+++ b/src/app/UI/Views/TrackEditor/GraphicsItem/AudioClipView.cpp
@@ -1,41 +1,27 @@
 #include "AudioClipView.h"
 
+#include "Global/TracksEditorGlobal.h"
+#include "UI/Utils/WaveformRenderUtils.h"
+
 #include <QCoreApplication>
-#include <QElapsedTimer>
 #include <QPainter>
 #include <QPainterPath>
-#include <QPolygon>
-#include "UI/Utils/WaveformRenderUtils.h"
-#include <cmath>
-
-#include "Global/TracksEditorGlobal.h"
-#include "Modules/Audio/AudioContext.h"
-
-#include <TalcsFormat/FormatManager.h>
-#include <TalcsFormat/AbstractAudioFormatIO.h>
 
 using namespace TracksEditorGlobal;
-
-static constexpr int kSincHalfKernel = 16;
-static constexpr double kCurveThreshold = 4.0;
-static constexpr int kCurveOversample = 3;
 
 AudioClipView::AudioClipView(const int itemId, QGraphicsItem *parent)
     : AbstractClipView(itemId, parent) {
 }
 
-AudioClipView::~AudioClipView() {
-    resetIO();
-}
+AudioClipView::~AudioClipView() = default;
 
 QString AudioClipView::path() const {
     return m_path;
 }
 
 void AudioClipView::setPath(const QString &path) {
-    if (m_path != path)
-        resetIO();
     m_path = path;
+    m_waveformSampler.setPath(path);
     if (m_status != AppGlobal::Error)
         m_status = AppGlobal::Loaded;
 }
@@ -64,70 +50,6 @@ int AudioClipView::contentLength() const {
     return length();
 }
 
-bool AudioClipView::ensureIO() {
-    if (m_io)
-        return true;
-    if (m_path.isEmpty())
-        return false;
-    auto *fm = AudioContext::instance()->formatManager();
-    if (!fm)
-        return false;
-    m_io = fm->getFormatLoad(m_path);
-    if (!m_io)
-        return false;
-    if (!m_io->open(talcs::AbstractAudioFormatIO::Read)) {
-        delete m_io;
-        m_io = nullptr;
-        return false;
-    }
-    return true;
-}
-
-void AudioClipView::resetIO() {
-    if (m_io) {
-        m_io->close();
-        delete m_io;
-        m_io = nullptr;
-    }
-}
-
-double AudioClipView::sincInterpolate(const QVector<float> &samples, const qint64 offset,
-                                      const qint64 totalFrames, const double position,
-                                      const int halfKernel) {
-    const int center = static_cast<int>(std::floor(position));
-    const double frac = position - center;
-
-    double result = 0.0;
-    for (int i = -halfKernel; i <= halfKernel; i++) {
-        const qint64 idx = static_cast<qint64>(center) + i;
-        if (idx < 0 || idx >= totalFrames)
-            continue;
-        const int bufIdx = static_cast<int>(idx - offset);
-        if (bufIdx < 0 || bufIdx >= samples.size())
-            continue;
-
-        const double x = frac - i;
-        double sinc_val;
-        double window;
-        if (std::abs(x) < 1e-9) {
-            sinc_val = 1.0;
-            window = 1.0;
-        } else {
-            sinc_val = std::sin(M_PI * x) / (M_PI * x);
-            const double wx = x / halfKernel;
-            window = (std::abs(wx) < 1.0) ? std::sin(M_PI * wx) / (M_PI * wx) : 0.0;
-        }
-        result += samples[bufIdx] * sinc_val * window;
-    }
-    return result;
-}
-
-// Dispatches to the appropriate rendering method based on zoom level.
-//
-// samplesPerPixel thresholds:
-//   > chunkSize  → peak mipmap / peakCache (vertical lines, batch drawLines)
-//   > ~4         → sub-chunk peak mode (IO seek+read, per-pixel min/max lines)
-//   ≤ ~4         → waveform curve mode (IO seek+read, Lanczos sinc interpolation, QPainterPath)
 void AudioClipView::setRenderMode(const WaveformRenderUtils::Mode mode) {
     m_renderMode = mode;
     update();
@@ -140,11 +62,9 @@ WaveformRenderUtils::Mode AudioClipView::renderMode() const {
 void AudioClipView::drawPreviewArea(QPainter *painter, const QRectF &previewRect,
                                     const QColor color) {
     if (m_status == AppGlobal::Error) {
-        QPen pen;
         auto dimmed = color;
         dimmed.setAlphaF(color.alphaF() * 0.5);
-        pen.setColor(dimmed);
-        painter->setPen(pen);
+        painter->setPen(dimmed);
         auto text = QCoreApplication::translate("AudioClipView", "File missing");
         if (!m_errorMessage.isEmpty())
             text += ": " + m_errorMessage;
@@ -152,381 +72,60 @@ void AudioClipView::drawPreviewArea(QPainter *painter, const QRectF &previewRect
         return;
     }
     if (m_status == AppGlobal::Loading) {
-        QPen pen;
-        pen.setColor(color);
-        painter->setPen(pen);
+        painter->setPen(color);
         painter->drawText(previewRect, "Loading...", QTextOption(Qt::AlignCenter));
     }
 
-    if (m_audioInfo.sampleRate <= 0 || m_audioInfo.chunkSize <= 0)
-        return;
+    const auto previewTopLeft = mapToScene(previewRect.topLeft());
+    const auto previewBottomRight = mapToScene(previewRect.bottomRight());
+    const auto waveform = m_waveformSampler.sample({
+        .audioInfo = &m_audioInfo,
+        .timeline = &m_timeline,
+        .materialStartTick = start(),
+        .visibleStartTick = start() + clipStart(),
+        .previewSceneRect = QRectF(previewTopLeft, previewBottomRight),
+        .visibleSceneRect = visibleRect(),
+        .horizontalScale = scaleX(),
+        .pixelsPerQuarterNote = pixelsPerQuarterNote,
+        .leftMarginPx = leftMarginPx(),
+        .devicePixelRatio = painter->deviceTransform().m11(),
+    });
 
-    const double ticksPerScenePixel =
-        AppGlobal::ticksPerQuarterNote / (scaleX() * pixelsPerQuarterNote);
-    // Dispatch by the local density at the visible start; per-pixel math inside
-    // the modes is piecewise over the tempo map
-    const double samplesPerTick = static_cast<double>(m_audioInfo.sampleRate) * 60.0 /
-                                  m_timeline.tempoAt(start() + clipStart()) /
-                                  AppGlobal::ticksPerQuarterNote;
-    const double scaleXDev = painter->deviceTransform().m11();
-    const double samplesPerDevPixel = ticksPerScenePixel * samplesPerTick / scaleXDev;
-    const double chunkSize = static_cast<double>(m_audioInfo.chunkSize);
-
-    if (samplesPerDevPixel <= chunkSize) {
-        if (samplesPerDevPixel <= kCurveThreshold)
-            drawWaveformCurve(painter, previewRect, color);
-        else
-            drawSubChunkPeakMode(painter, previewRect, color);
-    } else {
-        drawPeakMode(painter, previewRect, color);
-    }
-}
-
-// Absolute tick → material sample position, piecewise over the tempo map.
-// The material's tick origin is start(); its ms origin follows from it.
-double AudioClipView::tickToSamplePos(const double absTick) const {
-    return (m_timeline.tickToMs(absTick) - m_timeline.tickToMs(start())) *
-           m_audioInfo.sampleRate / 1000.0;
-}
-
-// Inverse of tickToSamplePos
-double AudioClipView::samplePosToTick(const double samplePos) const {
-    return m_timeline.msToTick(m_timeline.tickToMs(start()) +
-                               samplePos * 1000.0 / m_audioInfo.sampleRate);
-}
-
-// Peak mode: uses pre-computed peakCache / peakCacheMipmap.
-// Physical-pixel stepping + scene-aligned grid.
-void AudioClipView::drawPeakMode(QPainter *painter, const QRectF &previewRect,
-                                 const QColor &color) {
-    if (m_audioInfo.peakCache.count() == 0 || m_audioInfo.peakCacheMipmap.count() == 0)
-        return;
-
-    const auto rectLeft = previewRect.left();
-    const auto rectTop = previewRect.top();
-    const auto rectWidth = previewRect.width();
-    const auto rectHeight = previewRect.height();
-    const auto halfRectHeight = rectHeight / 2;
-
-    // Select resolution level: use full-resolution peak data when zoomed in,
-    // downsampled mipmap when zoomed out
-    m_resolution = scaleX() >= 0.2 ? High : Low;
-    const auto &peakData =
-        m_resolution == Low ? m_audioInfo.peakCacheMipmap : m_audioInfo.peakCache;
-    const double framesPerChunk =
-        m_resolution == Low ? static_cast<double>(m_audioInfo.chunkSize) * m_audioInfo.mipmapScale
-                            : static_cast<double>(m_audioInfo.chunkSize);
-
-    const auto rectLeftScene = mapToScene(previewRect.topLeft()).x();
-    const auto rectRightScene = mapToScene(previewRect.bottomRight()).x();
-    const auto visLeft = visibleRect().left();
-    const auto visRight = visibleRect().right();
-    const auto drawLeftScene = std::max(visLeft, rectLeftScene);
-    const auto drawRightScene = std::min(visRight, rectRightScene);
-
-    if (drawLeftScene >= drawRightScene)
-        return;
-
-    const double ticksPerScenePixel =
-        AppGlobal::ticksPerQuarterNote / (scaleX() * pixelsPerQuarterNote);
-    const int peakCount = peakData.count();
-
-    const auto &dt = painter->deviceTransform();
-    const double scaleXDev = dt.m11();
-    const double devLeft = dt.map(QPointF(rectLeft, 0)).x();
-
-    const double drawLeftLocal = drawLeftScene - rectLeftScene;
-    const double drawRightLocal = drawRightScene - rectLeftScene;
-    const int devStart = static_cast<int>(std::floor(drawLeftLocal * scaleXDev));
-    const int devEnd = static_cast<int>(std::ceil(drawRightLocal * scaleXDev));
-    const int stepCount = devEnd - devStart + 1;
-
-    QVector<WaveformRenderUtils::PeakPoint> points;
-    points.reserve(stepCount);
-
-    // Convert per pixel edge (piecewise over the tempo map); carry the previous
-    // edge so each pixel covers a contiguous chunk range
-    // 场景坐标含 leftMarginPx() 偏移，换算成 tick 必须扣除，否则波形右移 10px
-    // （237a904a 引入；drawSubChunkPeakMode / drawWaveformCurve 同样处理）
-    double prevChunkPos = tickToSamplePos((rectLeftScene + devStart / scaleXDev - leftMarginPx()) *
-                                          ticksPerScenePixel) /
-                          framesPerChunk;
-
-    for (int di = devStart; di <= devEnd; di++) {
-        const double localX = di / scaleXDev;
-        const double nextChunkPos =
-            tickToSamplePos((rectLeftScene + (di + 1) / scaleXDev - leftMarginPx()) *
-                            ticksPerScenePixel) /
-            framesPerChunk;
-        const double chunkPos = prevChunkPos;
-        prevChunkPos = nextChunkPos;
-        if (localX < 0 || localX > rectWidth)
-            continue;
-
-        const double chunkEnd = nextChunkPos;
-
-        // Find min/max peak values within this pixel's chunk range
-        short min = 0;
-        short max = 0;
-
-        const int jStart = static_cast<int>(std::floor(chunkPos));
-        const int jEnd = std::max(jStart + 1, static_cast<int>(std::ceil(chunkEnd)));
-        for (int j = jStart; j < jEnd; j++) {
-            if (j < 0)
-                continue;
-            if (j >= peakCount)
-                break;
-            const auto &frame = peakData.at(j);
-            const auto frameMin = std::get<0>(frame);
-            const auto frameMax = std::get<1>(frame);
-            if (frameMin < min)
-                min = frameMin;
-            if (frameMax > max)
-                max = frameMax;
+    if (waveform.geometry == AudioWaveformSampler::Geometry::FilledPeaks ||
+        waveform.geometry == AudioWaveformSampler::Geometry::VerticalPeaks) {
+        QVector<WaveformRenderUtils::PeakPoint> localPeaks;
+        localPeaks.reserve(waveform.peaks.size());
+        for (const auto &point : waveform.peaks) {
+            const auto minimum = mapFromScene(QPointF(point.x, point.yMin));
+            const auto maximum = mapFromScene(QPointF(point.x, point.yMax));
+            localPeaks.append({minimum.x(), minimum.y(), maximum.y()});
         }
-
-        const double x = rectLeft + localX;
-        const double yMin = -min * halfRectHeight / 32767.0 + halfRectHeight + rectTop;
-        const double yMax = -max * halfRectHeight / 32767.0 + halfRectHeight + rectTop;
-        points.append({x, yMin, yMax});
+        const auto mode = waveform.geometry == AudioWaveformSampler::Geometry::FilledPeaks
+                              ? m_renderMode
+                              : WaveformRenderUtils::LineMode;
+        WaveformRenderUtils::renderWaveform(painter, color, mode, localPeaks);
+        return;
     }
 
-    WaveformRenderUtils::renderWaveform(painter, color, m_renderMode, points);
-}
-
-// Sub-chunk peak mode: reads raw samples via IO, computes per-pixel min/max.
-// Used when zoomed in enough that each pixel covers fewer samples than chunkSize
-// but still more than ~4 samples.
-void AudioClipView::drawSubChunkPeakMode(QPainter *painter, const QRectF &previewRect,
-                                         const QColor &color) {
-    if (!ensureIO())
+    if (waveform.geometry != AudioWaveformSampler::Geometry::Curve || waveform.curve.isEmpty())
         return;
-
-    const auto rectLeft = previewRect.left();
-    const auto rectTop = previewRect.top();
-    const auto rectWidth = previewRect.width();
-    const auto rectHeight = previewRect.height();
-    const auto halfRectHeight = rectHeight / 2;
-
-    const auto rectLeftScene = mapToScene(previewRect.topLeft()).x();
-    const auto rectRightScene = mapToScene(previewRect.bottomRight()).x();
-    const auto visLeft = visibleRect().left();
-    const auto visRight = visibleRect().right();
-    const auto drawLeftScene = std::max(visLeft, rectLeftScene);
-    const auto drawRightScene = std::min(visRight, rectRightScene);
-
-    if (drawLeftScene >= drawRightScene)
-        return;
-
-    const double ticksPerScenePixel =
-        AppGlobal::ticksPerQuarterNote / (scaleX() * pixelsPerQuarterNote);
-    const int channels = m_audioInfo.channels;
-    const qint64 totalFrames = m_audioInfo.frames;
-
-    const auto &dt = painter->deviceTransform();
-    const double scaleXDev = dt.m11();
-
-    const double drawLeftLocal = drawLeftScene - rectLeftScene;
-    const double drawRightLocal = drawRightScene - rectLeftScene;
-    const int devStart = static_cast<int>(std::floor(drawLeftLocal * scaleXDev));
-    const int devEnd = static_cast<int>(std::ceil(drawRightLocal * scaleXDev));
-    const int stepCount = devEnd - devStart + 1;
-
-    qint64 sampleStart = static_cast<qint64>(std::floor(tickToSamplePos(
-        (rectLeftScene + devStart / scaleXDev - leftMarginPx()) * ticksPerScenePixel)));
-    qint64 sampleEnd = static_cast<qint64>(std::ceil(tickToSamplePos(
-        (rectLeftScene + (devEnd + 1) / scaleXDev - leftMarginPx()) * ticksPerScenePixel)));
-    sampleStart = std::max(sampleStart, qint64(0));
-    sampleEnd = std::min(sampleEnd, totalFrames);
-
-    if (sampleEnd <= sampleStart)
-        return;
-
-    const qint64 framesToRead = sampleEnd - sampleStart;
-    m_ioBuffer.resize(static_cast<int>(framesToRead * channels));
-
-    m_io->seek(sampleStart);
-    const qint64 framesRead = m_io->read(m_ioBuffer.data(), framesToRead);
-
-    QVector<WaveformRenderUtils::PeakPoint> points;
-    points.reserve(stepCount);
-
-    double prevSamplePos = tickToSamplePos((rectLeftScene + devStart / scaleXDev - leftMarginPx()) *
-                                           ticksPerScenePixel);
-
-    for (int di = devStart; di <= devEnd; di++) {
-        const double localX = di / scaleXDev;
-        const double nextSamplePos = tickToSamplePos(
-            (rectLeftScene + (di + 1) / scaleXDev - leftMarginPx()) * ticksPerScenePixel);
-        const double samplePos = prevSamplePos;
-        prevSamplePos = nextSamplePos;
-        if (localX < 0 || localX > rectWidth)
-            continue;
-
-        const double samplePosEnd = nextSamplePos;
-
-        qint64 jStart = static_cast<qint64>(std::floor(samplePos));
-        qint64 jEnd = static_cast<qint64>(std::ceil(samplePosEnd));
-        jStart = std::max(jStart, sampleStart);
-        jEnd = std::min(jEnd, sampleStart + framesRead);
-
-        float min = 0.0f;
-        float max = 0.0f;
-
-        for (qint64 j = jStart; j < jEnd; j++) {
-            const int bufOffset = static_cast<int>((j - sampleStart) * channels);
-            float mono = 0.0f;
-            for (int ch = 0; ch < channels; ch++)
-                mono += m_ioBuffer[bufOffset + ch];
-            mono /= channels;
-            if (mono < min)
-                min = mono;
-            if (mono > max)
-                max = mono;
-        }
-
-        const double x = rectLeft + localX;
-        const double yMin = -min * halfRectHeight + halfRectHeight + rectTop;
-        const double yMax = -max * halfRectHeight + halfRectHeight + rectTop;
-        points.append({x, yMin, yMax});
-    }
-
-    // Sub-chunk mode uses LineMode for performance (FilledMode is too slow at this zoom level)
-    WaveformRenderUtils::renderWaveform(painter, color, WaveformRenderUtils::LineMode, points);
-}
-
-// Waveform curve mode: reads raw samples, applies Lanczos sinc interpolation,
-// draws a smooth continuous curve via QPainterPath.
-// Each physical pixel gets kCurveOversample interpolation points for smoothness.
-// When sample points are far enough apart (> 6 logical pixels), draws filled circles
-// at each actual sample position to show the discrete sampling grid.
-void AudioClipView::drawWaveformCurve(QPainter *painter, const QRectF &previewRect,
-                                      const QColor &color) {
-    if (!ensureIO())
-        return;
-
-    const auto rectLeft = previewRect.left();
-    const auto rectTop = previewRect.top();
-    const auto rectWidth = previewRect.width();
-    const auto rectHeight = previewRect.height();
-    const auto halfRectHeight = rectHeight / 2;
-
     painter->setRenderHint(QPainter::Antialiasing, true);
-    QPen pen;
-    pen.setColor(color);
-    pen.setWidthF(0);
+    QPen pen(color);
+    pen.setWidthF(0.0);
     painter->setPen(pen);
-
-    const auto rectLeftScene = mapToScene(previewRect.topLeft()).x();
-    const auto rectRightScene = mapToScene(previewRect.bottomRight()).x();
-    const auto visLeft = visibleRect().left();
-    const auto visRight = visibleRect().right();
-    const auto drawLeftScene = std::max(visLeft, rectLeftScene);
-    const auto drawRightScene = std::min(visRight, rectRightScene);
-
-    if (drawLeftScene >= drawRightScene)
-        return;
-
-    const double ticksPerScenePixel =
-        AppGlobal::ticksPerQuarterNote / (scaleX() * pixelsPerQuarterNote);
-    const int channels = m_audioInfo.channels;
-    const qint64 totalFrames = m_audioInfo.frames;
-
-    const auto &dt = painter->deviceTransform();
-    const double scaleXDev = dt.m11();
-
-    const double drawLeftLocal = drawLeftScene - rectLeftScene;
-    const double drawRightLocal = drawRightScene - rectLeftScene;
-    const int devStart = static_cast<int>(std::floor(drawLeftLocal * scaleXDev));
-    const int devEnd = static_cast<int>(std::ceil(drawRightLocal * scaleXDev));
-
-    const double firstSamplePos = tickToSamplePos(
-        (rectLeftScene + devStart / scaleXDev - leftMarginPx()) * ticksPerScenePixel);
-    const double lastSamplePos =
-        tickToSamplePos((rectLeftScene + devEnd / scaleXDev - leftMarginPx()) * ticksPerScenePixel);
-    qint64 sampleStart = static_cast<qint64>(std::floor(firstSamplePos)) - kSincHalfKernel;
-    qint64 sampleEnd = static_cast<qint64>(std::ceil(lastSamplePos)) + kSincHalfKernel;
-    sampleStart = std::max(sampleStart, qint64(0));
-    sampleEnd = std::min(sampleEnd, totalFrames);
-
-    if (sampleEnd <= sampleStart)
-        return;
-
-    const qint64 framesToRead = sampleEnd - sampleStart;
-    m_ioBuffer.resize(static_cast<int>(framesToRead * channels));
-
-    m_io->seek(sampleStart);
-    const qint64 framesRead = m_io->read(m_ioBuffer.data(), framesToRead);
-    if (framesRead <= 0)
-        return;
-
-    QVector<float> monoSamples(static_cast<int>(framesRead));
-    for (int i = 0; i < framesRead; i++) {
-        float mono = 0.0f;
-        const int bufOffset = i * channels;
-        for (int ch = 0; ch < channels; ch++)
-            mono += m_ioBuffer[bufOffset + ch];
-        mono /= channels;
-        monoSamples[i] = mono;
-    }
-
-    const int totalPoints = (devEnd - devStart) * kCurveOversample + 1;
-
     QPainterPath path;
-    bool started = false;
-
-    for (int i = 0; i < totalPoints; i++) {
-        const double devX = devStart + static_cast<double>(i) / kCurveOversample;
-        const double localX = devX / scaleXDev;
-        if (localX < 0 || localX > rectWidth)
-            continue;
-
-        const double sceneX = rectLeftScene + localX;
-        const double samplePos = tickToSamplePos((sceneX - leftMarginPx()) * ticksPerScenePixel);
-
-        const double value =
-            sincInterpolate(monoSamples, sampleStart, totalFrames, samplePos, kSincHalfKernel);
-
-        const double x = rectLeft + localX;
-        const double y = -value * halfRectHeight + halfRectHeight + rectTop;
-
-        if (!started) {
-            path.moveTo(x, y);
-            started = true;
-        } else {
-            path.lineTo(x, y);
-        }
-    }
-
+    path.moveTo(mapFromScene(waveform.curve.constFirst()));
+    for (auto index = 1; index < waveform.curve.size(); ++index)
+        path.lineTo(mapFromScene(waveform.curve[index]));
     painter->drawPath(path);
 
-    const double samplesPerLogicalPixel =
-        devEnd > devStart ? (lastSamplePos - firstSamplePos) / ((devEnd - devStart) / scaleXDev)
-                          : 0.0;
-    if (samplesPerLogicalPixel > 0 && samplesPerLogicalPixel < 1.0 / 6.0) {
-        const double dotRadius = std::min(3.0, 1.0 / samplesPerLogicalPixel * 0.3);
-        painter->setBrush(color);
-        painter->setPen(Qt::NoPen);
-
-        const qint64 firstSample = static_cast<qint64>(std::floor(firstSamplePos));
-        const qint64 lastSample = static_cast<qint64>(std::ceil(lastSamplePos));
-
-        for (qint64 s = std::max(firstSample, qint64(0)); s < std::min(lastSample, totalFrames);
-             s++) {
-            const int bufIdx = static_cast<int>(s - sampleStart);
-            if (bufIdx < 0 || bufIdx >= monoSamples.size())
-                continue;
-
-            const double sceneX =
-                samplePosToTick(static_cast<double>(s)) / ticksPerScenePixel + leftMarginPx();
-            const double logicalX = sceneX - rectLeftScene;
-            if (logicalX < 0 || logicalX > rectWidth)
-                continue;
-
-            const double x = rectLeft + logicalX;
-            const double y = -monoSamples[bufIdx] * halfRectHeight + halfRectHeight + rectTop;
-            painter->drawEllipse(QPointF(x, y), dotRadius, dotRadius);
-        }
+    if (waveform.sampleDots.isEmpty())
+        return;
+    painter->setBrush(color);
+    painter->setPen(Qt::NoPen);
+    for (const auto &point : waveform.sampleDots) {
+        painter->drawEllipse(mapFromScene(point), waveform.sampleDotRadius,
+                             waveform.sampleDotRadius);
     }
 }
 

--- a/src/app/UI/Views/TrackEditor/GraphicsItem/AudioClipView.cpp
+++ b/src/app/UI/Views/TrackEditor/GraphicsItem/AudioClipView.cpp
@@ -28,11 +28,13 @@ void AudioClipView::setPath(const QString &path) {
 
 void AudioClipView::setTimeline(const Timeline &timeline) {
     m_timeline = timeline;
+    m_waveformSampler.invalidate();
     update();
 }
 
 void AudioClipView::setAudioInfo(const AudioInfoModel &info) {
     m_audioInfo = info;
+    m_waveformSampler.invalidate();
     update();
 }
 

--- a/src/app/UI/Views/TrackEditor/GraphicsItem/AudioClipView.h
+++ b/src/app/UI/Views/TrackEditor/GraphicsItem/AudioClipView.h
@@ -2,16 +2,12 @@
 #define AUDIOCLIPGRAPHICSITEM_H
 
 #include "AbstractClipView.h"
+#include "Global/AppGlobal.h"
+#include "UI/Utils/WaveformRenderUtils.h"
+#include "UI/Views/TrackEditor/AudioWaveformSampler.h"
+
 #include <lite/MusicBase/Timeline.h>
 #include <lite/ProjectModel/AppModel/AudioInfoModel.h>
-#include "Global/AppGlobal.h"
-
-#include <QVector>
-#include "UI/Utils/WaveformRenderUtils.h"
-
-namespace talcs {
-class AbstractAudioFormatIO;
-}
 
 // Graphics item that displays an audio clip's waveform in the track editor.
 //
@@ -44,38 +40,18 @@ public:
     [[nodiscard]] int contentLength() const override;
 
 private:
-    enum RenderResolution { High, Low };
-
     void drawPreviewArea(QPainter *painter, const QRectF &previewRect, QColor color) override;
     [[nodiscard]] QString clipTypeName() const override;
     [[nodiscard]] QString iconPath() const override;
-
-    bool ensureIO();
-    void resetIO();
-
-    static double sincInterpolate(const QVector<float> &samples, qint64 offset,
-                                  qint64 totalFrames, double position, int halfKernel = 16);
-
-    double tickToSamplePos(double absTick) const;
-    double samplePosToTick(double samplePos) const;
-
-    void drawPeakMode(QPainter *painter, const QRectF &previewRect, const QColor &color);
-    void drawSubChunkPeakMode(QPainter *painter, const QRectF &previewRect, const QColor &color);
-    void drawWaveformCurve(QPainter *painter, const QRectF &previewRect, const QColor &color);
 
     AppGlobal::AudioLoadStatus m_status = AppGlobal::Init;
     AudioInfoModel m_audioInfo;
     QString m_errorMessage;
     Timeline m_timeline;
-    RenderResolution m_resolution = High;
     QString m_path;
 
     WaveformRenderUtils::Mode m_renderMode = WaveformRenderUtils::FilledMode;
-
-    talcs::AbstractAudioFormatIO *m_io = nullptr;
-    QVector<float> m_ioBuffer;
+    AudioWaveformSampler m_waveformSampler;
 };
-
-
 
 #endif // AUDIOCLIPGRAPHICSITEM_H

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -176,6 +176,8 @@ TracksRhiWidget::TracksRhiWidget(QWidget *parent)
         scheduleSnapshot();
     });
     connect(appModel, &AppModel::timelineChanged, this, [this] {
+        for (const auto &sampler : m_audioWaveformSamplers)
+            sampler->invalidate();
         updateAutoPageTurnAvailability();
         scheduleSnapshot();
     });
@@ -708,7 +710,11 @@ void TracksRhiWidget::rebuildModelConnections() {
         });
         for (const auto *clip : track->clips()) {
             disconnect(clip, nullptr, this, nullptr);
-            connect(clip, &Clip::propertyChanged, this, &TracksRhiWidget::scheduleSnapshot);
+            connect(clip, &Clip::propertyChanged, this, [this, clip] {
+                if (const auto sampler = m_audioWaveformSamplers.value(clip->id()))
+                    sampler->invalidate();
+                scheduleSnapshot();
+            });
             if (const auto *singing = qobject_cast<const SingingClip *>(clip)) {
                 connect(singing, &SingingClip::defaultLanguageChanged, this,
                         &TracksRhiWidget::scheduleSnapshot);
@@ -751,19 +757,18 @@ void TracksRhiWidget::appendGrid(EditorRhiFrameData &frame, const double dpr) co
 
 void TracksRhiWidget::appendClips(EditorRhiFrameData &frame, const double dpr) {
     m_clipSnapshots.clear();
-    QSet<int> audioClipIds;
+    QSet<int> sampledAudioClipIds;
     const auto visiblePhysical = QRectF(m_viewport.visibleSceneRect().topLeft() * dpr,
                                         m_viewport.visibleSceneRect().size() * dpr)
                                      .adjusted(-width() * dpr, 0, width() * dpr, 0);
     const auto &tracks = appModel->tracks();
     for (int trackIndex = 0; trackIndex < tracks.size(); ++trackIndex) {
         for (const auto *clip : tracks.at(trackIndex)->clips()) {
-            if (clip->clipType() == IClip::Audio)
-                audioClipIds.insert(clip->id());
             auto snapshot = buildClipSnapshot(clip, trackIndex, dpr);
             if (!visiblePhysical.intersects(snapshot.physicalRect))
                 continue;
             if (const auto audio = qobject_cast<const AudioClip *>(clip)) {
+                sampledAudioClipIds.insert(snapshot.id);
                 auto &sampler = m_audioWaveformSamplers[snapshot.id];
                 if (!sampler)
                     sampler = std::make_shared<AudioWaveformSampler>();
@@ -781,7 +786,7 @@ void TracksRhiWidget::appendClips(EditorRhiFrameData &frame, const double dpr) {
     }
     for (auto iterator = m_audioWaveformSamplers.begin();
          iterator != m_audioWaveformSamplers.end();) {
-        if (audioClipIds.contains(iterator.key()))
+        if (sampledAudioClipIds.contains(iterator.key()))
             ++iterator;
         else
             iterator = m_audioWaveformSamplers.erase(iterator);
@@ -927,13 +932,10 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
         const auto waveformColor = clip.selected ? selectedFill : fill;
         const auto physicalCameraOffset =
             QPointF(m_viewport.horizontalOffset(), m_viewport.verticalOffset()) * dpr;
-        const auto cameraCorrection =
-            physicalCameraOffset - QPointF(std::round(m_viewport.horizontalOffset()),
-                                           std::round(m_viewport.verticalOffset())) *
-                                       dpr;
-        const auto physicalWaveformPoint = [dpr, cameraCorrection](const QPointF &point) {
-            return point * dpr + cameraCorrection + QPointF(0.0, -0.5);
+        const auto physicalWaveformPoint = [dpr](const QPointF &point) {
+            return point * dpr + QPointF(0.0, -0.5);
         };
+        QVector<EditorRhiSolidVertex> waveformVertices;
         if (clip.waveform.geometry == AudioWaveformSampler::Geometry::FilledPeaks) {
             QVector<QPointF> top;
             QVector<QPointF> bottom;
@@ -943,7 +945,7 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
                 top.append(physicalWaveformPoint({point.x, point.yMax}));
                 bottom.append(physicalWaveformPoint({point.x, point.yMin}));
             }
-            EditorRhiGeometry::appendAntialiasedWaveform(frame.solidVertices, top, bottom, preview,
+            EditorRhiGeometry::appendAntialiasedWaveform(waveformVertices, top, bottom, preview,
                                                          waveformColor, 0.75);
 
             auto flatRunStart = -1;
@@ -959,7 +961,7 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
                     const auto runEnd = physicalWaveformPoint(
                         {clip.waveform.peaks[index - 1].x, clip.waveform.peaks[index - 1].yMax});
                     EditorRhiGeometry::appendPixelAlignedHorizontalLine(
-                        frame.solidVertices, runStart.y(), runStart.x(), runEnd.x(), waveformColor);
+                        waveformVertices, runStart.y(), runStart.x(), runEnd.x(), waveformColor);
                     flatRunStart = -1;
                 }
             }
@@ -969,7 +971,7 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
                 const auto runEnd = physicalWaveformPoint(
                     {clip.waveform.peaks.constLast().x, clip.waveform.peaks.constLast().yMax});
                 EditorRhiGeometry::appendPixelAlignedHorizontalLine(
-                    frame.solidVertices, runStart.y(), runStart.x(), runEnd.x(), waveformColor);
+                    waveformVertices, runStart.y(), runStart.x(), runEnd.x(), waveformColor);
             }
         } else if (clip.waveform.geometry == AudioWaveformSampler::Geometry::VerticalPeaks) {
             auto cosmeticLineOffset = 0.0;
@@ -990,7 +992,7 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
                 const auto lineX = std::floor(top.x() - physicalCameraOffset.x()) +
                                    physicalCameraOffset.x() + cosmeticLineOffset;
                 EditorRhiGeometry::appendRect(
-                    frame.solidVertices,
+                    waveformVertices,
                     QRectF(lineX, lineTop, 1.0, std::max(1.0, lineBottom - lineTop)),
                     waveformColor);
             }
@@ -999,16 +1001,17 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
             curve.reserve(clip.waveform.curve.size());
             for (const auto &point : clip.waveform.curve)
                 curve.append(physicalWaveformPoint(point));
-            EditorRhiGeometry::appendAntialiasedHairline(frame.solidVertices, curve, waveformColor);
+            EditorRhiGeometry::appendAntialiasedHairline(waveformVertices, curve, waveformColor);
             const auto radius = clip.waveform.sampleDotRadius * dpr;
             for (const auto &point : clip.waveform.sampleDots) {
                 const auto center = physicalWaveformPoint(point);
                 EditorRhiGeometry::appendRoundedRect(
-                    frame.solidVertices,
+                    waveformVertices,
                     QRectF(center.x() - radius, center.y() - radius, radius * 2.0, radius * 2.0),
                     radius, waveformColor);
             }
         }
+        EditorRhiGeometry::appendClippedTriangles(frame.solidVertices, waveformVertices, preview);
     }
 }
 
@@ -1074,9 +1077,6 @@ AudioWaveformSampler::Result TracksRhiWidget::sampleAudioWaveform(AudioWaveformS
                clip.physicalRect.width(), clip.physicalRect.height() - 20.0 * dpr);
     const auto previewScene = QRectF(previewPhysical.left() / dpr, previewPhysical.top() / dpr,
                                      previewPhysical.width() / dpr, previewPhysical.height() / dpr);
-    auto waveformVisibleRect = m_viewport.visibleSceneRect();
-    waveformVisibleRect.moveTo(std::round(waveformVisibleRect.left()),
-                               std::round(waveformVisibleRect.top()));
     const auto &timeline = appModel->timeline();
     return sampler.sample({
         .audioInfo = &audioInfo,
@@ -1084,7 +1084,7 @@ AudioWaveformSampler::Result TracksRhiWidget::sampleAudioWaveform(AudioWaveformS
         .materialStartTick = clip.contentStartTick,
         .visibleStartTick = clip.visibleStartTick,
         .previewSceneRect = previewScene,
-        .visibleSceneRect = waveformVisibleRect,
+        .visibleSceneRect = m_viewport.visibleSceneRect(),
         .horizontalScale = scaleX(),
         .pixelsPerQuarterNote = pixelsPerQuarterNote,
         .leftMarginPx = m_leftMarginPx,

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -33,6 +33,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QResizeEvent>
+#include <QSet>
 #include <QShowEvent>
 #include <QTimer>
 #include <QWheelEvent>
@@ -55,11 +56,10 @@ namespace {
     QString commonClipTitle(const Clip::ClipCommonProperties &properties, const int id,
                             const double scaleX, const double scaleY) {
         const auto showDebug = appOptions->developer()->showClipDebugInfo;
-        const auto control =
-            (showDebug ? QStringLiteral("id: %1 ").arg(id) : QString()) +
-            QStringLiteral("%1 %2dB %3 ")
-                .arg(properties.name, QLocale().toString(properties.gain),
-                     properties.mute ? QStringLiteral("M") : QString());
+        const auto control = (showDebug ? QStringLiteral("id: %1 ").arg(id) : QString()) +
+                             QStringLiteral("%1 %2dB %3 ")
+                                 .arg(properties.name, QLocale().toString(properties.gain),
+                                      properties.mute ? QStringLiteral("M") : QString());
         if (!showDebug)
             return control;
         return control + QStringLiteral("s: %1 l: %2 cs: %3 cl: %4 sx: %5 sy: %6")
@@ -120,8 +120,7 @@ namespace {
 
         void drawSubdivision(QPainter *painter, const int tick, const int level,
                              const int levelCount) override {
-            const auto ratio =
-                levelCount > 1 ? static_cast<double>(level) / (levelCount - 1) : 0.0;
+            const auto ratio = levelCount > 1 ? static_cast<double>(level) / (levelCount - 1) : 0.0;
             m_callback(tick, withPainterOpacity(blendColor(m_beat, m_common, ratio), painter));
         }
 
@@ -318,6 +317,7 @@ void TracksRhiWidget::setSceneLength(const int tick) {
 }
 
 void TracksRhiWidget::setLeftMarginPx(const double px) {
+    m_leftMarginPx = px;
     m_viewport.setLeftMarginPx(px);
 }
 
@@ -751,15 +751,26 @@ void TracksRhiWidget::appendGrid(EditorRhiFrameData &frame, const double dpr) co
 
 void TracksRhiWidget::appendClips(EditorRhiFrameData &frame, const double dpr) {
     m_clipSnapshots.clear();
+    QSet<int> audioClipIds;
     const auto visiblePhysical = QRectF(m_viewport.visibleSceneRect().topLeft() * dpr,
                                         m_viewport.visibleSceneRect().size() * dpr)
                                      .adjusted(-width() * dpr, 0, width() * dpr, 0);
     const auto &tracks = appModel->tracks();
     for (int trackIndex = 0; trackIndex < tracks.size(); ++trackIndex) {
         for (const auto *clip : tracks.at(trackIndex)->clips()) {
+            if (clip->clipType() == IClip::Audio)
+                audioClipIds.insert(clip->id());
             auto snapshot = buildClipSnapshot(clip, trackIndex, dpr);
             if (!visiblePhysical.intersects(snapshot.physicalRect))
                 continue;
+            if (const auto audio = qobject_cast<const AudioClip *>(clip)) {
+                auto &sampler = m_audioWaveformSamplers[snapshot.id];
+                if (!sampler)
+                    sampler = std::make_shared<AudioWaveformSampler>();
+                sampler->setPath(audio->path());
+                snapshot.waveform =
+                    sampleAudioWaveform(*sampler, audio->audioInfo(), snapshot, dpr);
+            }
             m_clipSnapshots.append(std::move(snapshot));
             appendClip(frame, m_clipSnapshots.constLast(), dpr);
         }
@@ -767,6 +778,13 @@ void TracksRhiWidget::appendClips(EditorRhiFrameData &frame, const double dpr) {
     for (const auto &preview : m_pastePreviewSnapshots) {
         if (visiblePhysical.intersects(preview.physicalRect))
             appendClip(frame, preview, dpr);
+    }
+    for (auto iterator = m_audioWaveformSamplers.begin();
+         iterator != m_audioWaveformSamplers.end();) {
+        if (audioClipIds.contains(iterator.key()))
+            ++iterator;
+        else
+            iterator = m_audioWaveformSamplers.erase(iterator);
     }
 }
 
@@ -789,8 +807,7 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
                          clip.physicalRect.width(), clip.physicalRect.height() - titleHeight);
     const auto hasPreview = preview.height() >= 32.0 * dpr;
     const auto bodyColor = hasPreview ? transparent : (clip.selected ? selectedFill : fill);
-    EditorRhiGeometry::appendRoundedRect(frame.solidVertices, clip.physicalRect, radius,
-                                         bodyColor);
+    EditorRhiGeometry::appendRoundedRect(frame.solidVertices, clip.physicalRect, radius, bodyColor);
     if (hasPreview) {
         const auto titleBottom = clip.physicalRect.top() + titleHeight - 1.2 * dpr - 0.75;
         const QRectF titleRect(clip.physicalRect.left(), clip.physicalRect.top(),
@@ -816,21 +833,20 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
     const auto rawLeft = clip.physicalRect.left() - 0.6 * dpr;
     const auto rawRight = clip.physicalRect.right() + 0.6 * dpr;
     const auto visibleLeft = m_viewport.horizontalOffset() * dpr;
-    const auto titleLeft = visibleLeft < rawLeft ? clip.physicalRect.left() : visibleLeft + 0.6 * dpr;
+    const auto titleLeft =
+        visibleLeft < rawLeft ? clip.physicalRect.left() : visibleLeft + 0.6 * dpr;
     const auto titleWidth = rawRight - std::max(rawLeft, visibleLeft) - 2.4 * dpr;
     constexpr double iconWidth = 4.0;
     if (metrics.horizontalAdvance(clip.title) + iconWidth * dpr <= titleWidth &&
         metrics.height() <= titleHeight) {
-        const auto textTop = hasPreview
-                                 ? clip.physicalRect.top()
-                                 : clip.physicalRect.top() +
-                                       (clip.physicalRect.height() - metrics.height()) * 0.5;
+        const auto textTop = hasPreview ? clip.physicalRect.top()
+                                        : clip.physicalRect.top() +
+                                              (clip.physicalRect.height() - metrics.height()) * 0.5;
         const QRectF textClip(titleLeft + iconWidth * dpr, clip.physicalRect.top(),
                               titleWidth - iconWidth * dpr,
                               std::min(titleHeight, clip.physicalRect.height()));
-        m_glyphAtlas.appendText(clip.title, font,
-                                QPointF(titleLeft + iconWidth * dpr, textTop), foreground,
-                                textClip);
+        m_glyphAtlas.appendText(clip.title, font, QPointF(titleLeft + iconWidth * dpr, textTop),
+                                foreground, textClip);
     }
 
     if (!hasPreview || preview.width() < 16.0 * dpr || preview.height() < 32.0 * dpr)
@@ -852,10 +868,8 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
                 std::min(clip.visibleEndTick, clip.contentStartTick + note.start + note.length);
             if (end <= start)
                 continue;
-            const auto left =
-                std::max(preview.left(), m_viewport.tickToSceneX(start) * dpr);
-            const auto right =
-                std::min(preview.right(), m_viewport.tickToSceneX(end) * dpr);
+            const auto left = std::max(preview.left(), m_viewport.tickToSceneX(start) * dpr);
+            const auto right = std::min(preview.right(), m_viewport.tickToSceneX(end) * dpr);
             const auto top = contentTop + (high - note.key) * noteHeight;
             EditorRhiGeometry::appendRect(frame.solidVertices,
                                           QRectF(left, top, right - left, noteHeight), noteColor);
@@ -863,72 +877,137 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
 
         const QRectF pianoRollRect = appStatus->pianoRollVisibleRect;
         if (clip.active && !pianoRollRect.isNull() && !pianoRollRect.isEmpty()) {
-            const auto overlayStart = std::max(
-                pianoRollRect.left() + clip.contentStartTick,
-                static_cast<double>(clip.visibleStartTick));
-            const auto overlayEnd = std::min(
-                pianoRollRect.right() + clip.contentStartTick,
-                static_cast<double>(clip.visibleEndTick));
+            const auto overlayStart = std::max(pianoRollRect.left() + clip.contentStartTick,
+                                               static_cast<double>(clip.visibleStartTick));
+            const auto overlayEnd = std::min(pianoRollRect.right() + clip.contentStartTick,
+                                             static_cast<double>(clip.visibleEndTick));
             if (overlayEnd > overlayStart) {
-                const auto overlayTop =
-                    contentTop + (high - pianoRollRect.bottom()) * noteHeight;
-                const auto overlayBottom =
-                    contentTop + (high - pianoRollRect.top()) * noteHeight;
-                const QRectF overlay(m_viewport.tickToSceneX(overlayStart) * dpr, overlayTop,
-                                     (m_viewport.tickToSceneX(overlayEnd) -
-                                      m_viewport.tickToSceneX(overlayStart)) *
-                                         dpr,
-                                     overlayBottom - overlayTop);
+                const auto overlayTop = contentTop + (high - pianoRollRect.bottom()) * noteHeight;
+                const auto overlayBottom = contentTop + (high - pianoRollRect.top()) * noteHeight;
+                const QRectF overlay(
+                    m_viewport.tickToSceneX(overlayStart) * dpr, overlayTop,
+                    (m_viewport.tickToSceneX(overlayEnd) - m_viewport.tickToSceneX(overlayStart)) *
+                        dpr,
+                    overlayBottom - overlayTop);
                 const auto overlayColor = palette.clipBorder(clip.colorIndex);
                 if (preview.contains(overlay)) {
-                    EditorRhiGeometry::appendRoundedRectStroke(
-                        frame.solidVertices, overlay, radius, 1.2 * dpr, overlayColor);
+                    EditorRhiGeometry::appendRoundedRectStroke(frame.solidVertices, overlay, radius,
+                                                               1.2 * dpr, overlayColor);
                 } else if (preview.intersects(overlay)) {
                     const auto clipped = preview.intersected(overlay);
                     const auto lineWidth = 1.2 * dpr;
                     if (overlay.left() >= preview.left() && overlay.left() <= preview.right())
-                        EditorRhiGeometry::appendRect(
-                            frame.solidVertices,
-                            QRectF(overlay.left() - lineWidth * 0.5, clipped.top(), lineWidth,
-                                   clipped.height()),
-                            overlayColor);
+                        EditorRhiGeometry::appendRect(frame.solidVertices,
+                                                      QRectF(overlay.left() - lineWidth * 0.5,
+                                                             clipped.top(), lineWidth,
+                                                             clipped.height()),
+                                                      overlayColor);
                     if (overlay.right() >= preview.left() && overlay.right() <= preview.right())
-                        EditorRhiGeometry::appendRect(
-                            frame.solidVertices,
-                            QRectF(overlay.right() - lineWidth * 0.5, clipped.top(), lineWidth,
-                                   clipped.height()),
-                            overlayColor);
+                        EditorRhiGeometry::appendRect(frame.solidVertices,
+                                                      QRectF(overlay.right() - lineWidth * 0.5,
+                                                             clipped.top(), lineWidth,
+                                                             clipped.height()),
+                                                      overlayColor);
                     if (overlay.top() >= preview.top() && overlay.top() <= preview.bottom())
-                        EditorRhiGeometry::appendRect(
-                            frame.solidVertices,
-                            QRectF(clipped.left(), overlay.top() - lineWidth * 0.5,
-                                   clipped.width(), lineWidth),
-                            overlayColor);
+                        EditorRhiGeometry::appendRect(frame.solidVertices,
+                                                      QRectF(clipped.left(),
+                                                             overlay.top() - lineWidth * 0.5,
+                                                             clipped.width(), lineWidth),
+                                                      overlayColor);
                     if (overlay.bottom() >= preview.top() && overlay.bottom() <= preview.bottom())
-                        EditorRhiGeometry::appendRect(
-                            frame.solidVertices,
-                            QRectF(clipped.left(), overlay.bottom() - lineWidth * 0.5,
-                                   clipped.width(), lineWidth),
-                            overlayColor);
+                        EditorRhiGeometry::appendRect(frame.solidVertices,
+                                                      QRectF(clipped.left(),
+                                                             overlay.bottom() - lineWidth * 0.5,
+                                                             clipped.width(), lineWidth),
+                                                      overlayColor);
                 }
             }
         }
-    } else if (clip.type == IClip::Audio && !clip.peaks.isEmpty()) {
-        const auto count = clip.peaks.size();
-        const auto center = preview.center().y();
-        const auto halfHeight = preview.height() * 0.48;
-        const auto firstPixel = std::max(0, qRound(clip.physicalRect.left()));
-        const auto lastPixel = std::max(firstPixel + 1, qRound(clip.physicalRect.right()));
-        for (int x = firstPixel; x < lastPixel; ++x) {
-            const auto ratio =
-                (x - clip.physicalRect.left()) / std::max(1.0, clip.physicalRect.width());
-            const auto index =
-                std::clamp<qsizetype>(qRound(ratio * static_cast<double>(count - 1)), 0, count - 1);
-            const auto [minimum, maximum] = clip.peaks.at(index);
-            const auto top = center - maximum / 32768.0 * halfHeight;
-            const auto bottom = center - minimum / 32768.0 * halfHeight;
-            EditorRhiGeometry::appendPixelAlignedVerticalLine(frame.solidVertices, x, top, bottom,
-                                                              fill);
+    } else if (clip.type == IClip::Audio) {
+        const auto waveformColor = clip.selected ? selectedFill : fill;
+        const auto physicalCameraOffset =
+            QPointF(m_viewport.horizontalOffset(), m_viewport.verticalOffset()) * dpr;
+        const auto cameraCorrection =
+            physicalCameraOffset - QPointF(std::round(m_viewport.horizontalOffset()),
+                                           std::round(m_viewport.verticalOffset())) *
+                                       dpr;
+        const auto physicalWaveformPoint = [dpr, cameraCorrection](const QPointF &point) {
+            return point * dpr + cameraCorrection + QPointF(0.0, -0.5);
+        };
+        if (clip.waveform.geometry == AudioWaveformSampler::Geometry::FilledPeaks) {
+            QVector<QPointF> top;
+            QVector<QPointF> bottom;
+            top.reserve(clip.waveform.peaks.size());
+            bottom.reserve(clip.waveform.peaks.size());
+            for (const auto &point : clip.waveform.peaks) {
+                top.append(physicalWaveformPoint({point.x, point.yMax}));
+                bottom.append(physicalWaveformPoint({point.x, point.yMin}));
+            }
+            EditorRhiGeometry::appendAntialiasedWaveform(frame.solidVertices, top, bottom, preview,
+                                                         waveformColor, 0.75);
+
+            auto flatRunStart = -1;
+            for (auto index = 0; index < clip.waveform.peaks.size(); ++index) {
+                const auto &point = clip.waveform.peaks[index];
+                const auto flat = std::abs(point.yMax - point.yMin) < 0.5;
+                if (flat && flatRunStart < 0) {
+                    flatRunStart = index;
+                } else if (!flat && flatRunStart >= 0) {
+                    const auto runStart =
+                        physicalWaveformPoint({clip.waveform.peaks[flatRunStart].x,
+                                               clip.waveform.peaks[flatRunStart].yMax});
+                    const auto runEnd = physicalWaveformPoint(
+                        {clip.waveform.peaks[index - 1].x, clip.waveform.peaks[index - 1].yMax});
+                    EditorRhiGeometry::appendPixelAlignedHorizontalLine(
+                        frame.solidVertices, runStart.y(), runStart.x(), runEnd.x(), waveformColor);
+                    flatRunStart = -1;
+                }
+            }
+            if (flatRunStart >= 0) {
+                const auto runStart = physicalWaveformPoint(
+                    {clip.waveform.peaks[flatRunStart].x, clip.waveform.peaks[flatRunStart].yMax});
+                const auto runEnd = physicalWaveformPoint(
+                    {clip.waveform.peaks.constLast().x, clip.waveform.peaks.constLast().yMax});
+                EditorRhiGeometry::appendPixelAlignedHorizontalLine(
+                    frame.solidVertices, runStart.y(), runStart.x(), runEnd.x(), waveformColor);
+            }
+        } else if (clip.waveform.geometry == AudioWaveformSampler::Geometry::VerticalPeaks) {
+            auto cosmeticLineOffset = 0.0;
+            if (!clip.waveform.peaks.isEmpty()) {
+                const auto firstPhysicalX =
+                    physicalWaveformPoint({clip.waveform.peaks.constFirst().x, 0.0}).x();
+                const auto firstScreenX = firstPhysicalX - physicalCameraOffset.x();
+                const auto pixelPhase = firstScreenX - std::floor(firstScreenX);
+                // Preserve QPainter's aliased cosmetic-pen phase after the RHI camera transform.
+                cosmeticLineOffset = pixelPhase < 0.5 ? -0.5 : 0.0;
+            }
+            for (const auto &point : clip.waveform.peaks) {
+                const auto top = physicalWaveformPoint({point.x, std::min(point.yMin, point.yMax)});
+                const auto bottom =
+                    physicalWaveformPoint({point.x, std::max(point.yMin, point.yMax)});
+                const auto lineTop = top.y() - 0.5;
+                const auto lineBottom = bottom.y() + 0.5;
+                const auto lineX = std::floor(top.x() - physicalCameraOffset.x()) +
+                                   physicalCameraOffset.x() + cosmeticLineOffset;
+                EditorRhiGeometry::appendRect(
+                    frame.solidVertices,
+                    QRectF(lineX, lineTop, 1.0, std::max(1.0, lineBottom - lineTop)),
+                    waveformColor);
+            }
+        } else if (clip.waveform.geometry == AudioWaveformSampler::Geometry::Curve) {
+            QVector<QPointF> curve;
+            curve.reserve(clip.waveform.curve.size());
+            for (const auto &point : clip.waveform.curve)
+                curve.append(physicalWaveformPoint(point));
+            EditorRhiGeometry::appendAntialiasedHairline(frame.solidVertices, curve, waveformColor);
+            const auto radius = clip.waveform.sampleDotRadius * dpr;
+            for (const auto &point : clip.waveform.sampleDots) {
+                const auto center = physicalWaveformPoint(point);
+                EditorRhiGeometry::appendRoundedRect(
+                    frame.solidVertices,
+                    QRectF(center.x() - radius, center.y() - radius, radius * 2.0, radius * 2.0),
+                    radius, waveformColor);
+            }
         }
     }
 }
@@ -951,7 +1030,6 @@ void TracksRhiWidget::appendPlaybackIndicators(EditorRhiFrameData &frame, const 
 TracksRhiWidget::ClipSnapshot TracksRhiWidget::buildClipSnapshot(const Clip *clip,
                                                                  const int trackIndex,
                                                                  const double dpr) const {
-    const auto track = appModel->tracks().at(trackIndex);
     const auto props = previewOrModelProperties(clip);
     const auto displayTrack = m_dragPreview && m_dragPreview->clipId == clip->id()
                                   ? m_dragPreview->trackIndex
@@ -976,19 +1054,42 @@ TracksRhiWidget::ClipSnapshot TracksRhiWidget::buildClipSnapshot(const Clip *cli
         const auto singerName = singing->singerInfo().name();
         const auto speakerName = SpeakerMixDisplayUtils::speakerDisplayName(
             singing->singerInfo(), singing->speakerInfo(), singing->speakerMixData());
-        result.title += QStringLiteral("%1%2 %3 ").arg(
-            singerName.isEmpty() ? tr("(No singer)") : singerName,
-            speakerName.isEmpty() ? QString() : QStringLiteral(" / ") + speakerName,
-            singing->defaultLanguage());
+        result.title +=
+            QStringLiteral("%1%2 %3 ")
+                .arg(singerName.isEmpty() ? tr("(No singer)") : singerName,
+                     speakerName.isEmpty() ? QString() : QStringLiteral(" / ") + speakerName,
+                     singing->defaultLanguage());
         for (const auto *note : singing->notes())
             result.notes.append({note->localStart(), note->length(), note->keyIndex()});
-    } else if (const auto audio = qobject_cast<const AudioClip *>(clip)) {
-        result.peaks = audio->audioInfo().peakCacheMipmap.isEmpty()
-                           ? audio->audioInfo().peakCache.toVector()
-                           : audio->audioInfo().peakCacheMipmap.toVector();
     }
-    Q_UNUSED(track);
     return result;
+}
+
+AudioWaveformSampler::Result TracksRhiWidget::sampleAudioWaveform(AudioWaveformSampler &sampler,
+                                                                  const AudioInfoModel &audioInfo,
+                                                                  const ClipSnapshot &clip,
+                                                                  const double dpr) const {
+    const auto previewPhysical =
+        QRectF(clip.physicalRect.left(), clip.physicalRect.top() + 20.0 * dpr,
+               clip.physicalRect.width(), clip.physicalRect.height() - 20.0 * dpr);
+    const auto previewScene = QRectF(previewPhysical.left() / dpr, previewPhysical.top() / dpr,
+                                     previewPhysical.width() / dpr, previewPhysical.height() / dpr);
+    auto waveformVisibleRect = m_viewport.visibleSceneRect();
+    waveformVisibleRect.moveTo(std::round(waveformVisibleRect.left()),
+                               std::round(waveformVisibleRect.top()));
+    const auto &timeline = appModel->timeline();
+    return sampler.sample({
+        .audioInfo = &audioInfo,
+        .timeline = &timeline,
+        .materialStartTick = clip.contentStartTick,
+        .visibleStartTick = clip.visibleStartTick,
+        .previewSceneRect = previewScene,
+        .visibleSceneRect = waveformVisibleRect,
+        .horizontalScale = scaleX(),
+        .pixelsPerQuarterNote = pixelsPerQuarterNote,
+        .leftMarginPx = m_leftMarginPx,
+        .devicePixelRatio = dpr,
+    });
 }
 
 void TracksRhiWidget::showTrackPastePreview(const TrackPastePreviewData &data,
@@ -1032,16 +1133,17 @@ void TracksRhiWidget::showTrackPastePreview(const TrackPastePreviewData &data,
             const auto speakerName = SpeakerMixDisplayUtils::speakerDisplayName(
                 targetTrack->singerInfo(), targetTrack->speakerInfo(),
                 targetTrack->speakerMixData());
-            snapshot.title += QStringLiteral("%1%2 %3 ").arg(
-                singerName.isEmpty() ? tr("(No singer)") : singerName,
-                speakerName.isEmpty() ? QString() : QStringLiteral(" / ") + speakerName,
-                clip.defaultLanguage);
+            snapshot.title +=
+                QStringLiteral("%1%2 %3 ")
+                    .arg(singerName.isEmpty() ? tr("(No singer)") : singerName,
+                         speakerName.isEmpty() ? QString() : QStringLiteral(" / ") + speakerName,
+                         clip.defaultLanguage);
             for (const auto &note : clip.notes)
                 snapshot.notes.append({note.start, note.length, note.key});
         } else if (clip.type == IClip::Audio) {
-            snapshot.peaks = clip.audioInfo.peakCacheMipmap.isEmpty()
-                                 ? clip.audioInfo.peakCache.toVector()
-                                 : clip.audioInfo.peakCacheMipmap.toVector();
+            AudioWaveformSampler sampler;
+            sampler.setPath(clip.audioPath);
+            snapshot.waveform = sampleAudioWaveform(sampler, clip.audioInfo, snapshot, dpr);
         }
         m_pastePreviewSnapshots.append(std::move(snapshot));
     }

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
@@ -1,6 +1,7 @@
 #ifndef TRACKSRHIWIDGET_H
 #define TRACKSRHIWIDGET_H
 
+#include "AudioWaveformSampler.h"
 #include "Interface/EditorViewState.h"
 #include "TrackEditorContextMenuController.h"
 #include "TracksGraphicsScene.h"
@@ -15,6 +16,7 @@
 #include <QTimer>
 #include <QUrl>
 
+#include <memory>
 #include <optional>
 
 class QContextMenuEvent;
@@ -42,8 +44,8 @@ class TracksRhiWidget final : public EditorRhiWidget, public ITrackPastePreviewH
     Q_PROPERTY(QColor selectedTrackColor READ selectedTrackColor WRITE setSelectedTrackColor)
     Q_PROPERTY(QColor clipSelectedBorderColor READ clipSelectedBorderColor WRITE
                    setClipSelectedBorderColor)
-    Q_PROPERTY(QColor rubberBandBorderColor READ rubberBandBorderColor WRITE
-                   setRubberBandBorderColor)
+    Q_PROPERTY(
+        QColor rubberBandBorderColor READ rubberBandBorderColor WRITE setRubberBandBorderColor)
     Q_PROPERTY(QColor rubberBandFillColor READ rubberBandFillColor WRITE setRubberBandFillColor)
     Q_PROPERTY(QColor dropHighlightColor READ dropHighlightColor WRITE setDropHighlightColor)
     Q_PROPERTY(QColor dropIndicatorColor READ dropIndicatorColor WRITE setDropIndicatorColor)
@@ -138,7 +140,7 @@ private:
         bool active = false;
         bool pastePreview = false;
         QVector<NoteSnapshot> notes;
-        QVector<std::tuple<short, short>> peaks;
+        AudioWaveformSampler::Result waveform;
     };
 
     struct DragPreview {
@@ -156,6 +158,10 @@ private:
     void appendDropOverlay(EditorRhiFrameData &frame, double dpr) const;
     [[nodiscard]] ClipSnapshot buildClipSnapshot(const Clip *clip, int trackIndex,
                                                  double dpr) const;
+    [[nodiscard]] AudioWaveformSampler::Result sampleAudioWaveform(AudioWaveformSampler &sampler,
+                                                                   const AudioInfoModel &audioInfo,
+                                                                   const ClipSnapshot &clip,
+                                                                   double dpr) const;
     [[nodiscard]] const ClipSnapshot *hitTest(const QPointF &viewportPosition) const;
     [[nodiscard]] double wheelDelta(const QWheelEvent *event, bool preferHorizontal) const;
     [[nodiscard]] int trackIndexAt(const QPointF &viewportPosition) const;
@@ -208,6 +214,7 @@ private:
 
     EditorViewportController m_viewport;
     EditorGlyphAtlas m_glyphAtlas;
+    QHash<int, std::shared_ptr<AudioWaveformSampler>> m_audioWaveformSamplers;
     QVector<ClipSnapshot> m_clipSnapshots;
     QVector<ClipSnapshot> m_pastePreviewSnapshots;
     bool m_snapshotScheduled = false;
@@ -217,6 +224,7 @@ private:
     QTimer m_positionThrottle;
     bool m_autoTurnPage = true;
     bool m_autoPageTurnAvailable = false;
+    double m_leftMarginPx = 0.0;
     DragMode m_dragMode = DragMode::None;
     QPointF m_mouseDownScene;
     QPointF m_rubberBandStart;


### PR DESCRIPTION
## Summary

- extract the existing waveform sampling, peak-cache selection, raw audio reads, mono mixing, and Lanczos interpolation into a shared backend-neutral `AudioWaveformSampler`
- keep `AudioClipView` as a thin QPainter adapter while feeding the same sampled geometry to the RHI track editor
- render filled peaks, per-pixel peak lines, interpolated curves, and sample dots with native RHI geometry, including camera/DPR and cosmetic-pen phase corrections
- cache samplers per visible audio clip and reuse the shared path for paste previews

## Why

The experimental RHI track editor previously used a simplified peak-mipmap renderer, so its waveform changed shape and detail substantially across zoom levels. Reimplementing the legacy algorithm in the RHI widget would create two independent sampling pipelines. This change instead makes both backends consume one sampling implementation and leaves only the final rasterization backend-specific.

## Rendering validation

Compared background-subtracted waveform pixels using `测试专用.wav` at horizontal scales `0.1`, `0.25`, `1`, `8`, `64`, `512`, and `10000`.

- waveform correlation: `0.9661–0.9997`
- waveform alpha MAE: `0.00056–0.0372`
- the default backend remained pixel-exact against its pre-refactor output at the five regression scales (`MAE 0`)
- GUI smoke test confirmed the real `TracksRhiWidget` setting, waveform display, playback, and stop behavior

## Checks

- `run-cmake-preset.ps1 -Mode ConfigureAndBuild -Preset debug`
- `git diff --check`
- CTest: 19/20 passed
  - `TestAnimationSettings` still reports six animation-duration assertions involving `ProgressIndicator`, `TapTempoButton`, and `ToolTip`; none of those modules or dependencies are changed by this PR
