### PR TITLE
Fix RHI interaction regressions

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteInteractionController.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteInteractionController.cpp
@@ -3,6 +3,7 @@
 #include "PianoRollGraphicsView.h"
 #include "NoteView.h"
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
+#include "UI/Views/Common/EditorResizeUtils.h"
 #include "Model/AppStatus/AppStatus.h"
 #include "Controller/ClipController.h"
 #include "Modules/Inference/EditSessionManager.h"
@@ -41,8 +42,6 @@ void NoteInteractionController::resetMoveDeltaKeyRange() {
 void NoteInteractionController::prepareForEditingNotes(const QMouseEvent *event,
                                                        const QPointF scenePos, const int keyIndex,
                                                        NoteView *noteItem) {
-    const auto resizeTolerance = AppGlobal::resizeTolerance;
-
     // If note is editing lyric, don't allow moving or resizing
     if (noteItem->isEditingLyric()) {
         m_mouseMoveBehavior = None;
@@ -69,9 +68,11 @@ void NoteInteractionController::prepareForEditingNotes(const QMouseEvent *event,
 
     const auto rPos = noteItem->mapFromScene(scenePos);
     const auto rx = rPos.x();
-    if (rx >= 0 && rx <= resizeTolerance) {
+    const auto edge = EditorResizeUtils::horizontalEdgeAt(
+        rx, noteItem->rect().width(), AppGlobal::resizeTolerance);
+    if (edge == EditorResizeUtils::HorizontalEdge::Left) {
         m_mouseMoveBehavior = ResizeLeft;
-    } else if (rx >= noteItem->rect().width() - resizeTolerance && rx <= noteItem->rect().width()) {
+    } else if (edge == EditorResizeUtils::HorizontalEdge::Right) {
         m_mouseMoveBehavior = ResizeRight;
     } else {
         m_mouseMoveBehavior = Move;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -400,6 +400,22 @@ void PianoRollGraphicsView::mousePressEvent(QMouseEvent *event) {
             d->m_currentHandler->mousePressEvent(event);
     } else
         TimeGraphicsView::mousePressEvent(event);
+
+    if (event->button() == Qt::LeftButton) {
+        Qt::Orientations axes;
+        const auto behavior = d->m_interactionController->mouseMoveBehavior();
+        if (behavior != NoteInteractionController::None) {
+            axes = behavior == NoteInteractionController::Move
+                       ? (Qt::Horizontal | Qt::Vertical)
+                       : Qt::Orientations(Qt::Horizontal);
+        } else if (d->m_currentHandler) {
+            axes = d->m_currentHandler->edgeAutoScrollAxes();
+            if (!axes && d->m_editMode == EditPitchAnchor)
+                axes = Qt::Horizontal | Qt::Vertical;
+        }
+        if (axes)
+            armEdgeAutoScroll(axes, event->pos());
+    }
     event->ignore();
 }
 
@@ -632,6 +648,7 @@ void PianoRollGraphicsView::mouseDoubleClickEvent(QMouseEvent *event) {
                 dynamic_cast<DrawNoteHandler *>(d->m_handlers.value(DrawNote, nullptr))) {
             drawHandler->prepareForDrawingNote(tick, keyIndex, noteLength);
             d->m_currentHandler = drawHandler;
+            armEdgeAutoScroll(Qt::Horizontal, event->pos());
         }
     }
 }

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -11,6 +11,7 @@
 #include "PianoRollSelectionModel.h"
 #include "PianoRollGraphicsView_p.h"
 #include "UI/Views/ClipEditor/AnchorEditor/AnchorOverlayView.h"
+#include "UI/Views/Common/EditorResizeUtils.h"
 #include "PitchEditorView.h"
 #include "PronunciationView.h"
 #include "PianoRollEditHandler.h"
@@ -1519,14 +1520,10 @@ void PianoRollGraphicsViewPrivate::onHoverMove(const QHoverEvent *event) {
 
     const auto rPos = noteView->mapFromScene(scenePos);
     const auto rx = rPos.x();
-    if (rx >= 0 && rx <= AppGlobal::resizeTolerance) {
-        q->setCursor(Qt::SizeHorCursor);
-    } else if (rx >= noteView->rect().width() - AppGlobal::resizeTolerance &&
-               rx <= noteView->rect().width()) {
-        q->setCursor(Qt::SizeHorCursor);
-    } else {
-        q->setCursor(Qt::ArrowCursor);
-    }
+    const auto edge = EditorResizeUtils::horizontalEdgeAt(
+        rx, noteView->rect().width(), AppGlobal::resizeTolerance);
+    q->setCursor(edge == EditorResizeUtils::HorizontalEdge::None ? Qt::ArrowCursor
+                                                                : Qt::SizeHorCursor);
 }
 
 void PianoRollGraphicsViewPrivate::onClipPropertyChanged() {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -13,6 +13,7 @@
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
 #include "UI/Views/Common/AutoPageTurnUtils.h"
 #include "UI/Views/Common/EdgeAutoScroller.h"
+#include "UI/Views/Common/EditorResizeUtils.h"
 #include "UI/Views/Common/EditorRhiGeometry.h"
 #include "UI/Views/Common/EditorGlyphAtlas.h"
 #include "UI/Views/Common/EditorRhiScrollBarController.h"
@@ -465,14 +466,11 @@ public:
     }
 
     void prepareEdgeAutoScroll(const QPointF &pressPosition) {
-        disarmEdgeAutoScroll();
-        edgeAutoScrollPressPos = pressPosition;
+        edgeAutoScroller.prepareDrag(pressPosition);
     }
 
     void disarmEdgeAutoScroll() {
-        edgeAutoScrollArmed = false;
-        edgeAutoScrollDistanceReached = false;
-        edgeAutoScroller.stop();
+        edgeAutoScroller.stopDrag();
     }
 
     void updateEdgeAutoScrollState(const QPointF &pointerPosition) {
@@ -482,24 +480,10 @@ public:
             return;
         }
 
-        edgeAutoScrollAxesValue = axes;
-        edgeAutoScrollArmed = true;
-        if (!edgeAutoScrollDistanceReached) {
-            if ((pointerPosition - edgeAutoScrollPressPos).manhattanLength() <
-                QApplication::startDragDistance()) {
-                return;
-            }
-            edgeAutoScrollDistanceReached = true;
-        }
-
         const QRectF viewportRect(QPointF(), q->size());
-        const auto velocity = EdgeAutoScroller::velocity(
-            pointerPosition, edgeAutoScrollPressPos, viewportRect, edgeAutoScrollAxesValue,
-            edgeAutoScroller.config());
-        if (!velocity.isNull())
-            edgeAutoScroller.start();
-        else
-            edgeAutoScroller.stop();
+        edgeAutoScroller.setDragAxes(axes);
+        edgeAutoScroller.updateDragState(pointerPosition, viewportRect,
+                                         QApplication::startDragDistance());
     }
 
     void continueEdgeDragAt(const QPointF &viewportPosition,
@@ -526,7 +510,7 @@ public:
     }
 
     void onEdgeAutoScrollFrame(const double dtMs) {
-        if (!edgeAutoScrollArmed || QGuiApplication::mouseButtons() == Qt::NoButton ||
+        if (!edgeAutoScroller.isDragArmed() || QGuiApplication::mouseButtons() == Qt::NoButton ||
             !q->isVisible()) {
             disarmEdgeAutoScroll();
             return;
@@ -534,8 +518,7 @@ public:
 
         const QPointF pointerPosition(q->mapFromGlobal(QCursor::pos()));
         const QRectF viewportRect(QPointF(), q->size());
-        const auto step = edgeAutoScroller.computeStep(pointerPosition, edgeAutoScrollPressPos,
-                                                       viewportRect, edgeAutoScrollAxesValue, dtMs);
+        const auto step = edgeAutoScroller.computeDragStep(pointerPosition, viewportRect, dtMs);
         if (!step.isNull()) {
             cameraX += step.x();
             cameraY += step.y();
@@ -581,12 +564,12 @@ public:
             return Interaction::None;
         const auto rect = noteViewportRect(note);
         const auto relativeX = viewportPosition.x() - rect.left();
-        if (relativeX >= 0 && relativeX <= AppGlobal::resizeTolerance)
+        const auto edge = EditorResizeUtils::horizontalEdgeAt(
+            relativeX, rect.width(), AppGlobal::resizeTolerance);
+        if (edge == EditorResizeUtils::HorizontalEdge::Left)
             return Interaction::ResizeLeft;
-        if (relativeX >= rect.width() - AppGlobal::resizeTolerance &&
-            relativeX <= rect.width()) {
+        if (edge == EditorResizeUtils::HorizontalEdge::Right)
             return Interaction::ResizeRight;
-        }
         return Interaction::Move;
     }
 
@@ -2645,10 +2628,6 @@ public:
     EditorGlyphAtlas glyphAtlas;
     EditorRhiDrawList drawList;
     EdgeAutoScroller edgeAutoScroller;
-    Qt::Orientations edgeAutoScrollAxesValue;
-    QPointF edgeAutoScrollPressPos;
-    bool edgeAutoScrollArmed = false;
-    bool edgeAutoScrollDistanceReached = false;
     int noteFontPixelSize = 13;
     QColor whiteKeyColor{38, 40, 44};
     QColor blackKeyColor{31, 33, 37};
@@ -2698,6 +2677,7 @@ PianoRollRhiWidget::PianoRollRhiWidget(QWidget *parent)
 }
 
 PianoRollRhiWidget::~PianoRollRhiWidget() {
+    d->finishNoteErase(EditSessionEndReason::Discard);
     d->cancelPitchEdit(false);
     d->finishAnchorEditSession(EditSessionEndReason::Discard);
 }
@@ -2823,6 +2803,7 @@ void PianoRollRhiWidget::showEvent(QShowEvent *event) {
 
 void PianoRollRhiWidget::hideEvent(QHideEvent *event) {
     d->disarmEdgeAutoScroll();
+    d->finishNoteErase(EditSessionEndReason::Discard);
     EditorRhiWidget::hideEvent(event);
     d->updateAutoPageTurnAvailability();
 }

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -122,6 +122,7 @@ namespace {
 class PianoRollRhiWidget::Private {
 public:
     enum class InlineEditField { None, Lyric, Pronunciation };
+    enum class Interaction { None, Move, ResizeLeft, ResizeRight, Draw, RectSelect };
 
     struct AnchorDragInfo {
         AnchorNode *node = nullptr;
@@ -569,6 +570,35 @@ public:
                 return note;
         }
         return nullptr;
+    }
+
+    bool noteEditingEnabled() const {
+        return editMode == Select || editMode == IntervalSelect || editMode == DrawNote;
+    }
+
+    Interaction noteInteractionAt(const Note *note, const QPointF &viewportPosition) const {
+        if (!note)
+            return Interaction::None;
+        const auto rect = noteViewportRect(note);
+        const auto relativeX = viewportPosition.x() - rect.left();
+        if (relativeX >= 0 && relativeX <= AppGlobal::resizeTolerance)
+            return Interaction::ResizeLeft;
+        if (relativeX >= rect.width() - AppGlobal::resizeTolerance &&
+            relativeX <= rect.width()) {
+            return Interaction::ResizeRight;
+        }
+        return Interaction::Move;
+    }
+
+    void updateNoteCursor(const QPointF &viewportPosition) const {
+        if (!noteEditingEnabled()) {
+            q->setCursor(Qt::ArrowCursor);
+            return;
+        }
+        const auto interaction = noteInteractionAt(noteAt(viewportPosition), viewportPosition);
+        const auto resizing =
+            interaction == Interaction::ResizeLeft || interaction == Interaction::ResizeRight;
+        q->setCursor(resizing ? Qt::SizeHorCursor : Qt::ArrowCursor);
     }
 
     void eraseNoteAt(const QPointF &viewportPosition) {
@@ -1511,6 +1541,8 @@ public:
             clearSplitPreview();
             return;
         }
+        if (!noteEditingEnabled())
+            return;
         if (editMode == DrawNote && !note) {
             interaction = Interaction::Draw;
             drawStart = snapLocalTick(localTickAt(event->position()));
@@ -1550,15 +1582,9 @@ public:
         interactionKey = note->keyIndex();
         mouseDownTick = localTickAt(event->position());
         mouseDownKey = keyAt(event->position());
-        const auto noteLeft = note->localStart() * pixelsPerTick() - cameraX;
-        const auto noteRight = (note->localStart() + note->length()) * pixelsPerTick() - cameraX;
-        constexpr double resizeTolerance = 6.0;
-        if (std::abs(event->position().x() - noteLeft) <= resizeTolerance)
-            interaction = Interaction::ResizeLeft;
-        else if (std::abs(event->position().x() - noteRight) <= resizeTolerance)
-            interaction = Interaction::ResizeRight;
-        else
-            interaction = Interaction::Move;
+        interaction = noteInteractionAt(note, event->position());
+        if (interaction == Interaction::ResizeLeft || interaction == Interaction::ResizeRight)
+            q->setCursor(Qt::SizeHorCursor);
         scheduleSnapshot();
     }
 
@@ -1568,6 +1594,8 @@ public:
             hoveredKey = key;
             emit q->keyHovered(key);
         }
+        if (event->buttons() == Qt::NoButton)
+            updateNoteCursor(event->position());
         if (editMode == EditPitchAnchor) {
             anchorCursorInView = true;
             mouseMoveAnchor(event);
@@ -1648,6 +1676,7 @@ public:
         interactionNoteId = -1;
         interactionDeltaTick = 0;
         interactionDeltaKey = 0;
+        updateNoteCursor(event->position());
         scheduleSnapshot();
     }
 
@@ -2548,7 +2577,6 @@ public:
     bool fallbackRequested = false;
     int trackColorIndex = 0;
     PianoRollEditMode editMode = Select;
-    enum class Interaction { None, Move, ResizeLeft, ResizeRight, Draw, RectSelect };
     Interaction interaction = Interaction::None;
     int interactionNoteId = -1;
     int interactionStart = 0;
@@ -2736,6 +2764,7 @@ bool PianoRollRhiWidget::revealFocus(const HistoryFocus &focus, bool) {
 
 void PianoRollRhiWidget::setEditMode(const PianoRollEditMode mode) {
     if (d->editMode != mode) {
+        setCursor(Qt::ArrowCursor);
         d->disarmEdgeAutoScroll();
         d->finishNoteErase(EditSessionEndReason::Discard);
         d->finishInlineEditing();
@@ -2912,6 +2941,7 @@ void PianoRollRhiWidget::keyPressEvent(QKeyEvent *event) {
 }
 
 void PianoRollRhiWidget::leaveEvent(QEvent *event) {
+    unsetCursor();
     if (d->hoveredKey >= 0) {
         d->hoveredKey = -1;
         emit keyHoverCleared();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -12,6 +12,7 @@
 #include "UI/Utils/ITimelinePainter.h"
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
 #include "UI/Views/Common/AutoPageTurnUtils.h"
+#include "UI/Views/Common/EdgeAutoScroller.h"
 #include "UI/Views/Common/EditorRhiGeometry.h"
 #include "UI/Views/Common/EditorGlyphAtlas.h"
 #include "UI/Views/Common/EditorRhiScrollBarController.h"
@@ -29,8 +30,10 @@
 #include <lite/Support/MathUtils.h>
 #include <lite/MusicBase/TimelineSnapUtils.h>
 
-#include <QEvent>
+#include <QApplication>
 #include <QContextMenuEvent>
+#include <QCursor>
+#include <QEvent>
 #include <QFontMetricsF>
 #include <QHash>
 #include <QHideEvent>
@@ -139,6 +142,8 @@ public:
     };
 
     explicit Private(PianoRollRhiWidget *q) : q(q) {
+        QObject::connect(&edgeAutoScroller, &EdgeAutoScroller::frame, q,
+                         [this](const double dtMs) { onEdgeAutoScrollFrame(dtMs); });
     }
 
     ~Private() {
@@ -178,6 +183,8 @@ public:
     }
 
     void setDataContext(SingingClip *newClip) {
+        disarmEdgeAutoScroll();
+        finishNoteErase(EditSessionEndReason::Discard);
         finishInlineEditing();
         cancelPitchEdit();
         cancelAnchorEdit(false);
@@ -329,7 +336,7 @@ public:
     }
 
     void handleAutoPageTurn() {
-        if (!autoPageTurn || !autoPageTurnAvailable || !clip ||
+        if (!autoPageTurn || !autoPageTurnAvailable || !clip || edgeAutoScroller.isRunning() ||
             appStatus->currentEditObject != AppStatus::EditObjectType::None ||
             interaction != Interaction::None || pitchEditing || anchorDragging || anchorSelecting) {
             return;
@@ -436,6 +443,105 @@ public:
         viewportChanged(false);
     }
 
+    QPointF scenePositionAt(const QPointF &viewportPosition) const {
+        return viewportPosition + QPointF(cameraX, cameraY);
+    }
+
+    Qt::Orientations edgeAutoScrollAxes() const {
+        if (noteErasing || anchorDragging || anchorSelecting || interaction == Interaction::Move ||
+            (interaction == Interaction::RectSelect && editMode != IntervalSelect)) {
+            return Qt::Horizontal | Qt::Vertical;
+        }
+        if (interaction == Interaction::ResizeLeft || interaction == Interaction::ResizeRight ||
+            interaction == Interaction::Draw ||
+            (interaction == Interaction::RectSelect && editMode == IntervalSelect)) {
+            return Qt::Horizontal;
+        }
+        return {};
+    }
+
+    void prepareEdgeAutoScroll(const QPointF &pressPosition) {
+        disarmEdgeAutoScroll();
+        edgeAutoScrollPressPos = pressPosition;
+    }
+
+    void disarmEdgeAutoScroll() {
+        edgeAutoScrollArmed = false;
+        edgeAutoScrollDistanceReached = false;
+        edgeAutoScroller.stop();
+    }
+
+    void updateEdgeAutoScrollState(const QPointF &pointerPosition) {
+        const auto axes = edgeAutoScrollAxes();
+        if (!axes) {
+            disarmEdgeAutoScroll();
+            return;
+        }
+
+        edgeAutoScrollAxesValue = axes;
+        edgeAutoScrollArmed = true;
+        if (!edgeAutoScrollDistanceReached) {
+            if ((pointerPosition - edgeAutoScrollPressPos).manhattanLength() <
+                QApplication::startDragDistance()) {
+                return;
+            }
+            edgeAutoScrollDistanceReached = true;
+        }
+
+        const QRectF viewportRect(QPointF(), q->size());
+        const auto velocity = EdgeAutoScroller::velocity(
+            pointerPosition, edgeAutoScrollPressPos, viewportRect, edgeAutoScrollAxesValue,
+            edgeAutoScroller.config());
+        if (!velocity.isNull())
+            edgeAutoScroller.start();
+        else
+            edgeAutoScroller.stop();
+    }
+
+    void continueEdgeDragAt(const QPointF &viewportPosition,
+                            const Qt::KeyboardModifiers modifiers) {
+        if (editMode == EditPitchAnchor) {
+            if (anchorDragging)
+                updateAnchorDrag(viewportPosition);
+            else if (anchorSelecting)
+                updateAnchorSelection(viewportPosition);
+            return;
+        }
+        if (noteErasing) {
+            eraseNoteAt(viewportPosition);
+            return;
+        }
+        if (interaction == Interaction::Draw) {
+            updateDrawNote(viewportPosition);
+        } else if (interaction == Interaction::RectSelect) {
+            updateRubberBandSelection(viewportPosition);
+        } else if (interaction != Interaction::None) {
+            updateInteractionDelta(viewportPosition, modifiers);
+            scheduleSnapshot();
+        }
+    }
+
+    void onEdgeAutoScrollFrame(const double dtMs) {
+        if (!edgeAutoScrollArmed || QGuiApplication::mouseButtons() == Qt::NoButton ||
+            !q->isVisible()) {
+            disarmEdgeAutoScroll();
+            return;
+        }
+
+        const QPointF pointerPosition(q->mapFromGlobal(QCursor::pos()));
+        const QRectF viewportRect(QPointF(), q->size());
+        const auto step = edgeAutoScroller.computeStep(pointerPosition, edgeAutoScrollPressPos,
+                                                       viewportRect, edgeAutoScrollAxesValue, dtMs);
+        if (!step.isNull()) {
+            cameraX += step.x();
+            cameraY += step.y();
+            viewportChanged(false);
+        }
+        continueEdgeDragAt(EdgeAutoScroller::clampToRect(pointerPosition, viewportRect),
+                           QGuiApplication::queryKeyboardModifiers());
+        updateEdgeAutoScrollState(pointerPosition);
+    }
+
     int keyAt(const QPointF &viewportPosition) const {
         const auto row =
             static_cast<int>(std::floor((cameraY + viewportPosition.y()) / (noteHeight * scaleY)));
@@ -453,11 +559,46 @@ public:
         const auto key = keyAt(viewportPosition);
         for (auto iterator = clip->notes().rbegin(); iterator != clip->notes().rend(); ++iterator) {
             auto *note = *iterator;
+            if (erasedNoteIds.contains(note->id()))
+                continue;
             if (note->keyIndex() == key && tick >= note->localStart() &&
                 tick <= note->localStart() + note->length())
                 return note;
         }
         return nullptr;
+    }
+
+    void eraseNoteAt(const QPointF &viewportPosition) {
+        auto *note = noteAt(viewportPosition);
+        if (!note || erasedNoteIds.contains(note->id()))
+            return;
+        if (noteEraseSessionId == 0 && !editSessionManager->hasActiveTransaction()) {
+            noteEraseSessionId = editSessionManager->beginTransaction(
+                AppStatus::EditObjectType::Note, clip ? clip->id() : -1, {}, {}, {}, {}, true);
+        }
+        appStatus->currentEditObject = AppStatus::EditObjectType::Note;
+        erasedNoteIds.append(note->id());
+        appStatus->pianoRollNoteErasePreview = erasedNoteIds;
+        editSessionManager->addNoteIds({note->id()});
+        scheduleSnapshot();
+    }
+
+    void finishNoteErase(const EditSessionEndReason reason) {
+        if (!noteErasing && erasedNoteIds.isEmpty() && noteEraseSessionId == 0)
+            return;
+        if (reason == EditSessionEndReason::Commit && !erasedNoteIds.isEmpty())
+            clipController->onRemoveNotes(erasedNoteIds);
+        appStatus->pianoRollNoteErasePreview = {};
+        erasedNoteIds.clear();
+        noteErasing = false;
+        if (noteEraseSessionId != 0 && editSessionManager->hasActiveTransaction() &&
+            editSessionManager->activeSession().sessionId == noteEraseSessionId) {
+            editSessionManager->endTransaction(noteEraseSessionId, reason);
+        }
+        noteEraseSessionId = 0;
+        if (!editSessionManager->hasActiveTransaction())
+            appStatus->currentEditObject = AppStatus::EditObjectType::None;
+        scheduleSnapshot();
     }
 
     void clearSplitPreview() {
@@ -1195,12 +1336,12 @@ public:
     }
 
     void updateAnchorSelection(const QPointF &viewportPosition) {
-        anchorSelectionRect.setBottomRight(viewportPosition);
+        anchorSelectionRect.setBottomRight(scenePositionAt(viewportPosition));
         const auto rect = anchorSelectionRect.normalized();
         clearAnchorSelection();
         for (auto *curve : anchorCurves) {
             for (auto *node : curve->nodes().toList()) {
-                if (rect.contains(anchorNodeViewportPosition(node)))
+                if (rect.contains(anchorNodeScenePosition(node)))
                     selectedAnchorNodes.append(node);
             }
         }
@@ -1214,10 +1355,9 @@ public:
                     {node, findAnchorOwner(node), nullptr, node->pos(), node->value()});
             }
         }
-        const auto deltaTick =
-            static_cast<int>((viewportPosition.x() - anchorDragStart.x()) / pixelsPerTick());
-        const auto deltaValue =
-            anchorPointAt(viewportPosition).y() - anchorPointAt(anchorDragStart).y();
+        const auto current = anchorPointAt(viewportPosition);
+        const auto deltaTick = current.x() - anchorDragStartPoint.x();
+        const auto deltaValue = current.y() - anchorDragStartPoint.y();
         for (auto &info : anchorDragInfos) {
             if (!info.sourceCurve)
                 continue;
@@ -1240,24 +1380,27 @@ public:
                 } else {
                     if (!selectedAnchorNodes.contains(node))
                         selectAnchorNode(node);
-                    anchorDragStart = event->position();
+                    anchorDragStartPoint = anchorPointAt(event->position());
+                    anchorDragPressViewportPos = event->position();
                     anchorDragging = false;
                     anchorDragInfos.clear();
                 }
             } else {
                 createAnchorAt(event->position());
-                anchorDragStart = event->position();
+                anchorDragStartPoint = anchorPointAt(event->position());
+                anchorDragPressViewportPos = event->position();
                 anchorDragging = false;
                 anchorDragInfos.clear();
             }
         } else if (node) {
             selectAnchorNode(node);
             enterAnchorEditing(currentAnchorCurve, node);
-            anchorDragStart = event->position();
+            anchorDragStartPoint = anchorPointAt(event->position());
+            anchorDragPressViewportPos = event->position();
             anchorDragging = false;
             anchorDragInfos.clear();
         } else {
-            anchorSelectionRect = QRectF(event->position(), QSizeF());
+            anchorSelectionRect = QRectF(scenePositionAt(event->position()), QSizeF());
             anchorSelecting = true;
         }
         scheduleSnapshot();
@@ -1266,7 +1409,8 @@ public:
     void mouseMoveAnchor(QMouseEvent *event) {
         if (event->buttons().testFlag(Qt::LeftButton)) {
             if (anchorEditing && !selectedAnchorNodes.isEmpty()) {
-                if (!anchorDragging && QLineF(anchorDragStart, event->position()).length() > 3.0) {
+                if (!anchorDragging &&
+                    QLineF(anchorDragPressViewportPos, event->position()).length() > 3.0) {
                     anchorDragging = true;
                 }
                 if (anchorDragging)
@@ -1342,6 +1486,8 @@ public:
     void mousePress(QMouseEvent *event) {
         if (!clip || event->button() != Qt::LeftButton)
             return;
+        if (noteErasing)
+            finishNoteErase(EditSessionEndReason::Discard);
         if (editMode == EditPitchAnchor) {
             mousePressAnchor(event);
             return;
@@ -1352,8 +1498,8 @@ public:
         }
         auto *note = noteAt(event->position());
         if (editMode == EraseNote) {
-            if (note)
-                clipController->onRemoveNotes({note->id()});
+            noteErasing = true;
+            eraseNoteAt(event->position());
             return;
         }
         if (editMode == SplitNote) {
@@ -1374,7 +1520,7 @@ public:
         }
         if (!note) {
             interaction = Interaction::RectSelect;
-            rubberBandStart = event->position();
+            rubberBandStart = scenePositionAt(event->position());
             rubberBandEnd = rubberBandStart;
             rubberBandBaseSelection = event->modifiers().testFlag(Qt::ControlModifier)
                                           ? appStatus->selectedNotes.get()
@@ -1434,30 +1580,35 @@ public:
             updatePitchEdit(event->position());
             return;
         }
-        if (interaction == Interaction::Draw) {
-            drawEnd = std::max(drawStart + 1, snapLocalTick(localTickAt(event->position())));
-            scheduleSnapshot();
-        } else if (interaction == Interaction::RectSelect) {
-            rubberBandEnd = event->position();
-            auto selected = rubberBandBaseSelection;
-            auto selection = QRectF(rubberBandStart, rubberBandEnd).normalized();
-            if (editMode == IntervalSelect) {
-                selection.setTop(0.0);
-                selection.setBottom(q->height());
-            }
-            for (const auto *note : clip->notes()) {
-                const QRectF rect(note->localStart() * pixelsPerTick() - cameraX,
-                                  (127 - note->keyIndex()) * noteHeight * scaleY - cameraY,
-                                  note->length() * pixelsPerTick(), noteHeight * scaleY);
-                if (selection.intersects(rect) && !selected.contains(note->id()))
-                    selected.append(note->id());
-            }
-            appStatus->selectedNotes = selected;
-            scheduleSnapshot();
-        } else if (interaction != Interaction::None) {
-            updateInteractionDelta(event->position(), event->modifiers());
-            scheduleSnapshot();
+        if (noteErasing) {
+            eraseNoteAt(event->position());
+            return;
         }
+        continueEdgeDragAt(event->position(), event->modifiers());
+    }
+
+    void updateDrawNote(const QPointF &viewportPosition) {
+        drawEnd = std::max(drawStart + 1, snapLocalTick(localTickAt(viewportPosition)));
+        scheduleSnapshot();
+    }
+
+    void updateRubberBandSelection(const QPointF &viewportPosition) {
+        rubberBandEnd = scenePositionAt(viewportPosition);
+        auto selected = rubberBandBaseSelection;
+        auto selection = QRectF(rubberBandStart, rubberBandEnd).normalized();
+        if (editMode == IntervalSelect) {
+            selection.setTop(0.0);
+            selection.setBottom(sceneHeight());
+        }
+        for (const auto *note : clip->notes()) {
+            const QRectF rect(note->localStart() * pixelsPerTick(),
+                              (127 - note->keyIndex()) * noteHeight * scaleY,
+                              note->length() * pixelsPerTick(), noteHeight * scaleY);
+            if (selection.intersects(rect) && !selected.contains(note->id()))
+                selected.append(note->id());
+        }
+        appStatus->selectedNotes = selected;
+        scheduleSnapshot();
     }
 
     void mouseRelease(QMouseEvent *event) {
@@ -1469,6 +1620,10 @@ public:
         }
         if (pitchEditing) {
             commitPitchEdit(event->position());
+            return;
+        }
+        if (noteErasing) {
+            finishNoteErase(EditSessionEndReason::Commit);
             return;
         }
         if (interaction == Interaction::Draw) {
@@ -1791,6 +1946,8 @@ private:
                                   editMode == ErasePitch || editMode == FreezePitch;
         const auto selectedNotes = appStatus->selectedNotes.get();
         for (const auto *note : clip->notes()) {
+            if (erasedNoteIds.contains(note->id()))
+                continue;
             auto noteStart = note->localStart();
             auto noteLength = note->length();
             auto noteKey = note->keyIndex();
@@ -2206,8 +2363,7 @@ private:
     void appendAnchorSelectionRect() {
         if (!anchorSelecting)
             return;
-        const auto viewportRect = anchorSelectionRect.normalized();
-        const auto sceneRect = viewportRect.translated(cameraX, cameraY);
+        const auto sceneRect = anchorSelectionRect.normalized();
         auto fill = q->anchorPreviewColor();
         fill.setAlpha(64);
         auto border = q->anchorPreviewColor();
@@ -2267,13 +2423,12 @@ private:
     void appendRubberBand() {
         if (interaction != Interaction::RectSelect)
             return;
-        auto viewportRect = QRectF(rubberBandStart, rubberBandEnd).normalized();
+        auto sceneRect = QRectF(rubberBandStart, rubberBandEnd).normalized();
         const auto intervalSelect = editMode == IntervalSelect;
         if (intervalSelect) {
-            viewportRect.setTop(0.0);
-            viewportRect.setBottom(q->height());
+            sceneRect.setTop(0.0);
+            sceneRect.setBottom(sceneHeight());
         }
-        const auto sceneRect = viewportRect.translated(cameraX, cameraY);
         if (intervalSelect) {
             appendLogicalRect(sceneRect, q->rubberBandFillColor());
             appendLine(sceneRect.topLeft(), sceneRect.bottomLeft(), 1.5,
@@ -2367,6 +2522,9 @@ public:
     QPoint pitchPreviousPos;
     QList<DrawCurve *> pitchPreviewCurves;
     DrawCurve *pitchEditingCurve = nullptr;
+    bool noteErasing = false;
+    QList<int> erasedNoteIds;
+    quint64 noteEraseSessionId = 0;
     QList<AnchorCurve *> anchorCurves;
     quint64 anchorEditSessionId = 0;
     bool anchorCommitting = false;
@@ -2380,7 +2538,8 @@ public:
     QList<AnchorDragInfo> anchorDragInfos;
     QRectF anchorSelectionRect;
     QPointF anchorPreviewPosition;
-    QPointF anchorDragStart;
+    QPoint anchorDragStartPoint;
+    QPointF anchorDragPressViewportPos;
     AnchorCurve *anchorPreviewCurve = nullptr;
     AnchorCurve *anchorMergeCandidateCurve = nullptr;
     AnchorNode *anchorMergeEndpointNode = nullptr;
@@ -2401,6 +2560,11 @@ public:
     TimelineLineEmitter timelineEmitter;
     EditorGlyphAtlas glyphAtlas;
     EditorRhiDrawList drawList;
+    EdgeAutoScroller edgeAutoScroller;
+    Qt::Orientations edgeAutoScrollAxesValue;
+    QPointF edgeAutoScrollPressPos;
+    bool edgeAutoScrollArmed = false;
+    bool edgeAutoScrollDistanceReached = false;
     int noteFontPixelSize = 13;
     QColor whiteKeyColor{38, 40, 44};
     QColor blackKeyColor{31, 33, 37};
@@ -2516,6 +2680,8 @@ bool PianoRollRhiWidget::revealFocus(const HistoryFocus &focus, bool) {
 
 void PianoRollRhiWidget::setEditMode(const PianoRollEditMode mode) {
     if (d->editMode != mode) {
+        d->disarmEdgeAutoScroll();
+        d->finishNoteErase(EditSessionEndReason::Discard);
         d->finishInlineEditing();
         d->cancelPitchEdit();
         if (d->editMode == EditPitchAnchor)
@@ -2571,6 +2737,7 @@ void PianoRollRhiWidget::showEvent(QShowEvent *event) {
 }
 
 void PianoRollRhiWidget::hideEvent(QHideEvent *event) {
+    d->disarmEdgeAutoScroll();
     EditorRhiWidget::hideEvent(event);
     d->updateAutoPageTurnAvailability();
 }
@@ -2598,17 +2765,21 @@ void PianoRollRhiWidget::wheelEvent(QWheelEvent *event) {
 
 void PianoRollRhiWidget::mousePressEvent(QMouseEvent *event) {
     setFocus(Qt::MouseFocusReason);
+    if (event->button() == Qt::LeftButton)
+        d->prepareEdgeAutoScroll(event->position());
     d->mousePress(event);
     event->accept();
 }
 
 void PianoRollRhiWidget::mouseMoveEvent(QMouseEvent *event) {
     d->mouseMove(event);
+    d->updateEdgeAutoScrollState(event->position());
     event->accept();
 }
 
 void PianoRollRhiWidget::mouseReleaseEvent(QMouseEvent *event) {
     d->mouseRelease(event);
+    d->disarmEdgeAutoScroll();
     event->accept();
 }
 
@@ -2616,7 +2787,9 @@ void PianoRollRhiWidget::mouseDoubleClickEvent(QMouseEvent *event) {
     if (d->clip && d->editMode == EditPitchAnchor && event->button() == Qt::LeftButton) {
         setFocus(Qt::MouseFocusReason);
         d->createAnchorAt(event->position());
-        d->anchorDragStart = event->position();
+        d->anchorDragStartPoint = d->anchorPointAt(event->position());
+        d->anchorDragPressViewportPos = event->position();
+        d->prepareEdgeAutoScroll(event->position());
         d->anchorDragging = false;
         d->anchorDragInfos.clear();
         d->scheduleSnapshot();
@@ -2644,6 +2817,7 @@ void PianoRollRhiWidget::mouseDoubleClickEvent(QMouseEvent *event) {
             d->drawEnd =
                 d->drawStart + TimelineSnapUtils::quantizeToTicks(appStatus->pianoRollQuantize);
             d->drawKey = d->keyAt(event->position());
+            d->prepareEdgeAutoScroll(event->position());
             d->scheduleSnapshot();
             event->accept();
             return;
@@ -2653,11 +2827,18 @@ void PianoRollRhiWidget::mouseDoubleClickEvent(QMouseEvent *event) {
 }
 
 void PianoRollRhiWidget::keyPressEvent(QKeyEvent *event) {
+    if (event->key() == Qt::Key_Escape)
+        d->disarmEdgeAutoScroll();
     if (d->editMode == EditPitchAnchor && d->keyPressAnchor(event)) {
         event->accept();
         return;
     }
     if (event->key() == Qt::Key_Escape) {
+        if (d->noteErasing) {
+            d->finishNoteErase(EditSessionEndReason::Discard);
+            event->accept();
+            return;
+        }
         if (d->pitchEditing) {
             d->cancelPitchEdit();
             event->accept();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -375,6 +375,13 @@ public:
             return HistoryFocusVisibility::Unavailable;
         if (focus.containerId >= 0 && focus.containerId != clip->id())
             return HistoryFocusVisibility::ContextSwitchRequired;
+        QList<int> resolvedIds;
+        const auto bounds = focusSceneRect(focus, &resolvedIds);
+        if (!resolvedIds.isEmpty()) {
+            const QRectF viewport(QPointF(cameraX, cameraY), q->size());
+            return viewport.intersects(bounds) ? HistoryFocusVisibility::Visible
+                                               : HistoryFocusVisibility::ScrollRequired;
+        }
         const auto tickOffset = focus.ticksAreLocal ? clip->start() : 0.0;
         const auto tickVisible =
             focus.tickEnd + tickOffset >= startTick() && focus.tickStart + tickOffset <= endTick();
@@ -390,13 +397,9 @@ public:
         if (focus.containerId >= 0 && focus.containerId != clip->id())
             return false;
         QList<int> selected;
-        for (const auto id : focus.objectIds)
-            if (clip->findNoteById(id))
-                selected.append(id);
+        const auto bounds = focusSceneRect(focus, &selected);
         appStatus->selectedNotes = selected;
-        const auto tickOffset = focus.ticksAreLocal ? clip->start() : 0.0;
-        return centerAt((focus.tickStart + focus.tickEnd) * 0.5 + tickOffset,
-                        (focus.valueStart + focus.valueEnd) * 0.5);
+        return ensureSceneRectVisible(bounds, 24.0, 24.0);
     }
 
     void horizontalScale(QWheelEvent *event) {
@@ -666,9 +669,7 @@ public:
     QRectF noteViewportRect(const Note *note) const {
         if (!note)
             return {};
-        return {note->localStart() * pixelsPerTick() - cameraX,
-                (127 - note->keyIndex()) * noteHeight * scaleY - cameraY,
-                note->length() * pixelsPerTick(), noteHeight * scaleY};
+        return noteSceneRect(note).translated(-cameraX, -cameraY);
     }
 
     Note *pronunciationAt(const QPointF &viewportPosition) const {
@@ -1725,6 +1726,61 @@ public:
     }
 
 private:
+    QRectF noteSceneRect(const Note *note) const {
+        if (!note)
+            return {};
+        return {note->localStart() * pixelsPerTick(),
+                (127 - note->keyIndex()) * noteHeight * scaleY,
+                note->length() * pixelsPerTick(), noteHeight * scaleY};
+    }
+
+    QRectF focusSceneRect(const HistoryFocus &focus, QList<int> *resolvedIds = nullptr) const {
+        QRectF bounds;
+        for (const auto id : focus.objectIds) {
+            if (const auto *note = clip->findNoteById(id)) {
+                if (resolvedIds)
+                    resolvedIds->append(id);
+                const auto rect = noteSceneRect(note);
+                bounds = bounds.isNull() ? rect : bounds.united(rect);
+            }
+        }
+        if (!bounds.isNull())
+            return bounds;
+
+        const auto localStart =
+            focus.ticksAreLocal ? focus.tickStart : focus.tickStart - clip->start();
+        const auto localEnd = focus.ticksAreLocal ? focus.tickEnd : focus.tickEnd - clip->start();
+        const auto keyHeight = noteHeight * scaleY;
+        const auto top = (127.0 - focus.valueEnd) * keyHeight;
+        const auto bottom = (127.0 - focus.valueStart) * keyHeight + keyHeight;
+        return {localStart * pixelsPerTick(), top,
+                std::max(1.0, (localEnd - localStart) * pixelsPerTick()),
+                std::max(keyHeight, bottom - top)};
+    }
+
+    bool ensureSceneRectVisible(const QRectF &rect, const double xMargin, const double yMargin) {
+        const auto bounds = rect.normalized();
+        if (!bounds.isValid() || !std::isfinite(bounds.left()) ||
+            !std::isfinite(bounds.top()) || !std::isfinite(bounds.right()) ||
+            !std::isfinite(bounds.bottom())) {
+            return false;
+        }
+        const auto targetX = EditorScrollUtils::boundedOffset(
+            EditorScrollUtils::ensureVisibleOffset(cameraX, q->width(), bounds.left(),
+                                                   bounds.right(), xMargin),
+            sceneWidth(), q->width());
+        const auto targetY = EditorScrollUtils::boundedOffset(
+            EditorScrollUtils::ensureVisibleOffset(cameraY, q->height(), bounds.top(),
+                                                   bounds.bottom(), yMargin),
+            sceneHeight(), q->height());
+        if (cameraX == targetX && cameraY == targetY)
+            return true;
+        cameraX = targetX;
+        cameraY = targetY;
+        viewportChanged(false);
+        return true;
+    }
+
     QPointF physicalCameraOffset() const {
         return QPointF(cameraX, cameraY) * dpr;
     }

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -425,21 +425,14 @@ public:
     }
 
     void horizontalScroll(QWheelEvent *event) {
-        const auto delta = EditorWheelUtils::horizontalScrollDelta(event);
-        (void) wheelInputState.isMouseWheel(event);
-        cameraX = EditorWheelUtils::scrollTarget(static_cast<int>(cameraX), q->width(), 0.2, delta);
+        cameraX = EditorWheelUtils::scrollTarget(static_cast<int>(cameraX), q->width(), 0.2, event,
+                                                 EditorWheelUtils::horizontalScrollAxis(event));
         viewportChanged(false);
     }
 
     void verticalScroll(QWheelEvent *event) {
-        const auto delta = EditorWheelUtils::wheelDelta(event, Qt::Vertical);
-        const auto fromWheel = wheelInputState.isMouseWheel(event);
-        if (fromWheel)
-            verticalTouchPadScroll.reset();
-        cameraY = fromWheel ? EditorWheelUtils::scrollTarget(static_cast<int>(cameraY), q->height(),
-                                                             0.15, delta)
-                            : verticalTouchPadScroll.scrollTarget(static_cast<int>(cameraY),
-                                                                  q->height(), 0.15, delta);
+        cameraY = EditorWheelUtils::scrollTarget(static_cast<int>(cameraY), q->height(), 0.15, event,
+                                                 Qt::Vertical);
         viewportChanged(false);
     }
 
@@ -2408,9 +2401,6 @@ public:
     TimelineLineEmitter timelineEmitter;
     EditorGlyphAtlas glyphAtlas;
     EditorRhiDrawList drawList;
-    EditorWheelUtils::InputState wheelInputState;
-    EditorWheelUtils::ScrollAccumulator verticalTouchPadScroll;
-
     int noteFontPixelSize = 13;
     QColor whiteKeyColor{38, 40, 44};
     QColor blackKeyColor{31, 33, 37};

--- a/src/app/UI/Views/Common/EdgeAutoScroller.cpp
+++ b/src/app/UI/Views/Common/EdgeAutoScroller.cpp
@@ -124,6 +124,57 @@ void EdgeAutoScroller::resetAccumulator() {
     m_accumulator = QPointF();
 }
 
+void EdgeAutoScroller::prepareDrag(const QPointF &pressPos, const Qt::Orientations axes) {
+    stopDrag();
+    m_dragPressPos = pressPos;
+    setDragAxes(axes);
+}
+
+void EdgeAutoScroller::setDragAxes(const Qt::Orientations axes) {
+    m_dragAxes = axes;
+    m_dragArmed = !!axes;
+    if (!m_dragArmed) {
+        m_dragDistanceReached = false;
+        stop();
+    }
+}
+
+void EdgeAutoScroller::updateDragState(const QPointF &pointerPos, const QRectF &viewportRect,
+                                       const int startDragDistance) {
+    if (!m_dragArmed)
+        return;
+    if (!m_dragDistanceReached) {
+        if ((pointerPos - m_dragPressPos).manhattanLength() < startDragDistance)
+            return;
+        m_dragDistanceReached = true;
+    }
+
+    const auto dragVelocity =
+        velocity(pointerPos, m_dragPressPos, viewportRect, m_dragAxes, m_config);
+    if (!dragVelocity.isNull())
+        start();
+    else
+        stop();
+}
+
+QPoint EdgeAutoScroller::computeDragStep(const QPointF &pointerPos, const QRectF &viewportRect,
+                                         const double dtMs) {
+    if (!m_dragArmed)
+        return {};
+    return computeStep(pointerPos, m_dragPressPos, viewportRect, m_dragAxes, dtMs);
+}
+
+void EdgeAutoScroller::stopDrag() {
+    m_dragArmed = false;
+    m_dragDistanceReached = false;
+    m_dragAxes = {};
+    stop();
+}
+
+bool EdgeAutoScroller::isDragArmed() const {
+    return m_dragArmed;
+}
+
 void EdgeAutoScroller::start() {
     if (m_timer.isActive())
         return;

--- a/src/app/UI/Views/Common/EdgeAutoScroller.h
+++ b/src/app/UI/Views/Common/EdgeAutoScroller.h
@@ -1,5 +1,5 @@
 //
-// Edge auto scroll for TimeGraphicsView-based editors.
+// Edge auto scroll for editor views.
 //
 // Pure computation (speed curve, sub-pixel accumulation, pointer clamping) is
 // kept free of any widget dependency so it can be unit-tested with injected
@@ -74,6 +74,16 @@ public:
                        const QRectF &viewportRect, Qt::Orientations axes, double dtMs);
     void resetAccumulator();
 
+    // --- Drag session ---
+
+    void prepareDrag(const QPointF &pressPos, Qt::Orientations axes = {});
+    void setDragAxes(Qt::Orientations axes);
+    void updateDragState(const QPointF &pointerPos, const QRectF &viewportRect,
+                         int startDragDistance);
+    QPoint computeDragStep(const QPointF &pointerPos, const QRectF &viewportRect, double dtMs);
+    void stopDrag();
+    [[nodiscard]] bool isDragArmed() const;
+
     // --- Runner ---
 
     void start();
@@ -89,6 +99,10 @@ private:
     QPointF m_accumulator;
     QTimer m_timer;
     QElapsedTimer m_elapsed;
+    QPointF m_dragPressPos;
+    Qt::Orientations m_dragAxes;
+    bool m_dragArmed = false;
+    bool m_dragDistanceReached = false;
 };
 
 #endif // EDGEAUTOSCROLLER_H

--- a/src/app/UI/Views/Common/EditorResizeUtils.h
+++ b/src/app/UI/Views/Common/EditorResizeUtils.h
@@ -1,0 +1,17 @@
+#ifndef EDITORRESIZEUTILS_H
+#define EDITORRESIZEUTILS_H
+
+namespace EditorResizeUtils {
+    enum class HorizontalEdge { None, Left, Right };
+
+    inline HorizontalEdge horizontalEdgeAt(const double position, const double width,
+                                           const double tolerance) {
+        if (position >= 0.0 && position <= tolerance)
+            return HorizontalEdge::Left;
+        if (position >= width - tolerance && position <= width)
+            return HorizontalEdge::Right;
+        return HorizontalEdge::None;
+    }
+}
+
+#endif // EDITORRESIZEUTILS_H

--- a/src/app/UI/Views/Common/EditorScrollUtils.h
+++ b/src/app/UI/Views/Common/EditorScrollUtils.h
@@ -4,6 +4,7 @@
 #include <QtMath>
 
 #include <algorithm>
+#include <cmath>
 
 namespace EditorScrollUtils {
 
@@ -14,6 +15,24 @@ namespace EditorScrollUtils {
     inline int boundedOffset(const double requestedOffset, const double contentLength,
                              const double viewportLength) {
         return std::clamp(qRound(requestedOffset), 0, rangeMaximum(contentLength, viewportLength));
+    }
+
+    inline double ensureVisibleOffset(const double currentOffset, const double viewportLength,
+                                      const double contentStart, const double contentEnd,
+                                      const double margin) {
+        if (!std::isfinite(currentOffset) || !std::isfinite(viewportLength) ||
+            !std::isfinite(contentStart) || !std::isfinite(contentEnd) ||
+            !std::isfinite(margin) || viewportLength <= 0.0) {
+            return currentOffset;
+        }
+        const auto safeMargin = std::max(0.0, margin);
+        const auto requiredStart = std::min(contentStart, contentEnd) - safeMargin;
+        const auto requiredEnd = std::max(contentStart, contentEnd) + safeMargin;
+        if (requiredStart < currentOffset)
+            return requiredStart;
+        if (requiredEnd > currentOffset + viewportLength)
+            return requiredEnd - viewportLength;
+        return currentOffset;
     }
 
 } // namespace EditorScrollUtils

--- a/src/app/UI/Views/Common/EditorViewportController.cpp
+++ b/src/app/UI/Views/Common/EditorViewportController.cpp
@@ -135,6 +135,26 @@ bool EditorViewportController::centerAt(const double tick, const double unit) {
     return true;
 }
 
+bool EditorViewportController::ensureVisible(const QRectF &rect, const double xMargin,
+                                             const double yMargin) {
+    const auto bounds = rect.normalized();
+    if (!bounds.isValid() || !std::isfinite(bounds.left()) || !std::isfinite(bounds.top()) ||
+        !std::isfinite(bounds.right()) || !std::isfinite(bounds.bottom()) ||
+        !std::isfinite(xMargin) || !std::isfinite(yMargin)) {
+        return false;
+    }
+
+    const auto previousOffset = QPointF(m_offsetX, m_offsetY);
+    m_offsetX = EditorScrollUtils::ensureVisibleOffset(
+        m_offsetX, m_viewportSize.width(), bounds.left(), bounds.right(), xMargin);
+    m_offsetY = EditorScrollUtils::ensureVisibleOffset(
+        m_offsetY, m_viewportSize.height(), bounds.top(), bounds.bottom(), yMargin);
+    normalize(false);
+    if (QPointF(m_offsetX, m_offsetY) != previousOffset)
+        notify(false);
+    return true;
+}
+
 bool EditorViewportController::setStartTick(const double tick) {
     if (!std::isfinite(tick))
         return false;

--- a/src/app/UI/Views/Common/EditorViewportController.h
+++ b/src/app/UI/Views/Common/EditorViewportController.h
@@ -35,6 +35,7 @@ public:
     bool restoreState(const State &state);
     bool setScale(double horizontal, double vertical, const QPointF &anchor);
     bool centerAt(double tick, double unit);
+    bool ensureVisible(const QRectF &rect, double xMargin, double yMargin);
     bool setStartTick(double tick);
     void scrollBy(const QPointF &deltaPixels);
     void zoomHorizontal(double wheelDelta, double anchorX);

--- a/src/app/UI/Views/Common/EditorWheelUtils.h
+++ b/src/app/UI/Views/Common/EditorWheelUtils.h
@@ -5,64 +5,42 @@
 #include <QTimer>
 #include <QWheelEvent>
 
-#include <cmath>
-
 namespace EditorWheelUtils {
 
-    inline double wheelDelta(const QWheelEvent *event, const Qt::Orientation axis) {
-        const auto pixelDelta = event->pixelDelta();
-        if (!pixelDelta.isNull()) {
-            const auto pixelValue = axis == Qt::Horizontal ? pixelDelta.x() : pixelDelta.y();
-            return pixelValue * 4.0;
-        }
+    inline double axisValue(const QPoint &delta, const Qt::Orientation axis) {
+        return axis == Qt::Horizontal ? delta.x() : delta.y();
+    }
 
-        const auto angleDelta = event->angleDelta();
-        const auto angleValue = axis == Qt::Horizontal ? angleDelta.x() : angleDelta.y();
-        return angleValue;
+    inline bool usesPixelDelta(const QWheelEvent *event) {
+        if (event->pixelDelta().isNull())
+            return false;
+        return event->angleDelta().isNull() ||
+               event->deviceType() == QInputDevice::DeviceType::TouchPad;
+    }
+
+    inline double wheelDelta(const QWheelEvent *event, const Qt::Orientation axis) {
+        if (usesPixelDelta(event))
+            return axisValue(event->pixelDelta(), axis) * 4.0;
+        return axisValue(event->angleDelta(), axis);
     }
 
     inline Qt::Orientation dominantAxis(const QWheelEvent *event) {
-        return qAbs(wheelDelta(event, Qt::Horizontal)) >
-                       qAbs(wheelDelta(event, Qt::Vertical))
-                   ? Qt::Horizontal
-                   : Qt::Vertical;
+        const auto delta = usesPixelDelta(event) ? event->pixelDelta() : event->angleDelta();
+        return qAbs(delta.x()) > qAbs(delta.y()) ? Qt::Horizontal : Qt::Vertical;
     }
 
-    inline double horizontalScrollDelta(const QWheelEvent *event) {
-        const auto sourceAxis =
-            event->modifiers() == Qt::ShiftModifier ? Qt::Vertical : Qt::Horizontal;
-        return wheelDelta(event, sourceAxis);
+    inline Qt::Orientation horizontalScrollAxis(const QWheelEvent *event) {
+        return event->modifiers() == Qt::ShiftModifier ? Qt::Vertical : Qt::Horizontal;
     }
 
     inline int scrollTarget(const int startValue, const int viewportLength,
-                            const double viewportFraction, const double wheelDelta) {
-        return static_cast<int>(startValue -
-                                viewportLength * viewportFraction * wheelDelta / 120.0);
+                            const double viewportFraction, const QWheelEvent *event,
+                            const Qt::Orientation axis) {
+        if (usesPixelDelta(event))
+            return static_cast<int>(startValue - axisValue(event->pixelDelta(), axis));
+        return static_cast<int>(startValue - viewportLength * viewportFraction *
+                                                 axisValue(event->angleDelta(), axis) / 120.0);
     }
-
-    class ScrollAccumulator final {
-    public:
-        int scrollTarget(const int startValue, const int viewportLength,
-                         const double viewportFraction, const double wheelDelta) {
-            const auto wholeStep = static_cast<int>(viewportLength * viewportFraction);
-            const auto offset = -wholeStep * wheelDelta / 120.0;
-            if (!qFuzzyIsNull(m_remainder) && !qFuzzyIsNull(offset) &&
-                std::signbit(m_remainder) != std::signbit(offset)) {
-                m_remainder = 0.0;
-            }
-            m_remainder += offset;
-            const auto wholeOffset = static_cast<int>(m_remainder);
-            m_remainder -= wholeOffset;
-            return startValue + wholeOffset;
-        }
-
-        void reset() {
-            m_remainder = 0.0;
-        }
-
-    private:
-        double m_remainder = 0.0;
-    };
 
     class InputState final {
     public:
@@ -77,6 +55,8 @@ namespace EditorWheelUtils {
 
         [[nodiscard]] bool isMouseWheel(const QWheelEvent *event) {
 #if defined(Q_OS_MAC) && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            if (usesPixelDelta(event))
+                return false;
             return event->deviceType() == QInputDevice::DeviceType::Mouse;
 #else
             const auto deltaX = event->angleDelta().x();
@@ -87,7 +67,7 @@ namespace EditorWheelUtils {
                 m_unlockTimer.start();
                 return false;
             }
-            if (!event->pixelDelta().isNull()) {
+            if (usesPixelDelta(event)) {
                 m_touchPadLocked = true;
                 m_unlockTimer.start();
                 return false;

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -390,10 +390,11 @@ void TimeGraphicsView::onWheelVerScale(QWheelEvent *event) {
 }
 
 void TimeGraphicsView::onWheelHorScroll(QWheelEvent *event) {
-    const auto deltaY = EditorWheelUtils::horizontalScrollDelta(event);
+    const auto fromWheel = isMouseEventFromWheel(event);
     auto startValue = horizontalBarValue();
-    auto endValue = EditorWheelUtils::scrollTarget(startValue, viewport()->width(), 0.2, deltaY);
-    if (isDirectManipulationEnabled() || !isMouseEventFromWheel(event))
+    auto endValue = EditorWheelUtils::scrollTarget(startValue, viewport()->width(), 0.2, event,
+                                                   EditorWheelUtils::horizontalScrollAxis(event));
+    if (isDirectManipulationEnabled() || !fromWheel)
         setHorizontalBarValue(endValue);
     else {
         horizontalBarAnimateTo(endValue);
@@ -401,15 +402,10 @@ void TimeGraphicsView::onWheelHorScroll(QWheelEvent *event) {
 }
 
 void TimeGraphicsView::onWheelVerScroll(QWheelEvent *event) {
-    const auto deltaY = EditorWheelUtils::wheelDelta(event, Qt::Vertical);
     const auto fromWheel = isMouseEventFromWheel(event);
-    if (fromWheel)
-        m_verticalTouchPadScroll.reset();
     const auto startValue = verticalBarValue();
-    const auto endValue =
-        fromWheel
-            ? EditorWheelUtils::scrollTarget(startValue, viewport()->height(), 0.15, deltaY)
-            : m_verticalTouchPadScroll.scrollTarget(startValue, viewport()->height(), 0.15, deltaY);
+    const auto endValue = EditorWheelUtils::scrollTarget(startValue, viewport()->height(), 0.15,
+                                                         event, Qt::Vertical);
     if (isDirectManipulationEnabled() || !fromWheel) {
         setVerticalBarValue(endValue);
     } else {

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -546,7 +546,7 @@ void TimeGraphicsView::mouseMoveEvent(QMouseEvent *event) {
     if (m_isDraggingContent) {
         updateRubberBandSelection(mapToScene(event->pos()));
     }
-    if (m_edgeAutoScrollArmed)
+    if (m_edgeAutoScroller.isDragArmed())
         updateEdgeAutoScrollState(event->pos());
     QGraphicsView::mouseMoveEvent(event);
 }
@@ -703,7 +703,7 @@ void TimeGraphicsView::updateAutoPageTurnAvailability() {
 
 void TimeGraphicsView::armEdgeAutoScroll(Qt::Orientations axes) {
     const auto pointerPos = viewport()->mapFromGlobal(QCursor::pos());
-    if (!m_edgeAutoScrollArmed) {
+    if (!m_edgeAutoScroller.isDragArmed()) {
         armEdgeAutoScroll(axes, pointerPos);
         return;
     }
@@ -711,21 +711,16 @@ void TimeGraphicsView::armEdgeAutoScroll(Qt::Orientations axes) {
     // and re-evaluate the hot zone, keeping the press position intact. This
     // also covers subclasses whose mouseMoveEvent returns before reaching the
     // base class implementation.
-    m_edgeAutoScrollAxes = axes;
+    m_edgeAutoScroller.setDragAxes(axes);
     updateEdgeAutoScrollState(pointerPos);
 }
 
 void TimeGraphicsView::armEdgeAutoScroll(const Qt::Orientations axes, const QPoint &pressPos) {
-    m_edgeAutoScrollAxes = axes;
-    m_edgeAutoScrollArmed = !!axes;
-    m_edgeAutoScrollDistanceReached = false;
-    m_edgeAutoScrollPressPos = pressPos;
+    m_edgeAutoScroller.prepareDrag(pressPos, axes);
 }
 
 void TimeGraphicsView::disarmEdgeAutoScroll() {
-    m_edgeAutoScrollArmed = false;
-    m_edgeAutoScrollDistanceReached = false;
-    m_edgeAutoScroller.stop();
+    m_edgeAutoScroller.stopDrag();
 }
 
 bool TimeGraphicsView::isEdgeAutoScrollActive() const {
@@ -733,34 +728,21 @@ bool TimeGraphicsView::isEdgeAutoScrollActive() const {
 }
 
 void TimeGraphicsView::updateEdgeAutoScrollState(const QPoint &viewportPos) {
-    if (!m_edgeAutoScrollArmed)
-        return;
-
-    if (!m_edgeAutoScrollDistanceReached) {
-        const auto delta = viewportPos - m_edgeAutoScrollPressPos;
-        if (delta.manhattanLength() < QApplication::startDragDistance())
-            return;
-        m_edgeAutoScrollDistanceReached = true;
-    }
-
     const QRectF vpRect(QPointF(0, 0), viewport()->size());
-    const auto v = EdgeAutoScroller::velocity(viewportPos, m_edgeAutoScrollPressPos, vpRect,
-                                              m_edgeAutoScrollAxes, m_edgeAutoScroller.config());
-    const bool inHotZone = !v.isNull();
-    if (inHotZone && !m_edgeAutoScroller.isRunning()) {
+    const auto wasRunning = m_edgeAutoScroller.isRunning();
+    m_edgeAutoScroller.updateDragState(viewportPos, vpRect, QApplication::startDragDistance());
+    if (!wasRunning && m_edgeAutoScroller.isRunning()) {
         // Direct scroll bar writes must not fight the bar animations
         m_hBarAnimation.stop();
         m_vBarAnimation.stop();
-        m_edgeAutoScroller.start();
-    } else if (!inHotZone && m_edgeAutoScroller.isRunning()) {
-        m_edgeAutoScroller.stop();
     }
 }
 
 void TimeGraphicsView::onEdgeAutoScrollTimerFrame(double dtMs) {
     // Safety net: stop if the mouse button was released without us seeing the
     // event (e.g. release outside the window swallowed by a popup).
-    if (!m_edgeAutoScrollArmed || QGuiApplication::mouseButtons() == Qt::NoButton || !isVisible()) {
+    if (!m_edgeAutoScroller.isDragArmed() || QGuiApplication::mouseButtons() == Qt::NoButton ||
+        !isVisible()) {
         disarmEdgeAutoScroll();
         return;
     }
@@ -768,8 +750,7 @@ void TimeGraphicsView::onEdgeAutoScrollTimerFrame(double dtMs) {
     const auto pointerPos = QPointF(viewport()->mapFromGlobal(QCursor::pos()));
     const QRectF vpRect(QPointF(0, 0), viewport()->size());
 
-    const auto step = m_edgeAutoScroller.computeStep(pointerPos, QPointF(m_edgeAutoScrollPressPos),
-                                                     vpRect, m_edgeAutoScrollAxes, dtMs);
+    const auto step = m_edgeAutoScroller.computeDragStep(pointerPos, vpRect, dtMs);
     if (step.x() != 0)
         setHorizontalBarValue(horizontalBarValue() + step.x());
     if (step.y() != 0)

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -529,12 +529,11 @@ void TimeGraphicsView::mousePressEvent(QMouseEvent *event) {
             m_isDraggingContent = true;
             if (m_dragBehavior == DragBehavior::RectSelect) {
                 m_rubberBand.setSelectMode(RubberBandView::SelectMode::RectSelect);
-                armEdgeAutoScroll(Qt::Horizontal | Qt::Vertical);
+                armEdgeAutoScroll(Qt::Horizontal | Qt::Vertical, event->pos());
             } else {
                 m_rubberBand.setSelectMode(RubberBandView::SelectMode::BeamSelect);
-                armEdgeAutoScroll(Qt::Horizontal);
+                armEdgeAutoScroll(Qt::Horizontal, event->pos());
             }
-            m_edgeAutoScrollPressPos = event->pos();
             m_rubberBand.mouseDown(mapToScene(event->pos()));
             m_rubberBandAdded = false;
         }
@@ -703,11 +702,9 @@ void TimeGraphicsView::updateAutoPageTurnAvailability() {
 }
 
 void TimeGraphicsView::armEdgeAutoScroll(Qt::Orientations axes) {
+    const auto pointerPos = viewport()->mapFromGlobal(QCursor::pos());
     if (!m_edgeAutoScrollArmed) {
-        m_edgeAutoScrollAxes = axes;
-        m_edgeAutoScrollArmed = !!axes;
-        m_edgeAutoScrollDistanceReached = false;
-        m_edgeAutoScrollPressPos = viewport()->mapFromGlobal(QCursor::pos());
+        armEdgeAutoScroll(axes, pointerPos);
         return;
     }
     // Already armed (callers may re-arm on every move event): refresh the axes
@@ -715,7 +712,14 @@ void TimeGraphicsView::armEdgeAutoScroll(Qt::Orientations axes) {
     // also covers subclasses whose mouseMoveEvent returns before reaching the
     // base class implementation.
     m_edgeAutoScrollAxes = axes;
-    updateEdgeAutoScrollState(viewport()->mapFromGlobal(QCursor::pos()));
+    updateEdgeAutoScrollState(pointerPos);
+}
+
+void TimeGraphicsView::armEdgeAutoScroll(const Qt::Orientations axes, const QPoint &pressPos) {
+    m_edgeAutoScrollAxes = axes;
+    m_edgeAutoScrollArmed = !!axes;
+    m_edgeAutoScrollDistanceReached = false;
+    m_edgeAutoScrollPressPos = pressPos;
 }
 
 void TimeGraphicsView::disarmEdgeAutoScroll() {

--- a/src/app/UI/Views/Common/TimeGraphicsView.h
+++ b/src/app/UI/Views/Common/TimeGraphicsView.h
@@ -123,6 +123,7 @@ protected:
     // once the pointer has travelled past startDragDistance() and enters the
     // hot zone, and stops on disarm/release/cancel.
     void armEdgeAutoScroll(Qt::Orientations axes);
+    void armEdgeAutoScroll(Qt::Orientations axes, const QPoint &pressPos);
     void disarmEdgeAutoScroll();
     [[nodiscard]] bool isEdgeAutoScrollActive() const;
     // Per-frame hook, called after the viewport has been scrolled. The base

--- a/src/app/UI/Views/Common/TimeGraphicsView.h
+++ b/src/app/UI/Views/Common/TimeGraphicsView.h
@@ -185,10 +185,6 @@ private:
 
     // Edge auto scroll state
     EdgeAutoScroller m_edgeAutoScroller;
-    Qt::Orientations m_edgeAutoScrollAxes;
-    bool m_edgeAutoScrollArmed = false;
-    bool m_edgeAutoScrollDistanceReached = false;
-    QPoint m_edgeAutoScrollPressPos;
 
     // Scene length = external base + temporary drag extension
     int m_baseSceneLength = 0;

--- a/src/app/UI/Views/Common/TimeGraphicsView.h
+++ b/src/app/UI/Views/Common/TimeGraphicsView.h
@@ -194,7 +194,6 @@ private:
     int m_sceneLengthExtension = 0;
 
     EditorWheelUtils::InputState m_wheelInputState;
-    EditorWheelUtils::ScrollAccumulator m_verticalTouchPadScroll;
 
     OverlayScrollBar *m_hScrollBar = nullptr;
     OverlayScrollBar *m_vScrollBar = nullptr;

--- a/src/app/UI/Views/TrackEditor/GraphicsItem/AbstractClipView.cpp
+++ b/src/app/UI/Views/TrackEditor/GraphicsItem/AbstractClipView.cpp
@@ -5,6 +5,7 @@
 #include "Global/TracksEditorGlobal.h"
 #include "Model/AppOptions/AppOptions.h"
 #include "UI/Views/Common/TimeGraphicsScene.h"
+#include "UI/Views/Common/EditorResizeUtils.h"
 #include <lite/GUI/Controls/Menu.h>
 #include "UI/Utils/AppColorPalette.h"
 
@@ -312,11 +313,10 @@ void AbstractClipView::paint(QPainter *painter, const QStyleOptionGraphicsItem *
 
 void AbstractClipView::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
     const auto rx = event->pos().rx();
-    if (rx >= 0 && rx <= AppGlobal::resizeTolerance ||
-        rx >= rect().width() - AppGlobal::resizeTolerance && rx <= rect().width())
-        setCursor(Qt::SizeHorCursor);
-    else
-        setCursor(Qt::ArrowCursor);
+    const auto edge =
+        EditorResizeUtils::horizontalEdgeAt(rx, rect().width(), AppGlobal::resizeTolerance);
+    setCursor(edge == EditorResizeUtils::HorizontalEdge::None ? Qt::ArrowCursor
+                                                              : Qt::SizeHorCursor);
 
     QGraphicsRectItem::hoverMoveEvent(event);
 }

--- a/src/app/UI/Views/TrackEditor/TracksGraphicsView.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksGraphicsView.cpp
@@ -18,6 +18,7 @@
 #include "Modules/Inference/EditSessionManager.h"
 #include <lite/GUI/Controls/AccentButton.h>
 #include "UI/Utils/SpeakerMixDisplayUtils.h"
+#include "UI/Views/Common/EditorResizeUtils.h"
 #include <lite/MusicBase/TimelineSnapUtils.h>
 
 #include <QDragEnterEvent>
@@ -646,12 +647,13 @@ void TracksGraphicsView::prepareForMovingOrResizingClip(const QMouseEvent *event
     }
     const auto rPos = clipItem->mapFromScene(scenePos);
     const auto rx = rPos.x();
-    if (rx >= 0 && rx <= AppGlobal::resizeTolerance) {
+    const auto edge = EditorResizeUtils::horizontalEdgeAt(
+        rx, clipItem->rect().width(), AppGlobal::resizeTolerance);
+    if (edge == EditorResizeUtils::HorizontalEdge::Left) {
         m_mouseMoveBehavior = ResizeLeft;
         clearSelections();
         clipItem->setSelected(true);
-    } else if (rx >= clipItem->rect().width() - AppGlobal::resizeTolerance &&
-               rx <= clipItem->rect().width()) {
+    } else if (edge == EditorResizeUtils::HorizontalEdge::Right) {
         m_mouseMoveBehavior = ResizeRight;
         clearSelections();
         clipItem->setSelected(true);

--- a/src/app/UI/Views/TrackEditor/TracksGraphicsView.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksGraphicsView.cpp
@@ -694,7 +694,8 @@ void TracksGraphicsView::prepareForMovingOrResizingClip(const QMouseEvent *event
 
     // Moving allows both axes (track change); resizing is horizontal only
     armEdgeAutoScroll(m_mouseMoveBehavior == Move ? (Qt::Horizontal | Qt::Vertical)
-                                                  : Qt::Orientations(Qt::Horizontal));
+                                                  : Qt::Orientations(Qt::Horizontal),
+                      event->pos());
 }
 
 AbstractClipView *TracksGraphicsView::findClipById(const int id) const {

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -355,24 +355,16 @@ void TracksRhiWidget::onWheelVerScale(QWheelEvent *event) {
 }
 
 void TracksRhiWidget::onWheelHorScroll(QWheelEvent *event) {
-    (void) m_wheelInputState.isMouseWheel(event);
-    const auto target =
-        EditorWheelUtils::scrollTarget(static_cast<int>(m_viewport.horizontalOffset()), width(),
-                                       0.2, EditorWheelUtils::horizontalScrollDelta(event));
+    const auto target = EditorWheelUtils::scrollTarget(
+        static_cast<int>(m_viewport.horizontalOffset()), width(), 0.2, event,
+        EditorWheelUtils::horizontalScrollAxis(event));
     m_viewport.scrollBy({target - m_viewport.horizontalOffset(), 0.0});
 }
 
 void TracksRhiWidget::onWheelVerScroll(QWheelEvent *event) {
-    const auto fromWheel = m_wheelInputState.isMouseWheel(event);
-    if (fromWheel)
-        m_verticalTouchPadScroll.reset();
     const auto startValue = static_cast<int>(m_viewport.verticalOffset());
     const auto target =
-        fromWheel
-            ? EditorWheelUtils::scrollTarget(startValue, height(), 0.15,
-                                             EditorWheelUtils::wheelDelta(event, Qt::Vertical))
-            : m_verticalTouchPadScroll.scrollTarget(
-                  startValue, height(), 0.15, EditorWheelUtils::wheelDelta(event, Qt::Vertical));
+        EditorWheelUtils::scrollTarget(startValue, height(), 0.15, event, Qt::Vertical);
     m_viewport.scrollBy({0.0, target - m_viewport.verticalOffset()});
 }
 

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -427,7 +427,12 @@ void TracksRhiWidget::showEvent(QShowEvent *event) {
 }
 
 void TracksRhiWidget::hideEvent(QHideEvent *event) {
-    disarmDragAutoScroll();
+    if (m_dragMode != DragMode::None)
+        discardDrag();
+    else
+        disarmDragAutoScroll();
+    if (m_externalDragActive)
+        endExternalDropOverlay();
     EditorRhiWidget::hideEvent(event);
     updateAutoPageTurnAvailability();
 }

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -293,9 +293,7 @@ bool TracksRhiWidget::revealFocus(const HistoryFocus &focus, bool) {
     if (!selectedIds.isEmpty()) {
         syncSelection(selectedIds);
         trackController->setActiveClip(selectedIds.first());
-        const auto centerTick = m_viewport.sceneXToTick(bounds.center().x());
-        const auto centerTrack = bounds.center().y() / (trackHeight * scaleY()) - 0.5;
-        return centerAt(centerTick, centerTrack);
+        return m_viewport.ensureVisible(bounds, 24.0, 24.0);
     }
     int trackIndex = focus.trackIndex;
     if (focus.trackId >= 0)
@@ -304,7 +302,12 @@ bool TracksRhiWidget::revealFocus(const HistoryFocus &focus, bool) {
         trackIndex = qRound((focus.valueStart + focus.valueEnd) * 0.5);
     if (trackIndex < 0)
         return false;
-    return centerAt((focus.tickStart + focus.tickEnd) * 0.5, trackIndex);
+    const auto left = m_viewport.tickToSceneX(focus.tickStart);
+    const auto right = m_viewport.tickToSceneX(focus.tickEnd);
+    return m_viewport.ensureVisible(
+        QRectF(left, m_viewport.unitToSceneY(trackIndex), std::max(1.0, right - left),
+               trackHeight * scaleY()),
+        24.0, 24.0);
 }
 
 QRectF TracksRhiWidget::logicalVisibleRect() const {

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -27,6 +27,7 @@
 #include <QApplication>
 #include <QCoreApplication>
 #include <QContextMenuEvent>
+#include <QCursor>
 #include <QDragEnterEvent>
 #include <QDragLeaveEvent>
 #include <QDragMoveEvent>
@@ -139,7 +140,8 @@ TracksRhiWidget::TracksRhiWidget(QWidget *parent)
     m_viewport.setPixelsPerQuarterNote(pixelsPerQuarterNote);
     m_viewport.setScaleBounds(0.0001, 10000.0, 0.575, 8.0);
     m_viewport.setEnsureContentFillsViewport(true, false);
-    m_viewport.setContentTickRange(0.0, appStatus->projectEditableLength);
+    m_baseSceneLength = std::max(0, appStatus->projectEditableLength.get());
+    m_viewport.setContentTickRange(0.0, effectiveSceneLength());
     // One extra unit for the virtual append slot at the bottom of the canvas
     m_viewport.setVerticalContent(appModel->tracks().size() + 1, trackHeight);
 
@@ -167,6 +169,8 @@ TracksRhiWidget::TracksRhiWidget(QWidget *parent)
     });
     connect(&m_edgeAutoScroller, &EdgeAutoScroller::frame, this,
             &TracksRhiWidget::onExternalDropScrollFrame);
+    connect(&m_dragAutoScroller, &EdgeAutoScroller::frame, this,
+            &TracksRhiWidget::onDragAutoScrollFrame);
 
     connect(appModel, &AppModel::modelChanged, this, [this] {
         rebuildModelConnections();
@@ -324,8 +328,21 @@ double TracksRhiWidget::endTick() const {
 }
 
 void TracksRhiWidget::setSceneLength(const int tick) {
-    m_viewport.setContentTickRange(0.0, std::max(0, tick));
+    m_baseSceneLength = std::max(0, tick);
+    m_viewport.setContentTickRange(0.0, effectiveSceneLength());
     updateAutoPageTurnAvailability();
+}
+
+int TracksRhiWidget::effectiveSceneLength() const {
+    return m_baseSceneLength + m_sceneLengthExtension;
+}
+
+void TracksRhiWidget::setSceneLengthExtension(const int ticks) {
+    const auto extension = std::max(0, ticks);
+    if (m_sceneLengthExtension == extension)
+        return;
+    m_sceneLengthExtension = extension;
+    m_viewport.setContentTickRange(0.0, effectiveSceneLength());
 }
 
 void TracksRhiWidget::setLeftMarginPx(const double px) {
@@ -375,7 +392,7 @@ void TracksRhiWidget::setVerticalOffset(const double value) {
 void TracksRhiWidget::updateScrollBars() {
     if (!m_scrollBars)
         return;
-    m_scrollBars->setMetrics(QSizeF(m_viewport.tickToSceneX(appStatus->projectEditableLength),
+    m_scrollBars->setMetrics(QSizeF(m_viewport.tickToSceneX(effectiveSceneLength()),
                                     m_viewport.unitToSceneY(appModel->tracks().size() + 1)),
                              QPointF(m_viewport.horizontalOffset(), m_viewport.verticalOffset()),
                              QSizeF(std::max(1, width() / 10),
@@ -404,6 +421,7 @@ void TracksRhiWidget::showEvent(QShowEvent *event) {
 }
 
 void TracksRhiWidget::hideEvent(QHideEvent *event) {
+    disarmDragAutoScroll();
     EditorRhiWidget::hideEvent(event);
     updateAutoPageTurnAvailability();
 }
@@ -426,6 +444,7 @@ void TracksRhiWidget::wheelEvent(QWheelEvent *event) {
 
 void TracksRhiWidget::mousePressEvent(QMouseEvent *event) {
     setFocus(Qt::MouseFocusReason);
+    disarmDragAutoScroll();
     if (event->button() != Qt::LeftButton) {
         EditorRhiWidget::mousePressEvent(event);
         return;
@@ -452,26 +471,20 @@ void TracksRhiWidget::mousePressEvent(QMouseEvent *event) {
         m_rubberBandStart = m_viewport.viewportToScene(event->position());
         m_rubberBandEnd = m_rubberBandStart;
     }
+    prepareDragAutoScroll(event->position());
     scheduleSnapshot();
     event->accept();
 }
 
 void TracksRhiWidget::mouseMoveEvent(QMouseEvent *event) {
     if (m_dragMode == DragMode::RectSelect) {
-        m_rubberBandEnd = m_viewport.viewportToScene(event->position());
-        const auto dpr = devicePixelRatioF();
-        const QRectF selection(m_rubberBandStart * dpr, m_rubberBandEnd * dpr);
-        QList<int> ids;
-        for (const auto &clip : m_clipSnapshots)
-            if (selection.normalized().intersects(clip.physicalRect))
-                ids.append(clip.id);
-        syncSelection(ids);
-        scheduleSnapshot();
+        updateRubberBandSelection(event->position());
     } else if (m_dragMode != DragMode::None) {
         updateDrag(event->position(), event->modifiers());
     } else {
         updateCursor(event->position());
     }
+    updateDragAutoScrollState(event->position());
     event->accept();
 }
 
@@ -482,9 +495,99 @@ void TracksRhiWidget::mouseReleaseEvent(QMouseEvent *event) {
         } else if (m_dragMode != DragMode::None) {
             commitDrag();
         }
+        disarmDragAutoScroll();
+        setSceneLengthExtension(0);
         scheduleSnapshot();
     }
     event->accept();
+}
+
+void TracksRhiWidget::updateRubberBandSelection(const QPointF &position) {
+    m_rubberBandEnd = m_viewport.viewportToScene(position);
+    const auto dpr = devicePixelRatioF();
+    const QRectF selection(m_rubberBandStart * dpr, m_rubberBandEnd * dpr);
+    QList<int> ids;
+    for (const auto &clip : m_clipSnapshots)
+        if (selection.normalized().intersects(clip.physicalRect))
+            ids.append(clip.id);
+    syncSelection(ids);
+    scheduleSnapshot();
+}
+
+Qt::Orientations TracksRhiWidget::dragAutoScrollAxes() const {
+    if (m_dragMode == DragMode::Move || m_dragMode == DragMode::RectSelect)
+        return Qt::Horizontal | Qt::Vertical;
+    if (m_dragMode == DragMode::ResizeLeft || m_dragMode == DragMode::ResizeRight)
+        return Qt::Horizontal;
+    return {};
+}
+
+void TracksRhiWidget::prepareDragAutoScroll(const QPointF &pressPosition) {
+    disarmDragAutoScroll();
+    m_dragAutoScrollPressPos = pressPosition;
+}
+
+void TracksRhiWidget::disarmDragAutoScroll() {
+    m_dragAutoScrollArmed = false;
+    m_dragAutoScrollDistanceReached = false;
+    m_dragAutoScroller.stop();
+}
+
+void TracksRhiWidget::updateDragAutoScrollState(const QPointF &pointerPosition) {
+    const auto axes = dragAutoScrollAxes();
+    if (!axes) {
+        disarmDragAutoScroll();
+        return;
+    }
+
+    m_dragAutoScrollAxes = axes;
+    m_dragAutoScrollArmed = true;
+    if (!m_dragAutoScrollDistanceReached) {
+        if ((pointerPosition - m_dragAutoScrollPressPos).manhattanLength() <
+            QApplication::startDragDistance()) {
+            return;
+        }
+        m_dragAutoScrollDistanceReached = true;
+    }
+
+    const QRectF viewportRect(QPointF(), size());
+    const auto velocity = EdgeAutoScroller::velocity(pointerPosition, m_dragAutoScrollPressPos,
+                                                     viewportRect, m_dragAutoScrollAxes,
+                                                     m_dragAutoScroller.config());
+    if (!velocity.isNull())
+        m_dragAutoScroller.start();
+    else
+        m_dragAutoScroller.stop();
+}
+
+void TracksRhiWidget::onDragAutoScrollFrame(const double dtMs) {
+    if (!m_dragAutoScrollArmed || QGuiApplication::mouseButtons() == Qt::NoButton || !isVisible()) {
+        disarmDragAutoScroll();
+        return;
+    }
+
+    const QPointF pointerPosition(mapFromGlobal(QCursor::pos()));
+    const QRectF viewportRect(QPointF(), size());
+    const auto step = m_dragAutoScroller.computeStep(pointerPosition, m_dragAutoScrollPressPos,
+                                                     viewportRect, m_dragAutoScrollAxes, dtMs);
+    if (step.x() > 0 &&
+        (m_dragMode == DragMode::Move || m_dragMode == DragMode::ResizeRight)) {
+        const auto maximumOffset =
+            std::max(0.0, m_viewport.tickToSceneX(effectiveSceneLength()) - width());
+        if (m_viewport.horizontalOffset() >= maximumOffset - 1.0) {
+            const auto visibleTicks = std::max(1, qRound(endTick() - startTick()));
+            setSceneLengthExtension(m_sceneLengthExtension + visibleTicks);
+        }
+    }
+    if (!step.isNull())
+        m_viewport.scrollBy(step);
+
+    const auto clamped = EdgeAutoScroller::clampToRect(pointerPosition, viewportRect);
+    if (m_dragMode == DragMode::RectSelect)
+        updateRubberBandSelection(clamped);
+    else if (m_dragMode != DragMode::None)
+        updateDrag(clamped, QGuiApplication::queryKeyboardModifiers());
+    updateDragAutoScrollState(pointerPosition);
 }
 
 void TracksRhiWidget::mouseDoubleClickEvent(QMouseEvent *event) {
@@ -663,7 +766,7 @@ void TracksRhiWidget::appendDropOverlay(EditorRhiFrameData &frame, const double 
     if (!m_externalDragActive || !m_dropSlot)
         return;
     const auto slot = *m_dropSlot;
-    const auto sceneWidth = m_viewport.tickToSceneX(appStatus->projectEditableLength);
+    const auto sceneWidth = m_viewport.tickToSceneX(effectiveSceneLength());
     const auto trackHeightPx = trackHeight * scaleY();
     const auto top = slot.trackIndex * trackHeightPx;
     EditorRhiGeometry::appendRect(frame.solidVertices,
@@ -783,7 +886,7 @@ void TracksRhiWidget::rebuildModelConnections() {
 
 void TracksRhiWidget::appendGrid(EditorRhiFrameData &frame, const double dpr) const {
     const auto visible = m_viewport.visibleSceneRect();
-    const auto sceneWidth = m_viewport.tickToSceneX(appStatus->projectEditableLength);
+    const auto sceneWidth = m_viewport.tickToSceneX(effectiveSceneLength());
     if (appStatus->selectedTrackIndex >= 0) {
         const auto top = appStatus->selectedTrackIndex * trackHeight * scaleY();
         EditorRhiGeometry::appendRect(
@@ -1373,6 +1476,8 @@ void TracksRhiWidget::commitDrag() {
     m_dragMode = DragMode::None;
     m_dragMoved = false;
     appStatus->currentEditObject = AppStatus::EditObjectType::None;
+    disarmDragAutoScroll();
+    setSceneLengthExtension(0);
 }
 
 void TracksRhiWidget::discardDrag() {
@@ -1381,6 +1486,8 @@ void TracksRhiWidget::discardDrag() {
     m_dragMode = DragMode::None;
     m_dragMoved = false;
     appStatus->currentEditObject = AppStatus::EditObjectType::None;
+    disarmDragAutoScroll();
+    setSceneLengthExtension(0);
     scheduleSnapshot();
 }
 
@@ -1411,7 +1518,8 @@ void TracksRhiWidget::setAutoPageTurn(const bool enabled) {
 }
 
 void TracksRhiWidget::handleAutoPageTurn() {
-    if (!m_autoTurnPage || !m_autoPageTurnAvailable ||
+    if (!m_autoTurnPage || !m_autoPageTurnAvailable || m_dragAutoScroller.isRunning() ||
+        m_edgeAutoScroller.isRunning() ||
         appStatus->currentEditObject != AppStatus::EditObjectType::None) {
         return;
     }

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -14,6 +14,7 @@
 #include "UI/Utils/ITimelinePainter.h"
 #include "UI/Utils/SpeakerMixDisplayUtils.h"
 #include "UI/Views/Common/AutoPageTurnUtils.h"
+#include "UI/Views/Common/EditorResizeUtils.h"
 #include "UI/Views/Common/EditorRhiScrollBarController.h"
 #include "UI/Views/Common/EditorWheelUtils.h"
 
@@ -167,10 +168,12 @@ TracksRhiWidget::TracksRhiWidget(QWidget *parent)
         updateScrollBars();
         scheduleSnapshot();
     });
-    connect(&m_edgeAutoScroller, &EdgeAutoScroller::frame, this,
-            &TracksRhiWidget::onExternalDropScrollFrame);
-    connect(&m_dragAutoScroller, &EdgeAutoScroller::frame, this,
-            &TracksRhiWidget::onDragAutoScrollFrame);
+    connect(&m_edgeAutoScroller, &EdgeAutoScroller::frame, this, [this](const double dtMs) {
+        if (m_externalDragActive)
+            onExternalDropScrollFrame(dtMs);
+        else
+            onDragAutoScrollFrame(dtMs);
+    });
 
     connect(appModel, &AppModel::modelChanged, this, [this] {
         rebuildModelConnections();
@@ -508,11 +511,17 @@ void TracksRhiWidget::mouseReleaseEvent(QMouseEvent *event) {
 void TracksRhiWidget::updateRubberBandSelection(const QPointF &position) {
     m_rubberBandEnd = m_viewport.viewportToScene(position);
     const auto dpr = devicePixelRatioF();
-    const QRectF selection(m_rubberBandStart * dpr, m_rubberBandEnd * dpr);
+    const QRectF selection = QRectF(m_rubberBandStart * dpr, m_rubberBandEnd * dpr).normalized();
     QList<int> ids;
-    for (const auto &clip : m_clipSnapshots)
-        if (selection.normalized().intersects(clip.physicalRect))
-            ids.append(clip.id);
+    const auto &tracks = appModel->tracks();
+    for (int trackIndex = 0; trackIndex < tracks.size(); ++trackIndex) {
+        for (const auto *clip : tracks.at(trackIndex)->clips()) {
+            if (selection.intersects(
+                    clipPhysicalRect(previewOrModelProperties(clip), trackIndex, dpr))) {
+                ids.append(clip->id());
+            }
+        }
+    }
     syncSelection(ids);
     scheduleSnapshot();
 }
@@ -526,14 +535,11 @@ Qt::Orientations TracksRhiWidget::dragAutoScrollAxes() const {
 }
 
 void TracksRhiWidget::prepareDragAutoScroll(const QPointF &pressPosition) {
-    disarmDragAutoScroll();
-    m_dragAutoScrollPressPos = pressPosition;
+    m_edgeAutoScroller.prepareDrag(pressPosition);
 }
 
 void TracksRhiWidget::disarmDragAutoScroll() {
-    m_dragAutoScrollArmed = false;
-    m_dragAutoScrollDistanceReached = false;
-    m_dragAutoScroller.stop();
+    m_edgeAutoScroller.stopDrag();
 }
 
 void TracksRhiWidget::updateDragAutoScrollState(const QPointF &pointerPosition) {
@@ -543,36 +549,22 @@ void TracksRhiWidget::updateDragAutoScrollState(const QPointF &pointerPosition) 
         return;
     }
 
-    m_dragAutoScrollAxes = axes;
-    m_dragAutoScrollArmed = true;
-    if (!m_dragAutoScrollDistanceReached) {
-        if ((pointerPosition - m_dragAutoScrollPressPos).manhattanLength() <
-            QApplication::startDragDistance()) {
-            return;
-        }
-        m_dragAutoScrollDistanceReached = true;
-    }
-
     const QRectF viewportRect(QPointF(), size());
-    const auto velocity = EdgeAutoScroller::velocity(pointerPosition, m_dragAutoScrollPressPos,
-                                                     viewportRect, m_dragAutoScrollAxes,
-                                                     m_dragAutoScroller.config());
-    if (!velocity.isNull())
-        m_dragAutoScroller.start();
-    else
-        m_dragAutoScroller.stop();
+    m_edgeAutoScroller.setDragAxes(axes);
+    m_edgeAutoScroller.updateDragState(pointerPosition, viewportRect,
+                                       QApplication::startDragDistance());
 }
 
 void TracksRhiWidget::onDragAutoScrollFrame(const double dtMs) {
-    if (!m_dragAutoScrollArmed || QGuiApplication::mouseButtons() == Qt::NoButton || !isVisible()) {
+    if (!m_edgeAutoScroller.isDragArmed() || QGuiApplication::mouseButtons() == Qt::NoButton ||
+        !isVisible()) {
         disarmDragAutoScroll();
         return;
     }
 
     const QPointF pointerPosition(mapFromGlobal(QCursor::pos()));
     const QRectF viewportRect(QPointF(), size());
-    const auto step = m_dragAutoScroller.computeStep(pointerPosition, m_dragAutoScrollPressPos,
-                                                     viewportRect, m_dragAutoScrollAxes, dtMs);
+    const auto step = m_edgeAutoScroller.computeDragStep(pointerPosition, viewportRect, dtMs);
     if (step.x() > 0 &&
         (m_dragMode == DragMode::Move || m_dragMode == DragMode::ResizeRight)) {
         const auto maximumOffset =
@@ -656,6 +648,7 @@ void TracksRhiWidget::contextMenuEvent(QContextMenuEvent *event) {
 void TracksRhiWidget::dragEnterEvent(QDragEnterEvent *event) {
     if (event->mimeData()->hasUrls()) {
         event->acceptProposedAction();
+        m_edgeAutoScroller.stopDrag();
         m_externalDragActive = true;
         m_dropScrollDistanceReached = false;
         m_dropDragStartPos = event->position();
@@ -725,7 +718,7 @@ void TracksRhiWidget::endExternalDropOverlay() {
     m_externalDragActive = false;
     m_dropSlot.reset();
     m_dropScrollDistanceReached = false;
-    m_edgeAutoScroller.stop();
+    m_edgeAutoScroller.stopDrag();
     scheduleSnapshot();
 }
 
@@ -1222,11 +1215,7 @@ TracksRhiWidget::ClipSnapshot TracksRhiWidget::buildClipSnapshot(const Clip *cli
     result.visibleEndTick = result.visibleStartTick + props.clipLen;
     result.selected = appStatus->selectedClips.get().contains(clip->id());
     result.active = appStatus->activeClipId == clip->id();
-    const auto left = m_viewport.tickToSceneX(props.start + props.clipStart) * dpr;
-    const auto right = m_viewport.tickToSceneX(props.start + props.clipStart + props.clipLen) * dpr;
-    result.physicalRect = QRectF(left, displayTrack * trackHeight * scaleY() * dpr, right - left,
-                                 trackHeight * scaleY() * dpr)
-                              .adjusted(0.6 * dpr, 1.2 * dpr, -0.6 * dpr, -1.2 * dpr);
+    result.physicalRect = clipPhysicalRect(props, displayTrack, dpr);
     result.title = commonClipTitle(props, clip->id(), scaleX(), scaleY());
     if (const auto audio = qobject_cast<const AudioClip *>(clip))
         result.audioMissing = audio->pathStatus() == AudioClip::PathStatus::Missing;
@@ -1243,6 +1232,16 @@ TracksRhiWidget::ClipSnapshot TracksRhiWidget::buildClipSnapshot(const Clip *cli
             result.notes.append({note->localStart(), note->length(), note->keyIndex()});
     }
     return result;
+}
+
+QRectF TracksRhiWidget::clipPhysicalRect(const Clip::ClipCommonProperties &properties,
+                                         const int trackIndex, const double dpr) const {
+    const auto left = m_viewport.tickToSceneX(properties.start + properties.clipStart) * dpr;
+    const auto right =
+        m_viewport.tickToSceneX(properties.start + properties.clipStart + properties.clipLen) * dpr;
+    return QRectF(left, trackIndex * trackHeight * scaleY() * dpr, right - left,
+                  trackHeight * scaleY() * dpr)
+        .adjusted(0.6 * dpr, 1.2 * dpr, -0.6 * dpr, -1.2 * dpr);
 }
 
 QRectF TracksRhiWidget::clipPreviewRect(const ClipSnapshot &clip, const double dpr) {
@@ -1379,9 +1378,11 @@ void TracksRhiWidget::beginClipDrag(const ClipSnapshot &clip, const QMouseEvent 
     const auto physicalScene = m_viewport.viewportToScene(event->position()) * devicePixelRatioF();
     const auto relativeX = physicalScene.x() - clip.physicalRect.left();
     const auto tolerance = AppGlobal::resizeTolerance * devicePixelRatioF();
-    if (relativeX <= tolerance)
+    const auto edge =
+        EditorResizeUtils::horizontalEdgeAt(relativeX, clip.physicalRect.width(), tolerance);
+    if (edge == EditorResizeUtils::HorizontalEdge::Left)
         m_dragMode = DragMode::ResizeLeft;
-    else if (relativeX >= clip.physicalRect.width() - tolerance)
+    else if (edge == EditorResizeUtils::HorizontalEdge::Right)
         m_dragMode = DragMode::ResizeRight;
     else
         m_dragMode = DragMode::Move;
@@ -1509,9 +1510,10 @@ void TracksRhiWidget::updateCursor(const QPointF &position) {
     const auto physical = m_viewport.viewportToScene(position).x() * devicePixelRatioF();
     const auto relative = physical - clip->physicalRect.left();
     const auto tolerance = AppGlobal::resizeTolerance * devicePixelRatioF();
-    setCursor(relative <= tolerance || relative >= clip->physicalRect.width() - tolerance
-                  ? Qt::SizeHorCursor
-                  : Qt::ArrowCursor);
+    const auto edge =
+        EditorResizeUtils::horizontalEdgeAt(relative, clip->physicalRect.width(), tolerance);
+    setCursor(edge == EditorResizeUtils::HorizontalEdge::None ? Qt::ArrowCursor
+                                                              : Qt::SizeHorCursor);
 }
 
 void TracksRhiWidget::setAutoPageTurn(const bool enabled) {
@@ -1521,8 +1523,7 @@ void TracksRhiWidget::setAutoPageTurn(const bool enabled) {
 }
 
 void TracksRhiWidget::handleAutoPageTurn() {
-    if (!m_autoTurnPage || !m_autoPageTurnAvailable || m_dragAutoScroller.isRunning() ||
-        m_edgeAutoScroller.isRunning() ||
+    if (!m_autoTurnPage || !m_autoPageTurnAvailable || m_edgeAutoScroller.isRunning() ||
         appStatus->currentEditObject != AppStatus::EditObjectType::None) {
         return;
     }

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
@@ -173,6 +173,7 @@ private:
     [[nodiscard]] int snapTick(int tick) const;
     void beginClipDrag(const ClipSnapshot &clip, const QMouseEvent *event);
     void updateDrag(const QPointF &position, Qt::KeyboardModifiers modifiers);
+    void updateRubberBandSelection(const QPointF &position);
     void commitDrag();
     void discardDrag();
     void syncSelection(const QList<int> &ids, int preferredTrack = -1) const;
@@ -180,7 +181,14 @@ private:
     void handleAutoPageTurn();
     void updateAutoPageTurnAvailability();
     void updateScrollBars();
+    [[nodiscard]] int effectiveSceneLength() const;
+    void setSceneLengthExtension(int ticks);
     [[nodiscard]] Clip::ClipCommonProperties previewOrModelProperties(const Clip *clip) const;
+    [[nodiscard]] Qt::Orientations dragAutoScrollAxes() const;
+    void prepareDragAutoScroll(const QPointF &pressPosition);
+    void disarmDragAutoScroll();
+    void updateDragAutoScrollState(const QPointF &pointerPosition);
+    void onDragAutoScrollFrame(double dtMs);
 
     // --- External file drag-and-drop (Phase 1) ---
     // Resolves the drop slot at the given viewport position, hitting either a
@@ -231,6 +239,8 @@ private:
     bool m_autoTurnPage = true;
     bool m_autoPageTurnAvailable = false;
     double m_leftMarginPx = 0.0;
+    int m_baseSceneLength = 0;
+    int m_sceneLengthExtension = 0;
     DragMode m_dragMode = DragMode::None;
     QPointF m_mouseDownScene;
     QPointF m_rubberBandStart;
@@ -240,6 +250,11 @@ private:
     Clip::ClipCommonProperties m_mouseDownProperties;
     int m_mouseDownTrackIndex = -1;
     bool m_dragMoved = false;
+    EdgeAutoScroller m_dragAutoScroller;
+    Qt::Orientations m_dragAutoScrollAxes;
+    QPointF m_dragAutoScrollPressPos;
+    bool m_dragAutoScrollArmed = false;
+    bool m_dragAutoScrollDistanceReached = false;
 
     // External file drag-and-drop state (Phase 1)
     bool m_externalDragActive = false;

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
@@ -162,6 +162,8 @@ private:
     void appendDropOverlay(EditorRhiFrameData &frame, double dpr) const;
     [[nodiscard]] ClipSnapshot buildClipSnapshot(const Clip *clip, int trackIndex,
                                                  double dpr) const;
+    [[nodiscard]] QRectF clipPhysicalRect(const Clip::ClipCommonProperties &properties,
+                                          int trackIndex, double dpr) const;
     [[nodiscard]] static QRectF clipPreviewRect(const ClipSnapshot &clip, double dpr);
     [[nodiscard]] AudioWaveformSampler::Result sampleAudioWaveform(AudioWaveformSampler &sampler,
                                                                    const AudioInfoModel &audioInfo,
@@ -250,11 +252,6 @@ private:
     Clip::ClipCommonProperties m_mouseDownProperties;
     int m_mouseDownTrackIndex = -1;
     bool m_dragMoved = false;
-    EdgeAutoScroller m_dragAutoScroller;
-    Qt::Orientations m_dragAutoScrollAxes;
-    QPointF m_dragAutoScrollPressPos;
-    bool m_dragAutoScrollArmed = false;
-    bool m_dragAutoScrollDistanceReached = false;
 
     // External file drag-and-drop state (Phase 1)
     bool m_externalDragActive = false;

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
@@ -219,8 +219,6 @@ private:
 
     EditorViewportController m_viewport;
     EditorGlyphAtlas m_glyphAtlas;
-    EditorWheelUtils::InputState m_wheelInputState;
-    EditorWheelUtils::ScrollAccumulator m_verticalTouchPadScroll;
     EditorRhiScrollBarController *m_scrollBars = nullptr;
     QHash<int, std::shared_ptr<AudioWaveformSampler>> m_audioWaveformSamplers;
     QVector<ClipSnapshot> m_clipSnapshots;

--- a/src/tests/TestEdgeAutoScroll/main.cpp
+++ b/src/tests/TestEdgeAutoScroll/main.cpp
@@ -249,6 +249,28 @@ int main(int argc, char *argv[]) {
                "computeStep scrolls right after crossing into the right zone");
     }
 
+    // --- Shared drag-session lifecycle ---
+    {
+        EdgeAutoScroller scroller;
+        const QPointF press(400, 300);
+        scroller.prepareDrag(press, bothAxes);
+        expect(scroller.isDragArmed() && !scroller.isRunning(),
+               "preparing a drag arms its axes without starting the timer");
+
+        scroller.updateDragState(QPointF(405, 300), vp, 10);
+        expect(!scroller.isRunning(), "movement below the drag threshold must not start scrolling");
+
+        scroller.updateDragState(QPointF(790, 300), vp, 10);
+        expect(scroller.isRunning(), "entering a hot zone after the threshold starts scrolling");
+        const auto step = scroller.computeDragStep(QPointF(790, 300), vp, 16);
+        expect(step.x() > 0 && step.y() == 0,
+               "drag-session steps reuse the stored press position and axes");
+
+        scroller.stopDrag();
+        expect(!scroller.isDragArmed() && !scroller.isRunning(),
+               "stopping a drag clears both session and runner state");
+    }
+
     // --- Pointer clamping ---
     {
         const auto c1 = EdgeAutoScroller::clampToRect(QPointF(-100, 300), vp);

--- a/src/tests/TestScrollBarInterplay/main.cpp
+++ b/src/tests/TestScrollBarInterplay/main.cpp
@@ -118,21 +118,6 @@ int main(int argc, char *argv[]) {
     expect(!rhiHorizontal->isVisible() && !rhiVertical->isVisible(),
            "subpixel layout noise must not create a false RHI scroll range");
 
-    auto wheelOffset = 0;
-    for (int i = 0; i < 5; ++i)
-        wheelOffset = EditorWheelUtils::scrollTarget(wheelOffset, 192, 0.15, -120.0);
-    expect(wheelOffset == 140,
-           "RHI wheel scrolling must retain the legacy integer target semantics");
-
-    EditorWheelUtils::ScrollAccumulator touchPadScroll;
-    wheelOffset = 0;
-    for (const auto delta : {-7.0, -206.0, -168.0, -149.0, -111.0, -91.0, -69.0, -60.0, -46.0,
-                             -36.0, -28.0, -22.0, -14.0, -8.0, -2.0}) {
-        wheelOffset = touchPadScroll.scrollTarget(wheelOffset, 325, 0.15, delta);
-    }
-    expect(wheelOffset == 406,
-           "touchpad scrolling must retain fractional wheel deltas across an event burst");
-
     QWheelEvent angleWheel(QPointF(10, 10), QPointF(10, 10), {}, QPoint(120, -240), Qt::NoButton,
                            Qt::NoModifier, Qt::NoScrollPhase, false);
     expect(EditorWheelUtils::wheelDelta(&angleWheel, Qt::Horizontal) == 120.0 &&
@@ -143,27 +128,34 @@ int main(int argc, char *argv[]) {
     expect(EditorWheelUtils::wheelDelta(&pixelWheel, Qt::Horizontal) == 12.0 &&
                EditorWheelUtils::wheelDelta(&pixelWheel, Qt::Vertical) == -20.0,
            "shared wheel delta extraction must preserve pixel-only touchpad input");
+    expect(EditorWheelUtils::scrollTarget(100, 192, 0.15, &pixelWheel, Qt::Horizontal) == 97 &&
+               EditorWheelUtils::scrollTarget(100, 192, 0.15, &pixelWheel, Qt::Vertical) == 105,
+           "touchpad scrolling must apply pixel displacement directly");
     EditorWheelUtils::InputState pixelInputState;
     expect(!pixelInputState.isMouseWheel(&pixelWheel),
-           "pixel-only wheel events must use touchpad accumulation semantics");
-    QWheelEvent combinedWheel(QPointF(10, 10), QPointF(10, 10), QPoint(3, -5),
-                              QPoint(120, -240), Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate,
+           "pixel-only wheel events must use touchpad direct-scroll semantics");
+    QWheelEvent combinedWheel(QPointF(10, 10), QPointF(10, 10), QPoint(0, -120),
+                              QPoint(0, -120), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase,
                               false);
-    expect(EditorWheelUtils::wheelDelta(&combinedWheel, Qt::Horizontal) == 12.0 &&
-               EditorWheelUtils::wheelDelta(&combinedWheel, Qt::Vertical) == -20.0,
-           "precision touchpad events must prefer pixel displacement over angle deltas");
+    expect(EditorWheelUtils::wheelDelta(&combinedWheel, Qt::Vertical) == -120.0,
+           "mouse wheels with both delta forms must retain their angle-step magnitude");
+    expect(EditorWheelUtils::scrollTarget(100, 192, 0.15, &combinedWheel, Qt::Vertical) == 128,
+           "one mouse wheel event must retain the legacy viewport-relative distance");
     EditorWheelUtils::InputState combinedInputState;
-    expect(!combinedInputState.isMouseWheel(&combinedWheel),
-           "events with pixel displacement must retain touchpad input semantics");
-    QWheelEvent horizontalTouchPad(QPointF(10, 10), QPointF(10, 10), QPoint(5, 0),
-                                   QPoint(0, -120), Qt::NoButton, Qt::NoModifier,
-                                   Qt::ScrollUpdate, false);
+    expect(combinedInputState.isMouseWheel(&combinedWheel),
+           "a discrete mouse wheel must not be reclassified by an auxiliary pixel delta");
+    QWheelEvent horizontalTouchPad(QPointF(10, 10), QPointF(10, 10), QPoint(5, 0), {},
+                                   Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
     expect(EditorWheelUtils::dominantAxis(&horizontalTouchPad) == Qt::Horizontal &&
-               EditorWheelUtils::horizontalScrollDelta(&horizontalTouchPad) == 20.0,
+               EditorWheelUtils::scrollTarget(100, 192, 0.2, &horizontalTouchPad,
+                                              EditorWheelUtils::horizontalScrollAxis(
+                                                  &horizontalTouchPad)) == 95,
            "unmodified horizontal touchpad gestures must retain their natural scroll axis");
     QWheelEvent shiftedWheel(QPointF(10, 10), QPointF(10, 10), {}, QPoint(0, -120), Qt::NoButton,
                              Qt::ShiftModifier, Qt::NoScrollPhase, false);
-    expect(EditorWheelUtils::horizontalScrollDelta(&shiftedWheel) == -120.0,
+    expect(EditorWheelUtils::scrollTarget(100, 200, 0.2, &shiftedWheel,
+                                          EditorWheelUtils::horizontalScrollAxis(&shiftedWheel)) ==
+               140,
            "Shift-wheel gestures must continue mapping the vertical wheel to horizontal scroll");
 
     EditorViewportController marginViewport;

--- a/src/tests/TestScrollBarInterplay/main.cpp
+++ b/src/tests/TestScrollBarInterplay/main.cpp
@@ -185,6 +185,28 @@ int main(int argc, char *argv[]) {
                qFuzzyCompare(viewport.verticalOffset(), 140.0),
            "resizing must clamp preserved offsets to the new scroll range");
 
+    EditorViewportController focusViewport;
+    focusViewport.setEnsureContentFillsViewport(false, false);
+    focusViewport.setContentTickRange(0, 30000);
+    focusViewport.setVerticalContent(20, 72);
+    focusViewport.setViewportSize(QSizeF(800, 300));
+    focusViewport.scrollBy(QPointF(300, 400));
+    int focusViewportChanges = 0;
+    QObject::connect(&focusViewport, &EditorViewportController::viewportChanged, &rhiViewport,
+                     [&focusViewportChanges] { ++focusViewportChanges; });
+    expect(focusViewport.ensureVisible(QRectF(500, 500, 100, 50), 24, 24) &&
+               qFuzzyCompare(focusViewport.horizontalOffset(), 300.0) &&
+               qFuzzyCompare(focusViewport.verticalOffset(), 400.0) && focusViewportChanges == 0,
+           "revealing an already visible RHI focus must not move or notify the viewport");
+    expect(focusViewport.ensureVisible(QRectF(1050, 680, 100, 40), 24, 24) &&
+               qFuzzyCompare(focusViewport.horizontalOffset(), 374.0) &&
+               qFuzzyCompare(focusViewport.verticalOffset(), 444.0) && focusViewportChanges == 1,
+           "revealing an obscured RHI focus must scroll only the minimum required distance");
+    expect(focusViewport.ensureVisible(QRectF(320, 420, 10, 10), 24, 24) &&
+               qFuzzyCompare(focusViewport.horizontalOffset(), 296.0) &&
+               qFuzzyCompare(focusViewport.verticalOffset(), 396.0) && focusViewportChanges == 2,
+           "revealing toward the leading edges must preserve the requested margin");
+
     if (g_failures == 0) {
         QTextStream(stdout) << "All ScrollBarInterplay tests passed" << Qt::endl;
         return 0;

--- a/src/tests/TestTrackEditorInteractions/main.cpp
+++ b/src/tests/TestTrackEditorInteractions/main.cpp
@@ -1,6 +1,7 @@
 #include "UI/Views/TrackEditor/AudioClipDragState.h"
 #include "UI/Views/TrackEditor/ClipResizeUtils.h"
 #include "UI/Views/TrackEditor/SingingClipPreviewLayout.h"
+#include "UI/Views/Common/EditorResizeUtils.h"
 #include "Global/AppGlobal.h"
 
 #include <lite/MusicBase/Timeline.h>
@@ -29,6 +30,14 @@ namespace {
 
 int main(int argc, char *argv[]) {
     QCoreApplication app(argc, argv);
+
+    using EditorResizeUtils::HorizontalEdge;
+    expect(EditorResizeUtils::horizontalEdgeAt(4.0, 100.0, 6.0) == HorizontalEdge::Left &&
+               EditorResizeUtils::horizontalEdgeAt(96.0, 100.0, 6.0) == HorizontalEdge::Right &&
+               EditorResizeUtils::horizontalEdgeAt(50.0, 100.0, 6.0) == HorizontalEdge::None,
+           "note and clip resize handles must share the same horizontal edge hit test");
+    expect(EditorResizeUtils::horizontalEdgeAt(5.0, 8.0, 6.0) == HorizontalEdge::Left,
+           "overlapping resize handles must retain left-edge precedence");
 
     Clip::ClipCommonProperties singing;
     singing.length = 1920;


### PR DESCRIPTION
## Summary

- restore legacy mouse-wheel scrolling and zoom scaling for both classic and RHI editors while preserving direct touchpad pixel scrolling
- restore edge auto-scroll arming in classic editors and add the missing RHI paths for note, pitch, anchor, selection, and clip drag/resize operations
- align RHI undo/redo focus reveal with the classic backend's minimal-scroll behavior
- restore RHI note resize hit tolerance, cursor feedback, and edit-mode isolation to match the classic backend

## Root cause

The merged RHI work exposed several interaction paths whose behavior had drifted from the classic backend:

- shared wheel normalization preferred and multiplied `pixelDelta` even when a normal mouse also supplied a valid `angleDelta`
- classic edge scrolling captured the first move position instead of the original press position, while multiple RHI drag paths were never connected to edge scrolling
- RHI history focus reveal always centered its target instead of scrolling only when necessary
- RHI note resize used a hard-coded 6 px hit area, omitted the classic resize cursor, and allowed pitch modes to fall through to note manipulation

## Validation

- Debug preset `DsEditorLite` build passed
- targeted interaction tests passed: `TestEdgeAutoScroll`, `TestScrollBarInterplay`, `TestEditorViewController`, `TestUndoRedoController`, and `TestTrackEditorInteractions`
- full CTest: 25/26 passed; the only failure is the existing `TestAnimationSettings` six-assertion animation timing/state baseline failure, unchanged from `origin/main`
- GUI checks covered both rendering backends, wheel feel, edge dragging, RHI undo focus behavior, note resize from both edges, edit-mode isolation, and clip resize
- final behavior was manually checked before publication