### PR TITLE
fix(options): sync cached developer settings

### DIFF
--- a/src/app/UI/Dialogs/Options/Pages/DeveloperPage.cpp
+++ b/src/app/UI/Dialogs/Options/Pages/DeveloperPage.cpp
@@ -7,10 +7,18 @@
 #include <lite/GUI/Controls/OptionListCard.h>
 #include <lite/GUI/Controls/SwitchButton.h>
 
+#include <QSignalBlocker>
 #include <QVBoxLayout>
 
 DeveloperPage::DeveloperPage(QWidget *parent) : IOptionPage(parent) {
     initializePage();
+    connect(appOptions, &AppOptions::optionsChanged, this,
+            [this](const AppOptionsGlobal::Option option) {
+                if (option == AppOptionsGlobal::DeveloperOptions ||
+                    option == AppOptionsGlobal::All) {
+                    syncFromOptions();
+                }
+            });
 }
 
 void DeveloperPage::modifyOption() {
@@ -24,6 +32,26 @@ void DeveloperPage::modifyOption() {
     option->editorRenderBackend = static_cast<DeveloperOption::EditorRenderBackend>(
         m_cbxEditorRenderBackend->currentData().toInt());
     appOptions->saveAndNotify(AppOptionsGlobal::DeveloperOptions);
+}
+
+void DeveloperPage::syncFromOptions() {
+    const auto option = appOptions->developer();
+    const QSignalBlocker diagnosticsBlocker(m_swEnableDiagnostics);
+    const QSignalBlocker logWindowBlocker(m_swShowLogWindow);
+    const QSignalBlocker timelineDebugInfoBlocker(m_swShowTimelineDebugInfo);
+    const QSignalBlocker clipDebugInfoBlocker(m_swShowClipDebugInfo);
+    const QSignalBlocker panelDetachBlocker(m_swEnablePanelDetach);
+    const QSignalBlocker embeddedOptionsDialogBlocker(m_swEnableEmbeddedOptionsDialog);
+    const QSignalBlocker renderBackendBlocker(m_cbxEditorRenderBackend);
+
+    m_swEnableDiagnostics->setValue(option->enableDiagnostics);
+    m_swShowLogWindow->setValue(option->showLogWindow);
+    m_swShowTimelineDebugInfo->setValue(option->showTimelineDebugInfo);
+    m_swShowClipDebugInfo->setValue(option->showClipDebugInfo);
+    m_swEnablePanelDetach->setValue(option->enablePanelDetach);
+    m_swEnableEmbeddedOptionsDialog->setValue(option->enableEmbeddedOptionsDialog);
+    m_cbxEditorRenderBackend->setCurrentIndex(
+        m_cbxEditorRenderBackend->findData(static_cast<int>(option->editorRenderBackend)));
 }
 
 QWidget *DeveloperPage::createContentWidget() {

--- a/src/app/UI/Dialogs/Options/Pages/DeveloperPage.h
+++ b/src/app/UI/Dialogs/Options/Pages/DeveloperPage.h
@@ -17,6 +17,8 @@ protected:
     QWidget *createContentWidget() override;
 
 private:
+    void syncFromOptions();
+
     SwitchButton *m_swEnableDiagnostics;
     SwitchButton *m_swShowLogWindow;
     SwitchButton *m_swShowTimelineDebugInfo;


### PR DESCRIPTION
## Summary

- keep the cached embedded Developer Options controls synchronized with the shared `AppOptions` model
- block control signals while applying model updates so synchronization cannot trigger saves or restart prompts
- preserve lazy page creation and embedded dialog reuse

## Root cause

The embedded `AppOptionsDialog` is cached by `MainWindow`, while standalone settings pages are recreated. After the cached embedded `DeveloperPage` changes the host mode to standalone, the standalone page can change the model back to embedded, but the cached page retained its old control state. This made the switch render as off even though the in-memory and persisted option were true.

## Validation

- full Debug configure and build via the project preset script
- `ctest --test-dir build/Debug --output-on-failure`: 25/25 passed
- Computer Use: repeated embedded off → standalone on → embedded reopen twice; the switch remained on both times