### PR TITLE
fix(rhi): prevent clipped titles on narrow tracks

### DIFF
--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -1003,7 +1003,7 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
                                        (clip.physicalRect.height() - metrics.height() * dpr) * 0.5;
         const QRectF textClip(titleLeft + iconWidth * dpr, clip.physicalRect.top(),
                               titleWidth - iconWidth * dpr,
-                              std::min(titleHeight, clip.physicalRect.height()));
+                              hasPreview ? titleHeight : clip.physicalRect.height());
         const auto textSpan = m_glyphAtlas.appendText(
             clip.title, font, QPointF(titleLeft + iconWidth * dpr, textTop), foreground, textClip,
             dpr, QPointF(m_viewport.horizontalOffset(), m_viewport.verticalOffset()) * dpr,


### PR DESCRIPTION
## Summary

- let narrow RHI clips use the full clip height as the title glyph clip region
- keep the existing 20 px title-band clipping when a clip preview is visible
- preserve the legacy QGraphicsView layout behavior without introducing a second rendering path

## Root cause

The narrow-track RHI path vertically centers the title across the full clip, but its glyph-atlas clip region remained limited to the 20 px title band at the top. The stricter RHI text rasterization introduced by `4316e65d` exposed that mismatch and clipped the lower half of the title. The legacy backend already clips against the full narrow clip height.

## Validation

- debug ConfigureAndBuild through the repository CMake preset helper
- `TestEditorGlyphAtlas` (Qt offscreen): passed
- QRhiWidget backend at vertical scale 0.575: title remains fully visible and centered
- legacy QGraphicsView backend at vertical scale 0.575: title remains fully visible and centered