### PR TITLE
fix(rhi): clear note selection in pitch modes

### DIFF
--- a/src/app/Interface/EditorViewState.h
+++ b/src/app/Interface/EditorViewState.h
@@ -17,6 +17,11 @@ namespace EditorViewGlobal {
         FreezePitch
     };
 
+    [[nodiscard]] constexpr bool isPitchEditMode(const PianoRollEditMode mode) noexcept {
+        return mode == DrawPitch || mode == EditPitchAnchor || mode == ErasePitch ||
+               mode == FreezePitch;
+    }
+
 } // namespace EditorViewGlobal
 
 struct TrackPanelViewState {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -1391,8 +1391,6 @@ void PianoRollGraphicsViewPrivate::setPitchEditMode(const bool on, const bool is
     m_isEditPitchMode = on;
     for (const auto note : noteViews)
         note->setEditingPitch(on);
-    if (on)
-        q->clearNoteSelections();
     m_pitchEditor->setTransparentMouseEvents(!on);
     m_pitchEditor->setEraseMode(isErase);
 }

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -2067,8 +2067,7 @@ private:
         const auto normalForeground = palette->noteForeground(trackColorIndex);
         const auto overlappedForeground = palette->noteForegroundOverlapped(trackColorIndex);
         const auto editingForeground = palette->noteForegroundEditingPitch(trackColorIndex);
-        const auto editingPitch = editMode == DrawPitch || editMode == EditPitchAnchor ||
-                                  editMode == ErasePitch || editMode == FreezePitch;
+        const auto editingPitch = EditorViewGlobal::isPitchEditMode(editMode);
         const auto selectedNotes = appStatus->selectedNotes.get();
         for (const auto *note : clip->notes()) {
             if (erasedNoteIds.contains(note->id()))

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
@@ -6,6 +6,7 @@
 #include "PianoRollContextMenuController.h"
 #include "PianoRollRhiWidget.h"
 #include "PhonemeView.h"
+#include "Controller/ClipController.h"
 #include "Model/AppOptions/AppOptions.h"
 #include "Model/AppStatus/AppStatus.h"
 #include "UI/Views/Common/TimeGraphicsView.h"
@@ -216,7 +217,7 @@ void PianoRollView::fallbackToLegacy() {
     failedView->deleteLater();
     connectLegacyBackend();
     m_graphicsView->setDataContext(m_clip);
-    m_graphicsView->setEditMode(m_editMode);
+    onEditModeChanged(m_editMode);
     QTimer::singleShot(0, this, [this, state] {
         setViewScale(state.horizontalScale, state.verticalScale);
         centerAt(state.centerTick, state.centerKeyIndex);
@@ -251,6 +252,8 @@ void PianoRollView::onEditModeChanged(const PianoRollEditMode mode) const {
         m_rhiView->setEditMode(mode);
     else
         m_graphicsView->setEditMode(mode);
+    if (EditorViewGlobal::isPitchEditMode(mode))
+        clipController->selectNotes({}, true);
 }
 
 void PianoRollView::setTrackColorIndex(int index) const {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PitchDisplayStrategy.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PitchDisplayStrategy.cpp
@@ -69,12 +69,10 @@ void PitchDisplayStrategy::MergedCurveCache::invalidate() {
 
 PitchDisplayMode PitchDisplayStrategy::displayModeForEditMode(
     const EditorViewGlobal::PianoRollEditMode editMode) {
-    if (editMode == EditorViewGlobal::DrawPitch || editMode == EditorViewGlobal::ErasePitch ||
-        editMode == EditorViewGlobal::FreezePitch) {
-        return PitchDisplayMode::Draw;
-    }
     if (editMode == EditorViewGlobal::EditPitchAnchor)
         return PitchDisplayMode::Anchor;
+    if (EditorViewGlobal::isPitchEditMode(editMode))
+        return PitchDisplayMode::Draw;
     return PitchDisplayMode::Final;
 }
 

--- a/src/tests/TestPitchDisplayStrategy/main.cpp
+++ b/src/tests/TestPitchDisplayStrategy/main.cpp
@@ -40,6 +40,19 @@ namespace {
                "anchor mode must use the anchor pitch presentation");
     }
 
+    void testPitchEditModeClassification() {
+        using namespace EditorViewGlobal;
+        expect(!isPitchEditMode(Select), "selection mode must not edit pitch");
+        expect(!isPitchEditMode(IntervalSelect), "interval selection mode must not edit pitch");
+        expect(!isPitchEditMode(DrawNote), "note drawing mode must not edit pitch");
+        expect(!isPitchEditMode(EraseNote), "note erase mode must not edit pitch");
+        expect(!isPitchEditMode(SplitNote), "note split mode must not edit pitch");
+        expect(isPitchEditMode(DrawPitch), "pitch drawing mode must edit pitch");
+        expect(isPitchEditMode(EditPitchAnchor), "pitch anchor mode must edit pitch");
+        expect(isPitchEditMode(ErasePitch), "pitch erase mode must edit pitch");
+        expect(isPitchEditMode(FreezePitch), "pitch freeze mode must edit pitch");
+    }
+
     void testDisplayLayers() {
         DrawCurve edited;
         edited.setLocalStart(10);
@@ -140,6 +153,7 @@ namespace {
 int main(int argc, char *argv[]) {
     QCoreApplication app(argc, argv);
     testDisplayModeMapping();
+    testPitchEditModeClassification();
     testDisplayLayers();
     testAnchorCoverage();
     testCurveSampling();


### PR DESCRIPTION
## 问题

RHI 钢琴卷帘切换到音高绘制模式时没有清除已选音符，导致返回选择模式后剪切、复制、删除等命令仍保持可用；旧版 QGraphicsView 后端没有这个问题。

## 原因与修复

- RHI 音高绘制支持引入 `PianoRollRhiWidget::setEditMode()` 时，遗漏了旧版 `setPitchEditMode()` 中的全局音符选择清理。
- 将“是否为音高编辑模式”的判断集中到 `EditorViewState`，由 `PianoRollView` 的共享模式切换路径在后端完成当前交互后统一清除选择。
- 旧版后端移除重复清理逻辑；RHI 绘制与音高显示策略复用同一模式分类，避免后续行为分叉。
- 为全部钢琴卷帘编辑模式补充分类测试。

## 验证

- `powershell -NoProfile -ExecutionPolicy Bypass -File .agents/skills/scripts/run-cmake-preset.ps1 -Mode ConfigureAndBuild -Preset debug`
- `build/Debug/out/bin/TestPitchDisplayStrategy.exe`
- Computer Use：RHI (`PianoRollRhiWidget`) 与 Legacy (`PianoRollGraphicsView`) 均验证选中音符后切换音高绘制模式会清除选择，剪切/复制/删除等菜单项变为禁用。