### PR TITLE
perf(playback): raise position update rate

### DIFF
--- a/docs/design/inference-ui-performance-design.md
+++ b/docs/design/inference-ui-performance-design.md
@@ -57,12 +57,14 @@
 
 **修复内容**（10 个文件，281 行新增）：
 
-- **播放位置更新节流**：`TimeGraphicsView` / `TimelineView` 的播放位置 setter 从"直接赋值 + update()"改为 `m_pendingPosition` + **33ms 单次定时器**（`m_positionThrottle`），自动翻页逻辑同样走节流路径
+- **播放位置更新节流**：`TimeGraphicsView` / `TimelineView` 的播放位置 setter 从"直接赋值 + update()"改为 `m_pendingPosition` + **33ms 单次定时器**（`m_positionThrottle`），自动翻页逻辑同样走节流路径（这是该提交引入时的取值）
 - **WaveformPainter pixmap 缓存修复**：缓存改为按 `devicePixelRatio` + 像素尺寸校验重建（修复缓存被 setter 清空后 `paint()` 画空白的问题）
 - **CommonParamEditorView 曲线删除泄漏修复**：移除曲线时同时 `delete` 曲线对象
 - 提交附带 MainWindow 的临时诊断事件过滤器（`EventDiagFilter`，测量事件间隙与 paint 阻塞时间，标注 "remove after investigation"）——**至今仍保留在 `MainWindow.cpp` 中，属于待清理的遗留代码**
 
 **效果**：播放中冻结问题解决；剩余待优化项目由本次综合修复覆盖，不再单独跟踪。
+
+后续波形采样和渲染完成统一、音素波形增加视口像素缓存后，所有播放头视图改为共享 `PlaybackGlobal::positionUpdateIntervalMs`，当前取值为 8ms。单次定时器仍负责合并音频后端的密集位置事件，但不再把 UI 播放头限制在约 30Hz。
 
 ## 设计约束（主线程 / 工作线程职责划分）
 

