### PR TITLE
fix(rhi): preserve minimum note draw length

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -1657,7 +1657,7 @@ public:
     }
 
     void updateDrawNote(const QPointF &viewportPosition) {
-        drawEnd = std::max(drawStart + 1, snapLocalTick(localTickAt(viewportPosition)));
+        drawEnd = std::max(drawEnd, snapLocalTick(localTickAt(viewportPosition)));
         scheduleSnapshot();
     }
 


### PR DESCRIPTION
## Summary

- keep the RHI note-drawing preview at its initial quantized length when the pointer moves left or by less than one quantization step
- align the RHI gesture with the existing Legacy QGraphicsView behavior without adding parallel state

## Root cause

The RHI backend replaced its quantized preview end with `drawStart + 1` when the snapped pointer moved before the start. After the rendering inset, that one-tick rectangle disappears. The behavior dates to the initial RHI backend implementation; the recent edge auto-scroll change only moved the code into its current helper.

## Validation

- full Debug configure and build through the project CMake preset helper
- Computer Use on Experimental (QRhiWidget), 1/16 quantization: press and drag left; a full quantized note remains and is committed
- Computer Use on Legacy (QGraphicsView), same gesture: a full quantized note remains and is committed