### PR TITLE
perf(options): lazily initialize settings pages

### DIFF
--- a/src/app/UI/Dialogs/Options/AppOptionsDialog.cpp
+++ b/src/app/UI/Dialogs/Options/AppOptionsDialog.cpp
@@ -43,31 +43,12 @@ AppOptionsDialog::AppOptionsDialog(QWidget *parent, const bool standalone)
     m_sidebar->setFixedWidth(m_tabList->minimumWidth() + sidebarLayout->contentsMargins().left()
                              + sidebarLayout->contentsMargins().right());
 
-    m_generalPage = new GeneralPage;
-    m_audioPage = new AudioPage;
-    m_midiPage = new MidiPage;
-    m_appearancePage = new AppearancePage;
-    m_inferencePage = new InferencePage;
-    m_developerPage = new DeveloperPage;
-
     m_pageContent = new QStackedWidget;
-    m_pageContent->addWidget(m_generalPage);
-    m_pageContent->addWidget(m_audioPage);
-    m_pageContent->addWidget(m_midiPage);
-    m_pageContent->addWidget(m_appearancePage);
-    m_pageContent->addWidget(m_inferencePage);
-    m_pageContent->addWidget(m_developerPage);
     m_pageContent->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
     m_pageContent->setMinimumWidth(600);
 
-    m_pages.append(m_generalPage);
-    m_pages.append(m_audioPage);
-    m_pages.append(m_midiPage);
-    m_pages.append(m_appearancePage);
-    m_pages.append(m_inferencePage);
-    m_pages.append(m_developerPage);
-
     retranslateUi();
+    m_pages.resize(m_tabList->count());
 
     const auto body = new QWidget;
     body->setContentsMargins({});
@@ -108,8 +89,44 @@ int AppOptionsDialog::showStandaloneDialog(const AppOptionsGlobal::Option option
     return result;
 }
 
-void AppOptionsDialog::onSelectionChanged(const int index) const {
-    m_pageContent->setCurrentWidget(m_pages.at(index));
+void AppOptionsDialog::onSelectionChanged(const int index) {
+    if (auto *page = ensurePage(index))
+        m_pageContent->setCurrentWidget(page);
+}
+
+IOptionPage *AppOptionsDialog::ensurePage(const int index) {
+    if (index < 0 || index >= m_pages.size())
+        return nullptr;
+    if (m_pages.at(index))
+        return m_pages.at(index);
+
+    IOptionPage *page = nullptr;
+    switch (static_cast<AppOptionsGlobal::Option>(index + 1)) {
+        case AppOptionsGlobal::General:
+            page = new GeneralPage;
+            break;
+        case AppOptionsGlobal::Audio:
+            page = new AudioPage;
+            break;
+        case AppOptionsGlobal::Midi:
+            page = new MidiPage;
+            break;
+        case AppOptionsGlobal::Appearance:
+            page = new AppearancePage;
+            break;
+        case AppOptionsGlobal::Inference:
+            page = new InferencePage;
+            break;
+        case AppOptionsGlobal::DeveloperOptions:
+            page = new DeveloperPage;
+            break;
+        default:
+            return nullptr;
+    }
+
+    m_pages[index] = page;
+    m_pageContent->addWidget(page);
+    return page;
 }
 
 void AppOptionsDialog::selectOption(const AppOptionsGlobal::Option option) {

--- a/src/app/UI/Dialogs/Options/AppOptionsDialog.h
+++ b/src/app/UI/Dialogs/Options/AppOptionsDialog.h
@@ -5,12 +5,6 @@
 
 #include "Global/AppOptionsGlobal.h"
 
-class AudioPage;
-class MidiPage;
-class AppearancePage;
-class GeneralPage;
-class InferencePage;
-class DeveloperPage;
 class IOptionPage;
 class QListWidget;
 class QStackedWidget;
@@ -39,9 +33,10 @@ protected:
     void changeEvent(QEvent *event) override;
 
 private slots:
-    void onSelectionChanged(int index) const;
+    void onSelectionChanged(int index);
 
 private:
+    IOptionPage *ensurePage(int index);
     void retranslateUi();
 
     QListWidget *m_tabList = nullptr;
@@ -49,12 +44,6 @@ private:
     QWidget *m_sidebar = nullptr;
     bool m_standalone = false;
 
-    GeneralPage *m_generalPage = nullptr;
-    AudioPage *m_audioPage = nullptr;
-    MidiPage *m_midiPage = nullptr;
-    AppearancePage *m_appearancePage = nullptr;
-    InferencePage *m_inferencePage = nullptr;
-    DeveloperPage *m_developerPage = nullptr;
     QList<IOptionPage *> m_pages;
 };
 


### PR DESCRIPTION
## Summary

- create each settings page only when it is first selected
- reuse already-created pages while the settings panel remains open
- keep the standalone and embedded settings hosts on the same shared implementation

## Root cause

`AppOptionsDialog` eagerly constructed all six pages on every standalone open. That also ran unrelated initialization such as audio and MIDI device enumeration, inference GPU/cache work, and layout/style processing for every hidden page before the requested page could be shown.

## Impact

Opening the common General settings entry no longer initializes unrelated pages. In a Debug build, two equivalent Computer Use measurements dropped from 988/967 ms to 547/553 ms end-to-end (about 43% lower). The measurement includes fixed UI-automation state capture overhead; temporary in-app timing anchors attributed roughly 411–429 ms of the baseline to the eager setup path and were removed before commit.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File .agents/skills/scripts/run-cmake-preset.ps1 -Mode ConfigureAndBuild -Preset debug`
- repeated standalone settings open/close checks with Computer Use
- verified all six pages initialize and display on first selection
- verified revisiting a page reuses its instance
- verified opening Inference directly does not construct General or other unrelated pages