--- a/src/app/Global/PlaybackGlobal.h
+++ b/src/app/Global/PlaybackGlobal.h
@@ -2,6 +2,8 @@
 #define PLAYBACKGLOBAL_H
 
 namespace PlaybackGlobal {
+    inline constexpr int positionUpdateIntervalMs = 8;
+
     enum PlaybackStatus {
         Stopped,
         Playing,

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
@@ -4,6 +4,7 @@
 #include "Controller/ClipController.h"
 #include "Controller/PlaybackController.h"
 #include "Global/AppGlobal.h"
+#include "Global/PlaybackGlobal.h"
 #include "Global/TracksEditorGlobal.h"
 #include <lite/ProjectModel/AppModel/AppModel.h>
 #include <lite/ProjectModel/InferenceData/InferPiece.h>
@@ -45,7 +46,7 @@ PhonemeView::PhonemeView(QWidget *parent) : QWidget(parent) {
             &PhonemeView::setLastPosition);
 
     m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
+    m_positionThrottle.setInterval(PlaybackGlobal::positionUpdateIntervalMs);
     connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
         m_position = m_pendingPosition;
         update();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -7,6 +7,7 @@
 #include "PronunciationView.h"
 #include "Controller/ClipController.h"
 #include "Global/AppGlobal.h"
+#include "Global/PlaybackGlobal.h"
 #include "Model/AppOptions/AppOptions.h"
 #include "Model/AppStatus/AppStatus.h"
 #include "UI/Utils/AppColorPalette.h"
@@ -2761,7 +2762,7 @@ PianoRollRhiWidget::PianoRollRhiWidget(QWidget *parent)
             [this] { d->scheduleSnapshot(); });
     connect(appStatus, &AppStatus::noteSelectionChanged, this, [this] { d->scheduleSnapshot(); });
     d->positionThrottle.setSingleShot(true);
-    d->positionThrottle.setInterval(33);
+    d->positionThrottle.setInterval(PlaybackGlobal::positionUpdateIntervalMs);
     connect(&d->positionThrottle, &QTimer::timeout, this,
             [this] { d->applyPendingPlaybackPosition(); });
     connect(appModel, &AppModel::timelineChanged, this, [this] {

--- a/src/app/UI/Views/Common/EditorRhiWidget.cpp
+++ b/src/app/UI/Views/Common/EditorRhiWidget.cpp
@@ -1,40 +1,17 @@
 #include "EditorRhiWidget.h"
 
-#include "Model/AppOptions/AppOptions.h"
-
-#include <QElapsedTimer>
 #include <QEvent>
 #include <QFile>
 #include <QMatrix4x4>
 #include <QMetaObject>
-#include <QTimer>
 #include <rhi/qrhi.h>
 
 #include <algorithm>
 
 namespace {
-    constexpr int kStatsWindow = 120;
-
     QShader loadShader(const QString &path) {
         QFile file(path);
         return file.open(QIODevice::ReadOnly) ? QShader::fromSerialized(file.readAll()) : QShader();
-    }
-
-    double percentile(const QVector<double> &values, const double ratio) {
-        if (values.isEmpty())
-            return 0.0;
-        auto sorted = values;
-        std::sort(sorted.begin(), sorted.end());
-        const auto index = static_cast<qsizetype>(std::clamp(ratio, 0.0, 1.0) *
-                                                  static_cast<double>(sorted.size() - 1));
-        return sorted.at(index);
-    }
-
-    QString statsTriple(const QVector<double> &values) {
-        return QStringLiteral("%1/%2/%3")
-            .arg(percentile(values, 0.50), 0, 'f', 3)
-            .arg(percentile(values, 0.95), 0, 'f', 3)
-            .arg(percentile(values, 0.99), 0, 'f', 3);
     }
 
     void configurePremultipliedBlend(QRhiGraphicsPipeline *pipeline) {
@@ -73,7 +50,6 @@ public:
 
     Private(EditorRhiWidget *q, QString diagnosticsTag)
         : q(q), diagnosticsTag(std::move(diagnosticsTag)) {
-        clock.start();
     }
 
     void initialize() {
@@ -208,7 +184,6 @@ public:
     void submit(EditorRhiFrameData newFrame) {
         frame = std::move(newFrame);
         frameDirty = true;
-        updateRequestedNs = clock.nsecsElapsed();
         q->update();
     }
 
@@ -225,8 +200,6 @@ public:
                 return;
         }
 
-        QElapsedTimer uploadTimer;
-        uploadTimer.start();
         auto *updates = pendingUpdates.release();
         if (!updates)
             updates = rhi->nextResourceUpdateBatch();
@@ -234,19 +207,17 @@ public:
         ensureBuffer(solidBuffer, solidBufferCapacity,
                      frame.solidVertices.size() *
                          static_cast<qsizetype>(sizeof(EditorRhiSolidVertex)));
-        double uploadedBytes = 0.0;
         if (frameDirty && solidBuffer && !frame.solidVertices.isEmpty()) {
             const auto bytes = frame.solidVertices.size() * sizeof(EditorRhiSolidVertex);
             updates->updateDynamicBuffer(solidBuffer.get(), 0, static_cast<quint32>(bytes),
                                          frame.solidVertices.constData());
-            uploadedBytes += bytes;
         }
 
         for (const auto &batch : frame.textureBatches) {
             auto &resources = textureResources[batch.pageId];
             if (!resources)
                 resources = std::make_shared<TextureResources>();
-            ensureTextureResources(*resources, batch, updates, uploadedBytes);
+            ensureTextureResources(*resources, batch, updates);
         }
 
         const auto outputSize = renderTarget->pixelSize();
@@ -257,15 +228,10 @@ public:
                              static_cast<float>(-frame.physicalCameraOffset.y()));
         const auto matrix = rhi->clipSpaceCorrMatrix() * projection;
         updates->updateDynamicBuffer(uniformBuffer.get(), 0, 64, matrix.constData());
-        const auto uploadMs = uploadTimer.nsecsElapsed() / 1000000.0;
-
-        QElapsedTimer encodeTimer;
-        encodeTimer.start();
         cb->beginPass(renderTarget.get(), frame.clearColor, {1.0f, 0}, updates);
         cb->setViewport(QRhiViewport(0, 0, outputSize.width(), outputSize.height()));
         cb->setScissor(QRhiScissor(0, 0, outputSize.width(), outputSize.height()));
 
-        int drawCalls = 0;
         const auto drawSolid = [&](const qsizetype vertexOffset, const qsizetype vertexCount) {
             if (!solidBuffer || vertexCount <= 0)
                 return;
@@ -276,7 +242,6 @@ public:
             const QRhiCommandBuffer::VertexInput binding(solidBuffer.get(), byteOffset);
             cb->setVertexInput(0, 1, &binding);
             cb->draw(static_cast<quint32>(vertexCount));
-            ++drawCalls;
         };
         const auto drawTexture = [&](const int pageId, const qsizetype vertexOffset,
                                      const qsizetype vertexCount, const QColor &color) {
@@ -297,7 +262,6 @@ public:
             cb->setBlendConstants(color);
             cb->setVertexInput(0, 1, &binding);
             cb->draw(static_cast<quint32>(vertexCount));
-            ++drawCalls;
         };
         if (!frame.drawList.commands.isEmpty()) {
             for (const auto &command : frame.drawList.commands) {
@@ -311,17 +275,7 @@ public:
             drawSolid(0, frame.solidVertices.size());
         }
         cb->endPass();
-        const auto encodeMs = encodeTimer.nsecsElapsed() / 1000000.0;
         frameDirty = false;
-
-        if (appOptions->developer()->enableDiagnostics) {
-            uploadSamples.append(uploadMs);
-            encodeSamples.append(encodeMs);
-            cpuSamples.append(uploadMs + encodeMs);
-            vertexSamples.append(frame.solidVertices.size());
-            uploadByteSamples.append(uploadedBytes);
-            drawCallSamples.append(drawCalls);
-        }
     }
 
     void ensureBuffer(std::unique_ptr<QRhiBuffer> &buffer, qsizetype &capacity,
@@ -368,7 +322,7 @@ public:
     }
 
     void ensureTextureResources(TextureResources &resources, const EditorRhiTextureBatch &batch,
-                                QRhiResourceUpdateBatch *updates, double &uploadedBytes) {
+                                QRhiResourceUpdateBatch *updates) {
         if (batch.image.isNull())
             return;
         if (!resources.texture || resources.size != batch.image.size()) {
@@ -383,7 +337,6 @@ public:
         }
         if (resources.generation != batch.generation) {
             updates->uploadTexture(resources.texture.get(), batch.image);
-            uploadedBytes += batch.image.sizeInBytes();
             resources.generation = batch.generation;
         }
         if (!resources.bindings) {
@@ -407,43 +360,11 @@ public:
             updates->updateDynamicBuffer(resources.vertexBuffer.get(), 0,
                                          static_cast<quint32>(required),
                                          batch.vertices.constData());
-            uploadedBytes += required;
         }
     }
 
     void submitted() {
-        const auto now = clock.nsecsElapsed();
-        if (lastSubmittedNs != 0) {
-            const auto interval = (now - lastSubmittedNs) / 1000000.0;
-            if (interval <= 500.0 && appOptions->developer()->enableDiagnostics)
-                intervalSamples.append(interval);
-        }
-        lastSubmittedNs = now;
-        if (updateRequestedNs != 0 && appOptions->developer()->enableDiagnostics) {
-            submitSamples.append((now - updateRequestedNs) / 1000000.0);
-            updateRequestedNs = 0;
-        }
         q->onFrameSubmitted();
-
-        if (!appOptions->developer()->enableDiagnostics || cpuSamples.size() < kStatsWindow)
-            return;
-        qInfo().noquote() << QStringLiteral(
-                                 "[%1Stats] frames=%2 cpuMs=%3 uploadMs=%4 encodeMs=%5 "
-                                 "submitMs=%6 intervalMs=%7 vertices=%8 uploadBytes=%9 draws=%10")
-                                 .arg(diagnosticsTag)
-                                 .arg(cpuSamples.size())
-                                 .arg(statsTriple(cpuSamples), statsTriple(uploadSamples),
-                                      statsTriple(encodeSamples), statsTriple(submitSamples),
-                                      statsTriple(intervalSamples), statsTriple(vertexSamples),
-                                      statsTriple(uploadByteSamples), statsTriple(drawCallSamples));
-        cpuSamples.clear();
-        uploadSamples.clear();
-        encodeSamples.clear();
-        submitSamples.clear();
-        intervalSamples.clear();
-        vertexSamples.clear();
-        uploadByteSamples.clear();
-        drawCallSamples.clear();
     }
 
     void fail(const QString &reason) {
@@ -495,18 +416,6 @@ public:
     std::unique_ptr<QRhiGraphicsPipeline> textPipeline;
     std::unique_ptr<QRhiResourceUpdateBatch> pendingUpdates;
     QHash<int, std::shared_ptr<TextureResources>> textureResources;
-
-    QElapsedTimer clock;
-    qint64 updateRequestedNs = 0;
-    qint64 lastSubmittedNs = 0;
-    QVector<double> cpuSamples;
-    QVector<double> uploadSamples;
-    QVector<double> encodeSamples;
-    QVector<double> submitSamples;
-    QVector<double> intervalSamples;
-    QVector<double> vertexSamples;
-    QVector<double> uploadByteSamples;
-    QVector<double> drawCallSamples;
 };
 
 EditorRhiWidget::EditorRhiWidget(QString diagnosticsTag, QWidget *parent)

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -18,6 +18,7 @@
 #include "Model/AppStatus/AppStatus.h"
 #include "Model/AppOptions/AppOptions.h"
 #include "Global/AppGlobal.h"
+#include "Global/PlaybackGlobal.h"
 #include <lite/ProjectModel/AppModel/AppModel.h>
 #include <lite/GUI/Controls/OverlayScrollBar.h>
 
@@ -128,7 +129,7 @@ TimeGraphicsView::TimeGraphicsView(TimeGraphicsScene *scene, bool showLastPlayba
             &TimeGraphicsView::updateAutoPageTurnAvailability);
 
     m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
+    m_positionThrottle.setInterval(PlaybackGlobal::positionUpdateIntervalMs);
     connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
         double tick = m_pendingPosition;
         m_playbackPosition = tick;

--- a/src/app/UI/Views/Common/TimelineView.cpp
+++ b/src/app/UI/Views/Common/TimelineView.cpp
@@ -5,6 +5,7 @@
 #include <QWheelEvent>
 
 #include "Controller/PlaybackController.h"
+#include "Global/PlaybackGlobal.h"
 #include "Utils/FontManager.h"
 #include <lite/ProjectModel/AppModel/LoopSettings.h>
 #include <lite/ProjectModel/AppModel/SingingClip.h>
@@ -45,7 +46,7 @@ TimelineView::TimelineView(QWidget *parent) : QWidget(parent) {
     connect(&m_pieceUpdateThrottle, &QTimer::timeout, this, qOverload<>(&QWidget::update));
 
     m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
+    m_positionThrottle.setInterval(PlaybackGlobal::positionUpdateIntervalMs);
     connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
         m_position = m_pendingPosition;
         update();

--- a/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
+++ b/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
@@ -1,6 +1,7 @@
 #include "InfoLaneView.h"
 
 #include "Controller/PlaybackController.h"
+#include "Global/PlaybackGlobal.h"
 #include <lite/ProjectModel/AppModel/AppModel.h>
 
 #include <QContextMenuEvent>
@@ -39,7 +40,7 @@ InfoLaneView::InfoLaneView(QWidget *parent) : QWidget(parent) {
     connect(appModel, &AppModel::timelineChanged, this, applyTimeline);
 
     m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
+    m_positionThrottle.setInterval(PlaybackGlobal::positionUpdateIntervalMs);
     connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
         m_position = m_pendingPosition;
         update();

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -7,6 +7,7 @@
 #include "Controller/PlaybackController.h"
 #include "Controller/TrackController.h"
 #include "Global/AppGlobal.h"
+#include "Global/PlaybackGlobal.h"
 #include "Global/TracksEditorGlobal.h"
 #include "Model/AppOptions/AppOptions.h"
 #include "Model/AppStatus/AppStatus.h"
@@ -212,7 +213,7 @@ TracksRhiWidget::TracksRhiWidget(QWidget *parent)
                 }
             });
     m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
+    m_positionThrottle.setInterval(PlaybackGlobal::positionUpdateIntervalMs);
     connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
         m_playbackPosition = m_pendingPlaybackPosition;
         handleAutoPageTurn();


### PR DESCRIPTION
## Summary

- centralize playback-position UI throttling in `PlaybackGlobal::positionUpdateIntervalMs`
- change the shared interval from 33 ms to 8 ms for the six Legacy/RHI playhead views
- keep the existing single-shot coalescing behavior and document the historical 33 ms value
- remove the leftover per-frame RHI performance probes from `EditorRhiWidget`

## Performance observation

Reused the 400-note / 8-synthesized-piece stress project with accompaniment waveform on the experimental QRhiWidget backend.

- With per-second diagnostic printing suppressed, a 60 s observation window reported a maximum event-loop gap of 31 ms and no gaps at or above 100 ms.
- The initially observed once-per-second hitch was caused by the diagnostic event filter printing its aggregate batch every second, not by the 8 ms position throttle. All temporary diagnostic changes were removed.
- Steady RHI frame intervals were broadly unchanged between 8 ms and the 33 ms baseline (roughly 47–55 ms at p50/p95 in this stress scene). RHI CPU encode/upload cost also remained stable: about 1.3–1.7 ms for the piano roll and 0.25–0.45 ms for tracks.
- The old RHI probes performed high-resolution timing and counter bookkeeping on every frame even when diagnostic output was disabled. The PR now removes that residual runtime overhead.
- Waveform sampling and phoneme waveform rasterization remain cached. Further waveform-specific work is unlikely to improve the observed RHI cadence materially; a future higher-cost optimization would be to decouple the RHI playhead overlay from full static snapshot rebuilds.
- The known RHI playback memory-growth issue is intentionally outside this change.

## Validation

- Debug preset configure/build
- Debug `all` target build
- 26/26 CTest tests passed
- GUI stress playback with responsive pause/stop
- separate 8 ms / RHI-probes-on and 8 ms / RHI-probes-off comparison executables built and smoke-launched locally
