### PR TITLE
perf(playback): improve Legacy and RHI playhead cadence

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -101,6 +101,10 @@ qt_add_shaders(${PROJECT_NAME} "editor_rhi_shaders"
         UI/Views/Common/shaders/solid.frag
         UI/Views/Common/shaders/texture.vert
         UI/Views/Common/shaders/texture.frag
+        UI/Views/Common/shaders/scene.vert
+        UI/Views/Common/shaders/scene.frag
+        UI/Views/Common/shaders/overlay.vert
+        UI/Views/Common/shaders/overlay.frag
 )
 
 if(APPLE)

--- a/src/app/Controller/PlaybackController.cpp
+++ b/src/app/Controller/PlaybackController.cpp
@@ -8,10 +8,6 @@
 
 PlaybackController::PlaybackController() : d_ptr(new PlaybackControllerPrivate(this)) {
     Q_D(PlaybackController);
-    d->m_visualPositionTimer.setInterval(positionUpdateIntervalMs);
-    d->m_visualPositionTimer.setTimerType(Qt::PreciseTimer);
-    connect(&d->m_visualPositionTimer, &QTimer::timeout, this,
-            &PlaybackController::updateVisualPosition);
     connect(appModel, &AppModel::timelineChanged, this, [d, this] {
         d->m_visualPositionAnchor = d->m_position;
         d->m_visualPositionClock.restart();
@@ -66,14 +62,12 @@ void PlaybackController::play() {
     d->m_visualPositionAnchor = d->m_position;
     d->m_visualPositionClock.restart();
     emit playbackStatusChanged(Playing);
-    d->m_visualPositionTimer.start();
     emit visualPositionChanged(d->m_position);
 }
 
 void PlaybackController::pause() {
     Q_D(PlaybackController);
     d->m_playbackStatus = Paused;
-    d->m_visualPositionTimer.stop();
     emit playbackStatusChanged(Paused);
     emit visualPositionChanged(d->m_position);
 }
@@ -81,7 +75,6 @@ void PlaybackController::pause() {
 void PlaybackController::stop() {
     Q_D(PlaybackController);
     d->m_playbackStatus = Stopped;
-    d->m_visualPositionTimer.stop();
     emit playbackStatusChanged(Stopped);
     emit visualPositionChanged(d->m_position);
 }
@@ -102,20 +95,21 @@ void PlaybackController::setLastPosition(const double tick) {
     emit lastPositionChanged(tick);
 }
 
-void PlaybackController::sampleRateChanged(const double sr) {
-    Q_D(PlaybackController);
-    d->m_sampleRate = sr;
-}
-
-void PlaybackController::onModelChanged() {
-}
-
-void PlaybackController::updateVisualPosition() {
+void PlaybackController::requestVisualPositionUpdate() {
     Q_D(PlaybackController);
     if (d->m_playbackStatus != Playing || !d->m_visualPositionClock.isValid())
         return;
 
     const auto &timeline = appModel->timeline();
     const auto anchorMs = timeline.tickToMs(d->m_visualPositionAnchor);
-    emit visualPositionChanged(timeline.msToTick(anchorMs + d->m_visualPositionClock.elapsed()));
+    const auto elapsedMs = d->m_visualPositionClock.nsecsElapsed() / 1000000.0;
+    emit visualPositionChanged(timeline.msToTick(anchorMs + elapsedMs));
+}
+
+void PlaybackController::sampleRateChanged(const double sr) {
+    Q_D(PlaybackController);
+    d->m_sampleRate = sr;
+}
+
+void PlaybackController::onModelChanged() {
 }

--- a/src/app/Controller/PlaybackController.cpp
+++ b/src/app/Controller/PlaybackController.cpp
@@ -8,6 +8,16 @@
 
 PlaybackController::PlaybackController() : d_ptr(new PlaybackControllerPrivate(this)) {
     Q_D(PlaybackController);
+    d->m_visualPositionTimer.setInterval(positionUpdateIntervalMs);
+    d->m_visualPositionTimer.setTimerType(Qt::PreciseTimer);
+    connect(&d->m_visualPositionTimer, &QTimer::timeout, this,
+            &PlaybackController::updateVisualPosition);
+    connect(appModel, &AppModel::timelineChanged, this, [d, this] {
+        d->m_visualPositionAnchor = d->m_position;
+        d->m_visualPositionClock.restart();
+        if (d->m_playbackStatus == Playing)
+            emit visualPositionChanged(d->m_position);
+    });
     connect(appModel, &AppModel::modelChanged, this, [d, this] {
         if (d->m_playbackStatus != Stopped) {
             stop();
@@ -38,6 +48,11 @@ double PlaybackController::lastPosition() const {
     return d->m_lastPlayPosition;
 }
 
+void PlaybackController::setPlaybackStartGuard(std::function<bool()> guard) {
+    Q_D(PlaybackController);
+    d->m_playbackStartGuard = std::move(guard);
+}
+
 void PlaybackController::play() {
     Q_D(PlaybackController);
     if (appStatus->currentEditObject != AppStatus::EditObjectType::None) {
@@ -45,26 +60,40 @@ void PlaybackController::play() {
         Toast::show(tr("Please release mouse button before playing"));
         return;
     }
+    if (d->m_playbackStartGuard && !d->m_playbackStartGuard())
+        return;
     d->m_playbackStatus = Playing;
+    d->m_visualPositionAnchor = d->m_position;
+    d->m_visualPositionClock.restart();
     emit playbackStatusChanged(Playing);
+    d->m_visualPositionTimer.start();
+    emit visualPositionChanged(d->m_position);
 }
 
 void PlaybackController::pause() {
     Q_D(PlaybackController);
     d->m_playbackStatus = Paused;
+    d->m_visualPositionTimer.stop();
     emit playbackStatusChanged(Paused);
+    emit visualPositionChanged(d->m_position);
 }
 
 void PlaybackController::stop() {
     Q_D(PlaybackController);
     d->m_playbackStatus = Stopped;
+    d->m_visualPositionTimer.stop();
     emit playbackStatusChanged(Stopped);
+    emit visualPositionChanged(d->m_position);
 }
 
 void PlaybackController::setPosition(const double tick) {
     Q_D(PlaybackController);
     d->m_position = tick;
+    d->m_visualPositionAnchor = tick;
+    d->m_visualPositionClock.restart();
     emit positionChanged(tick);
+    if (d->m_playbackStatus != Playing)
+        emit visualPositionChanged(tick);
 }
 
 void PlaybackController::setLastPosition(const double tick) {
@@ -79,4 +108,14 @@ void PlaybackController::sampleRateChanged(const double sr) {
 }
 
 void PlaybackController::onModelChanged() {
+}
+
+void PlaybackController::updateVisualPosition() {
+    Q_D(PlaybackController);
+    if (d->m_playbackStatus != Playing || !d->m_visualPositionClock.isValid())
+        return;
+
+    const auto &timeline = appModel->timeline();
+    const auto anchorMs = timeline.tickToMs(d->m_visualPositionAnchor);
+    emit visualPositionChanged(timeline.msToTick(anchorMs + d->m_visualPositionClock.elapsed()));
 }

--- a/src/app/Controller/PlaybackController.cpp
+++ b/src/app/Controller/PlaybackController.cpp
@@ -118,7 +118,15 @@ void PlaybackController::requestVisualPositionUpdate() {
     const auto &timeline = appModel->timeline();
     const auto anchorMs = timeline.tickToMs(d->m_visualPositionAnchor);
     const auto elapsedMs = d->m_visualPositionClock.nsecsElapsed() / 1000000.0;
-    emit visualPositionChanged(timeline.msToTick(anchorMs + elapsedMs));
+    auto visualMs = anchorMs + elapsedMs;
+    const auto &loopSettings = appStatus->loopSettings.get();
+    if (loopSettings.enabled && loopSettings.length > 0) {
+        const auto loopStartMs = timeline.tickToMs(loopSettings.start);
+        const auto loopDurationMs = timeline.tickToMs(loopSettings.end()) - loopStartMs;
+        if (loopDurationMs > 0.0 && visualMs >= loopStartMs + loopDurationMs)
+            visualMs = loopStartMs + std::fmod(visualMs - loopStartMs, loopDurationMs);
+    }
+    emit visualPositionChanged(timeline.msToTick(visualMs));
 }
 
 void PlaybackController::updateVisualPositionTimerInterval() {

--- a/src/app/Controller/PlaybackController.cpp
+++ b/src/app/Controller/PlaybackController.cpp
@@ -6,8 +6,18 @@
 #include <lite/GUI/Controls/Toast.h>
 #include "Global/AppGlobal.h"
 
+#include <QGuiApplication>
+#include <QScreen>
+#include <QWindow>
+
+#include <chrono>
+#include <cmath>
+
 PlaybackController::PlaybackController() : d_ptr(new PlaybackControllerPrivate(this)) {
     Q_D(PlaybackController);
+    d->m_visualPositionTimer.setTimerType(Qt::PreciseTimer);
+    connect(&d->m_visualPositionTimer, &QChronoTimer::timeout, this,
+            &PlaybackController::requestVisualPositionUpdate);
     connect(appModel, &AppModel::timelineChanged, this, [d, this] {
         d->m_visualPositionAnchor = d->m_position;
         d->m_visualPositionClock.restart();
@@ -62,12 +72,15 @@ void PlaybackController::play() {
     d->m_visualPositionAnchor = d->m_position;
     d->m_visualPositionClock.restart();
     emit playbackStatusChanged(Playing);
+    updateVisualPositionTimerInterval();
+    d->m_visualPositionTimer.start();
     emit visualPositionChanged(d->m_position);
 }
 
 void PlaybackController::pause() {
     Q_D(PlaybackController);
     d->m_playbackStatus = Paused;
+    d->m_visualPositionTimer.stop();
     emit playbackStatusChanged(Paused);
     emit visualPositionChanged(d->m_position);
 }
@@ -75,6 +88,7 @@ void PlaybackController::pause() {
 void PlaybackController::stop() {
     Q_D(PlaybackController);
     d->m_playbackStatus = Stopped;
+    d->m_visualPositionTimer.stop();
     emit playbackStatusChanged(Stopped);
     emit visualPositionChanged(d->m_position);
 }
@@ -100,10 +114,24 @@ void PlaybackController::requestVisualPositionUpdate() {
     if (d->m_playbackStatus != Playing || !d->m_visualPositionClock.isValid())
         return;
 
+    updateVisualPositionTimerInterval();
     const auto &timeline = appModel->timeline();
     const auto anchorMs = timeline.tickToMs(d->m_visualPositionAnchor);
     const auto elapsedMs = d->m_visualPositionClock.nsecsElapsed() / 1000000.0;
     emit visualPositionChanged(timeline.msToTick(anchorMs + elapsedMs));
+}
+
+void PlaybackController::updateVisualPositionTimerInterval() {
+    Q_D(PlaybackController);
+    const auto *window = QGuiApplication::focusWindow();
+    const auto *screen = window ? window->screen() : QGuiApplication::primaryScreen();
+    auto refreshRate = screen ? screen->refreshRate() : 60.0;
+    if (!std::isfinite(refreshRate) || refreshRate <= 0.0)
+        refreshRate = 60.0;
+    const auto interval =
+        std::chrono::nanoseconds(qMax<qint64>(1, qRound64(1000000000.0 / refreshRate)));
+    if (d->m_visualPositionTimer.interval() != interval)
+        d->m_visualPositionTimer.setInterval(interval);
 }
 
 void PlaybackController::sampleRateChanged(const double sr) {

--- a/src/app/Controller/PlaybackController.h
+++ b/src/app/Controller/PlaybackController.h
@@ -46,13 +46,12 @@ public slots:
 
     void setPosition(double tick);
     void setLastPosition(double tick);
+    void requestVisualPositionUpdate();
 
     void sampleRateChanged(double sr);
     void onModelChanged();
 
 private:
-    void updateVisualPosition();
-
     Q_DECLARE_PRIVATE(PlaybackController)
     PlaybackControllerPrivate *d_ptr;
 };

--- a/src/app/Controller/PlaybackController.h
+++ b/src/app/Controller/PlaybackController.h
@@ -9,6 +9,8 @@
 
 #include <QObject>
 
+#include <functional>
+
 using namespace PlaybackGlobal;
 
 class PlaybackControllerPrivate;
@@ -29,9 +31,11 @@ public:
 
     [[nodiscard]] double position() const;
     [[nodiscard]] double lastPosition() const;
+    void setPlaybackStartGuard(std::function<bool()> guard);
 
     signals:
     void positionChanged(double tick);
+    void visualPositionChanged(double tick);
     void lastPositionChanged(double tick);
     void playbackStatusChanged(PlaybackStatus status);
 
@@ -47,6 +51,8 @@ public slots:
     void onModelChanged();
 
 private:
+    void updateVisualPosition();
+
     Q_DECLARE_PRIVATE(PlaybackController)
     PlaybackControllerPrivate *d_ptr;
 };

--- a/src/app/Controller/PlaybackController.h
+++ b/src/app/Controller/PlaybackController.h
@@ -46,12 +46,14 @@ public slots:
 
     void setPosition(double tick);
     void setLastPosition(double tick);
-    void requestVisualPositionUpdate();
 
     void sampleRateChanged(double sr);
     void onModelChanged();
 
 private:
+    void requestVisualPositionUpdate();
+    void updateVisualPositionTimerInterval();
+
     Q_DECLARE_PRIVATE(PlaybackController)
     PlaybackControllerPrivate *d_ptr;
 };

--- a/src/app/Controller/PlaybackController_p.h
+++ b/src/app/Controller/PlaybackController_p.h
@@ -1,6 +1,7 @@
 #ifndef PLAYBACKCONTROLLER_P_H
 #define PLAYBACKCONTROLLER_P_H
 
+#include <QChronoTimer>
 #include <QElapsedTimer>
 
 #include <functional>
@@ -19,6 +20,7 @@ public:
     PlaybackStatus m_playbackStatus = Stopped;
     double m_visualPositionAnchor = 0;
     QElapsedTimer m_visualPositionClock;
+    QChronoTimer m_visualPositionTimer;
     std::function<bool()> m_playbackStartGuard;
 
 private:

--- a/src/app/Controller/PlaybackController_p.h
+++ b/src/app/Controller/PlaybackController_p.h
@@ -1,6 +1,11 @@
 #ifndef PLAYBACKCONTROLLER_P_H
 #define PLAYBACKCONTROLLER_P_H
 
+#include <QElapsedTimer>
+#include <QTimer>
+
+#include <functional>
+
 class PlaybackControllerPrivate : public QObject {
     Q_OBJECT
     Q_DECLARE_PUBLIC(PlaybackController)
@@ -13,6 +18,10 @@ public:
     double m_lastPlayPosition = 0;
     double m_sampleRate = 48000;
     PlaybackStatus m_playbackStatus = Stopped;
+    double m_visualPositionAnchor = 0;
+    QElapsedTimer m_visualPositionClock;
+    QTimer m_visualPositionTimer;
+    std::function<bool()> m_playbackStartGuard;
 
 private:
     PlaybackController *q_ptr;

--- a/src/app/Controller/PlaybackController_p.h
+++ b/src/app/Controller/PlaybackController_p.h
@@ -2,7 +2,6 @@
 #define PLAYBACKCONTROLLER_P_H
 
 #include <QElapsedTimer>
-#include <QTimer>
 
 #include <functional>
 
@@ -20,7 +19,6 @@ public:
     PlaybackStatus m_playbackStatus = Stopped;
     double m_visualPositionAnchor = 0;
     QElapsedTimer m_visualPositionClock;
-    QTimer m_visualPositionTimer;
     std::function<bool()> m_playbackStartGuard;
 
 private:

--- a/src/app/Global/PlaybackGlobal.h
+++ b/src/app/Global/PlaybackGlobal.h
@@ -2,6 +2,8 @@
 #define PLAYBACKGLOBAL_H
 
 namespace PlaybackGlobal {
+    inline constexpr int positionUpdateIntervalMs = 8;
+
     enum PlaybackStatus {
         Stopped,
         Playing,

--- a/src/app/Global/PlaybackGlobal.h
+++ b/src/app/Global/PlaybackGlobal.h
@@ -2,8 +2,6 @@
 #define PLAYBACKGLOBAL_H
 
 namespace PlaybackGlobal {
-    inline constexpr int positionUpdateIntervalMs = 8;
-
     enum PlaybackStatus {
         Stopped,
         Playing,

--- a/src/app/Modules/Audio/AudioContext.cpp
+++ b/src/app/Modules/Audio/AudioContext.cpp
@@ -103,10 +103,13 @@ AudioContext::AudioContext(QObject *parent) : DspxProjectContext(parent) {
 
     connect(transport(), &talcs::TransportAudioSource::playbackStatusChanged, this,
             [this](auto status) {
-                if (status == talcs::TransportAudioSource::Paused &&
-                    playbackController->playbackStatus() == PlaybackGlobal::Stopped) {
-                    if (AudioSettings::playheadBehavior() == ReturnToStart)
-                        playbackController->setPosition(playbackController->lastPosition());
+                if (status != talcs::TransportAudioSource::Paused)
+                    return;
+                if (playbackController->playbackStatus() == PlaybackGlobal::Playing) {
+                    playbackController->pause();
+                } else if (playbackController->playbackStatus() == PlaybackGlobal::Stopped &&
+                           AudioSettings::playheadBehavior() == ReturnToStart) {
+                    playbackController->setPosition(playbackController->lastPosition());
                 }
             });
 
@@ -114,6 +117,7 @@ AudioContext::AudioContext(QObject *parent) : DspxProjectContext(parent) {
             &AudioContext::handlePlaybackStatusChanged);
     connect(playbackController, &PlaybackController::positionChanged, this,
             &AudioContext::handlePlaybackPositionChanged);
+    playbackController->setPlaybackStartGuard([this] { return ensurePlaybackDeviceStarted(); });
 
     connect(appModel, &AppModel::modelChanged, this, [this] {
         DEVICE_LOCKER;
@@ -211,6 +215,7 @@ AudioContext::AudioContext(QObject *parent) : DspxProjectContext(parent) {
 }
 
 AudioContext::~AudioContext() {
+    playbackController->setPlaybackStartGuard({});
     for (const auto trackSynthesizer : m_trackSynthDict.values()) {
         delete trackSynthesizer;
     }
@@ -265,7 +270,6 @@ void AudioContext::handleInferPieceFailed() {
 }
 
 void AudioContext::handlePlaybackStatusChanged(const PlaybackStatus status) {
-    const auto device = AudioSystem::outputSystem()->context()->device();
     switch (status) {
         case Stopped:
             transport()->pause();
@@ -276,10 +280,6 @@ void AudioContext::handlePlaybackStatusChanged(const PlaybackStatus status) {
                 m_levelMeterTickTime.start();
                 tickLevelMeters();
             }
-            if (!device || !device->isOpen())
-                QMessageBox::critical(nullptr, {}, tr("Cannot open audio device!"));
-            if (device && !device->isStarted())
-                device->start(AudioSystem::outputSystem()->context()->playback());
             if (m_lastStatus == Stopped) {
                 if (AudioSettings::playheadBehavior() == KeepAtCurrentButPlayFromStart)
                     playbackController->setPosition(playbackController->lastPosition());
@@ -301,6 +301,17 @@ void AudioContext::handlePlaybackStatusChanged(const PlaybackStatus status) {
             break;
     }
     m_lastStatus = status;
+}
+
+bool AudioContext::ensurePlaybackDeviceStarted() const {
+    const auto outputContext = AudioSystem::outputSystem()->context();
+    const auto device = outputContext->device();
+    if (device && device->isOpen() &&
+        (device->isStarted() || device->start(outputContext->playback()))) {
+        return true;
+    }
+    QMessageBox::critical(nullptr, {}, tr("Cannot open audio device!"));
+    return false;
 }
 
 void AudioContext::handlePlaybackPositionChanged(const double positionTick) const {

--- a/src/app/Modules/Audio/AudioContext.h
+++ b/src/app/Modules/Audio/AudioContext.h
@@ -79,6 +79,7 @@ private:
 
     void handlePlaybackStatusChanged(PlaybackStatus status);
     void handlePlaybackPositionChanged(double positionTick) const;
+    bool ensurePlaybackDeviceStarted() const;
     void tickLevelMeters();
 
     void handleModelChanged();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
@@ -39,7 +39,7 @@ PhonemeView::PhonemeView(QWidget *parent) : QWidget(parent) {
     installEventFilter(this);
 
     connect(appModel, &AppModel::timelineChanged, this, &PhonemeView::onTimelineChanged);
-    connect(playbackController, &PlaybackController::visualPositionChanged, this,
+    connect(playbackController, &PlaybackController::positionChanged, this,
             &PhonemeView::setPosition);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &PhonemeView::setLastPosition);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
@@ -39,7 +39,7 @@ PhonemeView::PhonemeView(QWidget *parent) : QWidget(parent) {
     installEventFilter(this);
 
     connect(appModel, &AppModel::timelineChanged, this, &PhonemeView::onTimelineChanged);
-    connect(playbackController, &PlaybackController::positionChanged, this,
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
             &PhonemeView::setPosition);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &PhonemeView::setLastPosition);
@@ -77,8 +77,12 @@ void PhonemeView::setTimeRange(const double startTick, const double endTick) {
 }
 
 void PhonemeView::setPosition(const double tick) {
+    const auto oldX = tickToX(m_position);
     m_position = tick;
-    update();
+    const auto newX = tickToX(m_position);
+    update(QRectF(oldX - 2, 0, 4, height()).toAlignedRect());
+    if (qRound(oldX) != qRound(newX))
+        update(QRectF(newX - 2, 0, 4, height()).toAlignedRect());
 }
 
 void PhonemeView::setLastPosition(const double tick) {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
@@ -39,17 +39,11 @@ PhonemeView::PhonemeView(QWidget *parent) : QWidget(parent) {
     installEventFilter(this);
 
     connect(appModel, &AppModel::timelineChanged, this, &PhonemeView::onTimelineChanged);
-    connect(playbackController, &PlaybackController::positionChanged, this,
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
             &PhonemeView::setPosition);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &PhonemeView::setLastPosition);
 
-    m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
-    connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
-        m_position = m_pendingPosition;
-        update();
-    });
     m_lastPosition = playbackController->lastPosition();
 }
 
@@ -83,9 +77,8 @@ void PhonemeView::setTimeRange(const double startTick, const double endTick) {
 }
 
 void PhonemeView::setPosition(const double tick) {
-    m_pendingPosition = tick;
-    if (!m_positionThrottle.isActive())
-        m_positionThrottle.start();
+    m_position = tick;
+    update();
 }
 
 void PhonemeView::setLastPosition(const double tick) {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.h
@@ -8,7 +8,6 @@
 #include <lite/GUI/Utils/TextPixmapCache.h>
 
 #include <QWidget>
-#include <QTimer>
 #include <QMap>
 #include <QPixmap>
 
@@ -144,9 +143,6 @@ private:
 
     SingingClip *m_clip = nullptr;
     ToolTip *m_tooltip = nullptr;
-
-    QTimer m_positionThrottle;
-    double m_pendingPosition = 0;
 
     PhonemeViewModel *phonemeAtTick(double tick);
     QList<PhonemeViewModel *> findPhonemesByNoteId(int noteId);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -375,15 +375,21 @@ public:
     }
 
     void setPlaybackPosition(const double tick) {
-        pendingPlaybackPosition = tick;
-        if (!positionThrottle.isActive())
-            positionThrottle.start();
+        playbackPosition = tick;
+        handleAutoPageTurn();
+        if (!snapshotScheduled)
+            updatePlaybackOverlay();
     }
 
-    void applyPendingPlaybackPosition() {
-        playbackPosition = pendingPlaybackPosition;
-        handleAutoPageTurn();
-        scheduleSnapshot();
+    void updatePlaybackOverlay() {
+        playbackOverlayVertices.clear();
+        if (clip && q->width() > 0 && q->height() > 0) {
+            const auto currentX = (playbackPosition - clip->start()) * pixelsPerTick() * dpr;
+            EditorRhiGeometry::appendAntialiasedVerticalLine(
+                playbackOverlayVertices, currentX, cameraY * dpr, (cameraY + q->height()) * dpr,
+                dpr, q->playPosIndicatorColor(), cameraX * dpr);
+        }
+        playbackOverlayVertices = q->submitOverlay(std::move(playbackOverlayVertices));
     }
 
     void setAutoPageTurn(const bool enabled) {
@@ -405,17 +411,21 @@ public:
         if (viewportLength <= 0.0)
             return;
 
+        const auto previousCameraX = cameraX;
         if (playbackPosition > viewportEnd) {
             const auto targetStart = playbackPosition - viewportLength;
             if (targetStart > viewportEnd)
                 cameraX = (playbackPosition - clip->start()) * pixelsPerTick();
             else
                 cameraX += q->width();
-            viewportChanged(false);
         } else if (playbackPosition < viewportStart) {
             cameraX = (playbackPosition - clip->start()) * pixelsPerTick();
-            viewportChanged(false);
+        } else {
+            return;
         }
+        clampCamera();
+        if (!qFuzzyIsNull(cameraX - previousCameraX))
+            viewportChanged(false);
     }
 
     void updateAutoPageTurnAvailability() {
@@ -1762,7 +1772,10 @@ public:
     }
 
     void rebuildSnapshot() {
+        auto frame = q->acquireFrame();
+        vertices = std::move(frame.solidVertices);
         vertices.clear();
+        drawList = std::move(frame.drawList);
         drawList.clear();
         dpr = q->devicePixelRatioF();
         glyphAtlas.beginFrame();
@@ -1780,18 +1793,18 @@ public:
             appendPitch(localStart, localEnd);
             appendAnchors(localStart, localEnd);
             appendClipMask(localStart, localEnd, sceneTop, sceneBottom);
-            appendPlaybackIndicators(sceneTop, sceneBottom);
+            appendLastPlaybackIndicator(sceneTop, sceneBottom);
             appendRubberBand();
             appendSplitPreview();
         }
-        EditorRhiFrameData frame;
         frame.clearColor = q->whiteKeyColor();
         frame.physicalCameraOffset = physicalCameraOffset();
-        frame.solidVertices = vertices;
         drawList.finish(vertices.size());
-        frame.drawList = drawList;
-        frame.textureBatches = glyphAtlas.textureBatches();
+        frame.solidVertices = std::move(vertices);
+        frame.drawList = std::move(drawList);
+        glyphAtlas.populateTextureBatches(frame.textureBatches);
         q->submitFrame(std::move(frame));
+        updatePlaybackOverlay();
     }
 
 private:
@@ -2571,14 +2584,12 @@ private:
         }
     }
 
-    void appendPlaybackIndicators(const double sceneTop, const double sceneBottom) {
+    void appendLastPlaybackIndicator(const double sceneTop, const double sceneBottom) {
         const auto lastX = (lastPlaybackPosition - clip->start()) * pixelsPerTick();
-        const auto currentX = (playbackPosition - clip->start()) * pixelsPerTick();
         for (auto top = sceneTop; top < sceneBottom; top += 6.0) {
             appendPixelAlignedVerticalLine(lastX, top, std::min(top + 4.0, sceneBottom),
                                            q->lastPlayPosIndicatorColor());
         }
-        appendPixelAlignedVerticalLine(currentX, sceneTop, sceneBottom, q->playPosIndicatorColor());
     }
 
     void appendRubberBand() {
@@ -2711,13 +2722,12 @@ public:
     double cameraX = 0.0;
     double cameraY = 0.0;
     double playbackPosition = 0.0;
-    double pendingPlaybackPosition = 0.0;
     double lastPlaybackPosition = 0.0;
-    QTimer positionThrottle;
     bool autoPageTurn = true;
     bool autoPageTurnAvailable = false;
     double dpr = 1.0;
     QVector<Vertex> vertices;
+    QVector<Vertex> playbackOverlayVertices;
     TimelineLineEmitter timelineEmitter;
     EditorGlyphAtlas glyphAtlas;
     EditorRhiDrawList drawList;
@@ -2760,10 +2770,6 @@ PianoRollRhiWidget::PianoRollRhiWidget(QWidget *parent)
     connect(appStatus, &AppStatus::pianoRollQuantizeChanged, this,
             [this] { d->scheduleSnapshot(); });
     connect(appStatus, &AppStatus::noteSelectionChanged, this, [this] { d->scheduleSnapshot(); });
-    d->positionThrottle.setSingleShot(true);
-    d->positionThrottle.setInterval(33);
-    connect(&d->positionThrottle, &QTimer::timeout, this,
-            [this] { d->applyPendingPlaybackPosition(); });
     connect(appModel, &AppModel::timelineChanged, this, [this] {
         d->updateAutoPageTurnAvailability();
         d->scheduleSnapshot();
@@ -3320,7 +3326,7 @@ QColor PianoRollRhiWidget::playPosIndicatorColor() const {
 
 void PianoRollRhiWidget::setPlayPosIndicatorColor(const QColor &color) {
     d->playPosIndicatorColor = color;
-    d->scheduleSnapshot();
+    d->updatePlaybackOverlay();
 }
 
 QColor PianoRollRhiWidget::lastPlayPosIndicatorColor() const {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -382,14 +382,14 @@ public:
     }
 
     void updatePlaybackOverlay() {
-        playbackOverlayVertices.clear();
+        playbackOverlayRects.clear();
         if (clip && q->width() > 0 && q->height() > 0) {
             const auto currentX = (playbackPosition - clip->start()) * pixelsPerTick() * dpr;
-            EditorRhiGeometry::appendAntialiasedVerticalLine(
-                playbackOverlayVertices, currentX, cameraY * dpr, (cameraY + q->height()) * dpr,
-                dpr, q->playPosIndicatorColor(), cameraX * dpr);
+            EditorRhiGeometry::appendAntialiasedVerticalOverlay(
+                playbackOverlayRects, currentX - cameraX * dpr, 0.0, q->height() * dpr, dpr,
+                q->playPosIndicatorColor());
         }
-        playbackOverlayVertices = q->submitOverlay(std::move(playbackOverlayVertices));
+        playbackOverlayRects = q->submitOverlay(std::move(playbackOverlayRects));
     }
 
     void setAutoPageTurn(const bool enabled) {
@@ -2727,7 +2727,7 @@ public:
     bool autoPageTurnAvailable = false;
     double dpr = 1.0;
     QVector<Vertex> vertices;
-    QVector<Vertex> playbackOverlayVertices;
+    QVector<EditorRhiOverlayRect> playbackOverlayRects;
     TimelineLineEmitter timelineEmitter;
     EditorGlyphAtlas glyphAtlas;
     EditorRhiDrawList drawList;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
@@ -302,10 +302,6 @@ int PianoRollView::horizontalBarValue() const {
     return m_rhiView ? m_rhiView->horizontalBarValue() : m_graphicsView->horizontalBarValue();
 }
 
-bool PianoRollView::isRhiBackendActive() const {
-    return m_rhiView != nullptr;
-}
-
 void PianoRollView::onWheelHorScale(QWheelEvent *event) const {
     if (m_rhiView)
         m_rhiView->onWheelHorScale(event);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
@@ -302,6 +302,10 @@ int PianoRollView::horizontalBarValue() const {
     return m_rhiView ? m_rhiView->horizontalBarValue() : m_graphicsView->horizontalBarValue();
 }
 
+bool PianoRollView::isRhiBackendActive() const {
+    return m_rhiView != nullptr;
+}
+
 void PianoRollView::onWheelHorScale(QWheelEvent *event) const {
     if (m_rhiView)
         m_rhiView->onWheelHorScale(event);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.h
@@ -36,6 +36,7 @@ public:
     bool revealFocus(const HistoryFocus &focus, bool animated = true) const;
     [[nodiscard]] double scaleX() const;
     [[nodiscard]] int horizontalBarValue() const;
+    [[nodiscard]] bool isRhiBackendActive() const;
 
 public slots:
     void onEditModeChanged(ClipEditorGlobal::PianoRollEditMode mode) const;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.h
@@ -36,7 +36,6 @@ public:
     bool revealFocus(const HistoryFocus &focus, bool animated = true) const;
     [[nodiscard]] double scaleX() const;
     [[nodiscard]] int horizontalBarValue() const;
-    [[nodiscard]] bool isRhiBackendActive() const;
 
 public slots:
     void onEditModeChanged(ClipEditorGlobal::PianoRollEditMode mode) const;

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
@@ -27,7 +27,7 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
             [=](const double tick) {
                 m_pianoRollView->setPlaybackPosition(tick);
             });
-    connect(playbackController, &PlaybackController::positionChanged, this,
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
             [=](const double tick) {
                 paramGraphicsView->setPlaybackPosition(tick);
             });

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
@@ -21,6 +21,8 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
     setStretchFactor(1, 1);
 
     const auto paramGraphicsView = m_paramEditorView->graphicsView();
+    // The piano roll owns page turning and forwards its horizontal position to this view.
+    paramGraphicsView->setAutoTurnPage(false);
     connect(playbackController, &PlaybackController::visualPositionChanged, this,
             [=](const double tick) {
                 m_pianoRollView->setPlaybackPosition(tick);

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
@@ -21,7 +21,8 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
     setStretchFactor(1, 1);
 
     const auto paramGraphicsView = m_paramEditorView->graphicsView();
-    connect(playbackController, &PlaybackController::positionChanged, this, [=](const double tick) {
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
+            [=](const double tick) {
         m_pianoRollView->setPlaybackPosition(tick);
         paramGraphicsView->setPlaybackPosition(tick);
     });

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
@@ -23,8 +23,14 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
     const auto paramGraphicsView = m_paramEditorView->graphicsView();
     connect(playbackController, &PlaybackController::visualPositionChanged, this,
             [=](const double tick) {
-        m_pianoRollView->setPlaybackPosition(tick);
-        paramGraphicsView->setPlaybackPosition(tick);
+                if (m_pianoRollView->isRhiBackendActive())
+                    m_pianoRollView->setPlaybackPosition(tick);
+            });
+    connect(playbackController, &PlaybackController::positionChanged, this,
+            [=](const double tick) {
+                if (!m_pianoRollView->isRhiBackendActive())
+                    m_pianoRollView->setPlaybackPosition(tick);
+                paramGraphicsView->setPlaybackPosition(tick);
     });
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             [=](const double tick) {

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
@@ -23,15 +23,12 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
     const auto paramGraphicsView = m_paramEditorView->graphicsView();
     connect(playbackController, &PlaybackController::visualPositionChanged, this,
             [=](const double tick) {
-                if (m_pianoRollView->isRhiBackendActive())
-                    m_pianoRollView->setPlaybackPosition(tick);
+                m_pianoRollView->setPlaybackPosition(tick);
             });
     connect(playbackController, &PlaybackController::positionChanged, this,
             [=](const double tick) {
-                if (!m_pianoRollView->isRhiBackendActive())
-                    m_pianoRollView->setPlaybackPosition(tick);
                 paramGraphicsView->setPlaybackPosition(tick);
-    });
+            });
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             [=](const double tick) {
                 m_pianoRollView->setLastPlaybackPosition(tick);

--- a/src/app/UI/Views/Common/EditorGlyphAtlas.cpp
+++ b/src/app/UI/Views/Common/EditorGlyphAtlas.cpp
@@ -90,15 +90,23 @@ EditorRhiTextureDrawSpan EditorGlyphAtlas::appendText(
     return {page.id, vertexOffset, page.vertices.size() - vertexOffset, color};
 }
 
-QVector<EditorRhiTextureBatch> EditorGlyphAtlas::textureBatches() const {
-    QVector<EditorRhiTextureBatch> result;
-    result.reserve(m_pages.size());
+void EditorGlyphAtlas::populateTextureBatches(QVector<EditorRhiTextureBatch> &batches) const {
+    const auto batchCount = std::count_if(m_pages.cbegin(), m_pages.cend(),
+                                          [](const auto &page) {
+                                              return !page->vertices.isEmpty();
+                                          });
+    batches.resize(batchCount);
+    auto batchIndex = qsizetype(0);
     for (const auto &page : m_pages) {
         if (page->vertices.isEmpty())
             continue;
-        result.append({page->id, page->generation, page->image, page->vertices});
+        auto &batch = batches[batchIndex++];
+        batch.pageId = page->id;
+        batch.generation = page->generation;
+        batch.image = page->image;
+        batch.vertices.resize(page->vertices.size());
+        std::copy(page->vertices.cbegin(), page->vertices.cend(), batch.vertices.begin());
     }
-    return result;
 }
 
 double EditorGlyphAtlas::hitRate() const {

--- a/src/app/UI/Views/Common/EditorGlyphAtlas.h
+++ b/src/app/UI/Views/Common/EditorGlyphAtlas.h
@@ -29,7 +29,7 @@ public:
                                         double devicePixelRatio = 1.0,
                                         const QPointF &physicalCameraOffset = {},
                                         const QPointF &physicalWindowOffset = {});
-    [[nodiscard]] QVector<EditorRhiTextureBatch> textureBatches() const;
+    void populateTextureBatches(QVector<EditorRhiTextureBatch> &batches) const;
     [[nodiscard]] double hitRate() const;
 
 private:

--- a/src/app/UI/Views/Common/EditorRhiGeometry.cpp
+++ b/src/app/UI/Views/Common/EditorRhiGeometry.cpp
@@ -500,6 +500,21 @@ void EditorRhiGeometry::appendAntialiasedVerticalLine(QVector<EditorRhiSolidVert
     }
 }
 
+void EditorRhiGeometry::appendAntialiasedVerticalOverlay(QVector<EditorRhiOverlayRect> &rects,
+                                                         const double physicalViewportX,
+                                                         const double top, const double bottom,
+                                                         const double physicalWidth,
+                                                         const QColor &color) {
+    if (bottom <= top || physicalWidth <= 0.0 || color.alpha() == 0)
+        return;
+    const auto lineStart = physicalViewportX - physicalWidth * 0.5;
+    const auto lineEnd = physicalViewportX + physicalWidth * 0.5;
+    for (const auto &span : pixelCoverageSpans(lineStart, lineEnd)) {
+        rects.append(
+            {QRectF(span.start, top, span.end - span.start, bottom - top), color, span.coverage});
+    }
+}
+
 void EditorRhiGeometry::appendAntialiasedHorizontalLine(QVector<EditorRhiSolidVertex> &vertices,
                                                         const double physicalY, const double left,
                                                         const double right,

--- a/src/app/UI/Views/Common/EditorRhiGeometry.h
+++ b/src/app/UI/Views/Common/EditorRhiGeometry.h
@@ -16,6 +16,12 @@ struct EditorRhiSolidVertex {
     float coverage = 1.0f;
 };
 
+struct EditorRhiOverlayRect {
+    QRectF physicalViewportRect;
+    QColor color;
+    float coverage = 1.0f;
+};
+
 namespace EditorRhiGeometry {
     void appendRect(QVector<EditorRhiSolidVertex> &vertices, const QRectF &physicalRect,
                     const QColor &color, float coverage = 1.0f);
@@ -39,6 +45,9 @@ namespace EditorRhiGeometry {
     void appendAntialiasedVerticalLine(QVector<EditorRhiSolidVertex> &vertices, double physicalX,
                                        double top, double bottom, double physicalWidth,
                                        const QColor &color, double physicalCameraX = 0.0);
+    void appendAntialiasedVerticalOverlay(QVector<EditorRhiOverlayRect> &rects,
+                                          double physicalViewportX, double top, double bottom,
+                                          double physicalWidth, const QColor &color);
     void appendAntialiasedHorizontalLine(QVector<EditorRhiSolidVertex> &vertices, double physicalY,
                                          double left, double right, double physicalWidth,
                                          const QColor &color, double physicalCameraY = 0.0);

--- a/src/app/UI/Views/Common/EditorRhiWidget.cpp
+++ b/src/app/UI/Views/Common/EditorRhiWidget.cpp
@@ -570,8 +570,6 @@ public:
             submitSamples.append((now - updateRequestedNs) / 1000000.0);
             updateRequestedNs = 0;
         }
-        q->onFrameSubmitted();
-
         if (!appOptions->developer()->enableDiagnostics || cpuSamples.size() < kStatsWindow)
             return;
         qInfo().noquote() << QStringLiteral(
@@ -733,9 +731,6 @@ bool EditorRhiWidget::event(QEvent *event) {
 }
 
 void EditorRhiWidget::onRhiReady() {
-}
-
-void EditorRhiWidget::onFrameSubmitted() {
 }
 
 void EditorRhiWidget::onDevicePixelRatioChanged() {

--- a/src/app/UI/Views/Common/EditorRhiWidget.cpp
+++ b/src/app/UI/Views/Common/EditorRhiWidget.cpp
@@ -58,6 +58,16 @@ namespace {
         blend.dstAlpha = QRhiGraphicsPipeline::One;
         pipeline->setTargetBlends({blend});
     }
+
+    void configureOverlayBlend(QRhiGraphicsPipeline *pipeline) {
+        QRhiGraphicsPipeline::TargetBlend blend;
+        blend.enable = true;
+        blend.srcColor = QRhiGraphicsPipeline::ConstantColor;
+        blend.dstColor = QRhiGraphicsPipeline::OneMinusConstantAlpha;
+        blend.srcAlpha = QRhiGraphicsPipeline::ConstantAlpha;
+        blend.dstAlpha = QRhiGraphicsPipeline::OneMinusConstantAlpha;
+        pipeline->setTargetBlends({blend});
+    }
 }
 
 class EditorRhiWidget::Private {
@@ -84,20 +94,13 @@ public:
             fail(QStringLiteral("QRhi or color texture is unavailable"));
             return;
         }
-
-        const QRhiTextureRenderTargetDescription targetDescription{
-            QRhiColorAttachment(colorTexture)};
-        renderTarget.reset(rhi->newTextureRenderTarget(targetDescription));
-        renderPassDescriptor.reset(renderTarget->newCompatibleRenderPassDescriptor());
-        renderTarget->setRenderPassDescriptor(renderPassDescriptor.get());
-        if (!renderTarget->create()) {
-            fail(QStringLiteral("failed to create color-only render target"));
+        if (!createRenderTargets())
             return;
-        }
 
         uniformBuffer.reset(rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 64));
-        if (!uniformBuffer->create()) {
-            fail(QStringLiteral("failed to create camera uniform buffer"));
+        blitUniformBuffer.reset(rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 16));
+        if (!uniformBuffer->create() || !blitUniformBuffer->create()) {
+            fail(QStringLiteral("failed to create editor uniform buffers"));
             return;
         }
 
@@ -108,11 +111,19 @@ public:
             fail(QStringLiteral("failed to create solid shader bindings"));
             return;
         }
+        overlayBindings.reset(rhi->newShaderResourceBindings());
+        if (!overlayBindings->create()) {
+            fail(QStringLiteral("failed to create overlay shader bindings"));
+            return;
+        }
 
         fallbackTexture.reset(rhi->newTexture(QRhiTexture::RGBA8, QSize(1, 1)));
         sampler.reset(rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
                                       QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge));
-        if (!fallbackTexture->create() || !sampler->create()) {
+        sceneSampler.reset(rhi->newSampler(QRhiSampler::Nearest, QRhiSampler::Nearest,
+                                           QRhiSampler::None, QRhiSampler::ClampToEdge,
+                                           QRhiSampler::ClampToEdge));
+        if (!fallbackTexture->create() || !sampler->create() || !sceneSampler->create()) {
             fail(QStringLiteral("failed to create text sampler resources"));
             return;
         }
@@ -127,11 +138,15 @@ public:
             fail(QStringLiteral("failed to create text shader bindings"));
             return;
         }
+        if (!createSceneBindings())
+            return;
 
         QImage fallbackImage(1, 1, QImage::Format_RGBA8888_Premultiplied);
         fallbackImage.fill(Qt::transparent);
         auto initialUpdates = rhi->nextResourceUpdateBatch();
         initialUpdates->uploadTexture(fallbackTexture.get(), fallbackImage);
+        const qint32 flip = rhi->isYUpInFramebuffer() ? 0 : 1;
+        initialUpdates->updateDynamicBuffer(blitUniformBuffer.get(), 0, sizeof(flip), &flip);
         pendingUpdates.reset(initialUpdates);
 
         if (!createPipelines())
@@ -139,7 +154,8 @@ public:
 
         resourcesReady = true;
         qInfo().noquote() << QStringLiteral(
-                                 "[%1] initialized backend=%2 sampleCount=1 depthStencil=none")
+                                 "[%1] initialized backend=%2 sampleCount=1 depthStencil=none "
+                                 "sceneCache=enabled")
                                  .arg(diagnosticsTag, QString::fromUtf8(rhi->backendName()));
         q->onRhiReady();
     }
@@ -149,17 +165,22 @@ public:
         const auto solidFragment = loadShader(QStringLiteral(":/editor_rhi/solid.frag.qsb"));
         const auto textureVertex = loadShader(QStringLiteral(":/editor_rhi/texture.vert.qsb"));
         const auto textureFragment = loadShader(QStringLiteral(":/editor_rhi/texture.frag.qsb"));
+        const auto sceneVertex = loadShader(QStringLiteral(":/editor_rhi/scene.vert.qsb"));
+        const auto sceneFragment = loadShader(QStringLiteral(":/editor_rhi/scene.frag.qsb"));
+        const auto overlayVertex = loadShader(QStringLiteral(":/editor_rhi/overlay.vert.qsb"));
+        const auto overlayFragment = loadShader(QStringLiteral(":/editor_rhi/overlay.frag.qsb"));
         if (!solidVertex.isValid() || !solidFragment.isValid() || !textureVertex.isValid() ||
-            !textureFragment.isValid()) {
+            !textureFragment.isValid() || !sceneVertex.isValid() || !sceneFragment.isValid() ||
+            !overlayVertex.isValid() || !overlayFragment.isValid()) {
             fail(QStringLiteral("failed to load editor RHI shaders"));
             return false;
         }
 
-        solidPipeline.reset(rhi->newGraphicsPipeline());
-        solidPipeline->setShaderStages({
-            {QRhiShaderStage::Vertex,   solidVertex  },
-            {QRhiShaderStage::Fragment, solidFragment}
-        });
+        solidPipeline.reset();
+        textPipeline.reset();
+        overlayPipeline.reset();
+        scenePipeline.reset();
+
         QRhiVertexInputLayout solidLayout;
         solidLayout.setBindings({{sizeof(EditorRhiSolidVertex)}});
         solidLayout.setAttributes({
@@ -167,9 +188,15 @@ public:
             {0, 1, QRhiVertexInputAttribute::Float4, offsetof(EditorRhiSolidVertex, r)       },
             {0, 2, QRhiVertexInputAttribute::Float,  offsetof(EditorRhiSolidVertex, coverage)},
         });
+
+        solidPipeline.reset(rhi->newGraphicsPipeline());
+        solidPipeline->setShaderStages({
+            {QRhiShaderStage::Vertex,   solidVertex  },
+            {QRhiShaderStage::Fragment, solidFragment}
+        });
         solidPipeline->setVertexInputLayout(solidLayout);
         solidPipeline->setShaderResourceBindings(solidBindings.get());
-        solidPipeline->setRenderPassDescriptor(renderPassDescriptor.get());
+        solidPipeline->setRenderPassDescriptor(sceneRenderPassDescriptor.get());
         solidPipeline->setSampleCount(1);
         solidPipeline->setFlags(QRhiGraphicsPipeline::UsesScissor);
         configurePremultipliedBlend(solidPipeline.get());
@@ -193,13 +220,92 @@ public:
         });
         textPipeline->setVertexInputLayout(textLayout);
         textPipeline->setShaderResourceBindings(fallbackTextBindings.get());
-        textPipeline->setRenderPassDescriptor(renderPassDescriptor.get());
+        textPipeline->setRenderPassDescriptor(sceneRenderPassDescriptor.get());
         textPipeline->setSampleCount(1);
         configureTextBlend(textPipeline.get());
         textPipeline->setFlags(QRhiGraphicsPipeline::UsesScissor |
                                QRhiGraphicsPipeline::UsesBlendConstants);
         if (!textPipeline->create()) {
             fail(QStringLiteral("failed to create text pipeline"));
+            return false;
+        }
+
+        overlayPipeline.reset(rhi->newGraphicsPipeline());
+        overlayPipeline->setShaderStages({
+            {QRhiShaderStage::Vertex,   overlayVertex  },
+            {QRhiShaderStage::Fragment, overlayFragment}
+        });
+        overlayPipeline->setVertexInputLayout({});
+        overlayPipeline->setShaderResourceBindings(overlayBindings.get());
+        overlayPipeline->setRenderPassDescriptor(renderPassDescriptor.get());
+        overlayPipeline->setSampleCount(1);
+        overlayPipeline->setFlags(QRhiGraphicsPipeline::UsesBlendConstants);
+        configureOverlayBlend(overlayPipeline.get());
+        if (!overlayPipeline->create()) {
+            fail(QStringLiteral("failed to create overlay pipeline"));
+            return false;
+        }
+
+        scenePipeline.reset(rhi->newGraphicsPipeline());
+        scenePipeline->setShaderStages({
+            {QRhiShaderStage::Vertex,   sceneVertex  },
+            {QRhiShaderStage::Fragment, sceneFragment}
+        });
+        scenePipeline->setVertexInputLayout({});
+        scenePipeline->setShaderResourceBindings(sceneBindings.get());
+        scenePipeline->setRenderPassDescriptor(renderPassDescriptor.get());
+        scenePipeline->setSampleCount(1);
+        if (!scenePipeline->create()) {
+            fail(QStringLiteral("failed to create scene compositing pipeline"));
+            return false;
+        }
+        return true;
+    }
+
+    bool createRenderTargets() {
+        if (!rhi || !colorTexture)
+            return false;
+
+        const QRhiTextureRenderTargetDescription targetDescription{
+            QRhiColorAttachment(colorTexture)};
+        renderTarget.reset(rhi->newTextureRenderTarget(targetDescription));
+        renderPassDescriptor.reset(renderTarget->newCompatibleRenderPassDescriptor());
+        renderTarget->setRenderPassDescriptor(renderPassDescriptor.get());
+        if (!renderTarget->create()) {
+            fail(QStringLiteral("failed to create color-only render target"));
+            return false;
+        }
+
+        const auto outputSize = colorTexture->pixelSize();
+        sceneTexture.reset(
+            rhi->newTexture(QRhiTexture::RGBA8, outputSize, 1, QRhiTexture::RenderTarget));
+        if (!sceneTexture->create()) {
+            fail(QStringLiteral("failed to create scene cache texture"));
+            return false;
+        }
+        const QRhiTextureRenderTargetDescription sceneDescription{
+            QRhiColorAttachment(sceneTexture.get())};
+        sceneRenderTarget.reset(rhi->newTextureRenderTarget(sceneDescription));
+        sceneRenderPassDescriptor.reset(sceneRenderTarget->newCompatibleRenderPassDescriptor());
+        sceneRenderTarget->setRenderPassDescriptor(sceneRenderPassDescriptor.get());
+        if (!sceneRenderTarget->create()) {
+            fail(QStringLiteral("failed to create scene cache render target"));
+            return false;
+        }
+        frameDirty = true;
+        return true;
+    }
+
+    bool createSceneBindings() {
+        sceneBindings.reset(rhi->newShaderResourceBindings());
+        sceneBindings->setBindings({
+            QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage,
+                                                     blitUniformBuffer.get()),
+            QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage,
+                                                      sceneTexture.get(), sceneSampler.get()),
+        });
+        if (!sceneBindings->create()) {
+            fail(QStringLiteral("failed to create scene cache bindings"));
             return false;
         }
         return true;
@@ -216,24 +322,22 @@ public:
         q->update();
     }
 
-    QVector<EditorRhiSolidVertex> submitOverlay(QVector<EditorRhiSolidVertex> newVertices) {
-        auto previousVertices = std::move(overlayVertices);
-        overlayVertices = std::move(newVertices);
-        overlayDirty = true;
+    QVector<EditorRhiOverlayRect> submitOverlay(QVector<EditorRhiOverlayRect> newRects) {
+        auto previousRects = std::move(overlayRects);
+        overlayRects = std::move(newRects);
         q->update();
-        return previousVertices;
+        return previousRects;
     }
 
     void render(QRhiCommandBuffer *cb) {
         if (!resourcesReady || !cb)
             return;
-        if (colorTexture != q->colorTexture() || !renderTarget) {
+        if (colorTexture != q->colorTexture() || !renderTarget || !sceneRenderTarget) {
             // Qt recreates the color buffer on resize / DPI change without
             // re-entering initialize(), so detect the swap here and rebuild the
-            // render target lazily.
+            // render targets lazily.
             colorTexture = q->colorTexture();
-            rebuildRenderTarget();
-            if (!renderTarget)
+            if (!rebuildRenderTargets())
                 return;
         }
 
@@ -255,17 +359,6 @@ public:
             uploadedBytes += bytes;
         }
 
-        ensureBuffer(overlayBuffer, overlayBufferCapacity,
-                     overlayVertices.size() *
-                         static_cast<qsizetype>(sizeof(EditorRhiSolidVertex)),
-                     overlayDirty);
-        if (overlayDirty && overlayBuffer && !overlayVertices.isEmpty()) {
-            const auto bytes = overlayVertices.size() * sizeof(EditorRhiSolidVertex);
-            updates->updateDynamicBuffer(overlayBuffer.get(), 0, static_cast<quint32>(bytes),
-                                         overlayVertices.constData());
-            uploadedBytes += bytes;
-        }
-
         for (const auto &batch : frame.textureBatches) {
             auto &resources = textureResources[batch.pageId];
             if (!resources)
@@ -274,27 +367,25 @@ public:
         }
 
         const auto outputSize = renderTarget->pixelSize();
-        QMatrix4x4 projection;
-        projection.ortho(0.0f, static_cast<float>(outputSize.width()),
-                         static_cast<float>(outputSize.height()), 0.0f, -1.0f, 1.0f);
-        projection.translate(static_cast<float>(-frame.physicalCameraOffset.x()),
-                             static_cast<float>(-frame.physicalCameraOffset.y()));
-        const auto matrix = rhi->clipSpaceCorrMatrix() * projection;
-        updates->updateDynamicBuffer(uniformBuffer.get(), 0, 64, matrix.constData());
+        if (frameDirty) {
+            QMatrix4x4 projection;
+            projection.ortho(0.0f, static_cast<float>(outputSize.width()),
+                             static_cast<float>(outputSize.height()), 0.0f, -1.0f, 1.0f);
+            projection.translate(static_cast<float>(-frame.physicalCameraOffset.x()),
+                                 static_cast<float>(-frame.physicalCameraOffset.y()));
+            const auto matrix = rhi->clipSpaceCorrMatrix() * projection;
+            updates->updateDynamicBuffer(uniformBuffer.get(), 0, 64, matrix.constData());
+        }
         const auto uploadMs = uploadTimer.nsecsElapsed() / 1000000.0;
 
         QElapsedTimer encodeTimer;
         encodeTimer.start();
-        cb->beginPass(renderTarget.get(), frame.clearColor, {1.0f, 0}, updates);
-        cb->setViewport(QRhiViewport(0, 0, outputSize.width(), outputSize.height()));
-        cb->setScissor(QRhiScissor(0, 0, outputSize.width(), outputSize.height()));
-
         int drawCalls = 0;
-        const auto drawSolid = [&](QRhiBuffer *buffer, const qsizetype vertexOffset,
-                                   const qsizetype vertexCount) {
-            if (!buffer || vertexCount <= 0)
+        const auto drawSolid = [&](QRhiGraphicsPipeline *pipeline, QRhiBuffer *buffer,
+                                   const qsizetype vertexOffset, const qsizetype vertexCount) {
+            if (!pipeline || !buffer || vertexCount <= 0)
                 return;
-            cb->setGraphicsPipeline(solidPipeline.get());
+            cb->setGraphicsPipeline(pipeline);
             cb->setShaderResources(solidBindings.get());
             const auto byteOffset =
                 static_cast<quint32>(vertexOffset * sizeof(EditorRhiSolidVertex));
@@ -324,22 +415,55 @@ public:
             cb->draw(static_cast<quint32>(vertexCount));
             ++drawCalls;
         };
-        if (!frame.drawList.commands.isEmpty()) {
-            for (const auto &command : frame.drawList.commands) {
-                if (command.type == EditorRhiDrawCommand::Type::Solid)
-                    drawSolid(solidBuffer.get(), command.vertexOffset, command.vertexCount);
-                else
-                    drawTexture(command.pageId, command.vertexOffset, command.vertexCount,
-                                command.color);
+
+        if (frameDirty) {
+            const auto sceneSize = sceneRenderTarget->pixelSize();
+            cb->beginPass(sceneRenderTarget.get(), frame.clearColor, {1.0f, 0}, updates);
+            updates = nullptr;
+            cb->setViewport(QRhiViewport(0, 0, sceneSize.width(), sceneSize.height()));
+            cb->setScissor(QRhiScissor(0, 0, sceneSize.width(), sceneSize.height()));
+            if (!frame.drawList.commands.isEmpty()) {
+                for (const auto &command : frame.drawList.commands) {
+                    if (command.type == EditorRhiDrawCommand::Type::Solid)
+                        drawSolid(solidPipeline.get(), solidBuffer.get(), command.vertexOffset,
+                                  command.vertexCount);
+                    else
+                        drawTexture(command.pageId, command.vertexOffset, command.vertexCount,
+                                    command.color);
+                }
+            } else {
+                drawSolid(solidPipeline.get(), solidBuffer.get(), 0, frame.solidVertices.size());
             }
-        } else {
-            drawSolid(solidBuffer.get(), 0, frame.solidVertices.size());
+            cb->endPass();
         }
-        drawSolid(overlayBuffer.get(), 0, overlayVertices.size());
+
+        cb->beginPass(renderTarget.get(), frame.clearColor, {1.0f, 0}, updates);
+        cb->setViewport(QRhiViewport(0, 0, outputSize.width(), outputSize.height()));
+        cb->setGraphicsPipeline(scenePipeline.get());
+        cb->setShaderResources(sceneBindings.get());
+        cb->draw(3);
+        ++drawCalls;
+        cb->setGraphicsPipeline(overlayPipeline.get());
+        cb->setShaderResources(overlayBindings.get());
+        const QRectF outputRect(0.0, 0.0, outputSize.width(), outputSize.height());
+        for (const auto &overlay : overlayRects) {
+            const auto rect = overlay.physicalViewportRect.intersected(outputRect);
+            const auto alpha = std::clamp(overlay.color.alphaF() * overlay.coverage, 0.0f, 1.0f);
+            if (rect.isEmpty() || alpha <= 0.0)
+                continue;
+            const auto blendColor =
+                QColor::fromRgbF(overlay.color.redF() * alpha, overlay.color.greenF() * alpha,
+                                 overlay.color.blueF() * alpha, alpha);
+            cb->setViewport(QRhiViewport(static_cast<float>(rect.x()), static_cast<float>(rect.y()),
+                                         static_cast<float>(rect.width()),
+                                         static_cast<float>(rect.height())));
+            cb->setBlendConstants(blendColor);
+            cb->draw(3);
+            ++drawCalls;
+        }
         cb->endPass();
         const auto encodeMs = encodeTimer.nsecsElapsed() / 1000000.0;
         frameDirty = false;
-        overlayDirty = false;
 
         if (appOptions->developer()->enableDiagnostics) {
             uploadSamples.append(uploadMs);
@@ -369,24 +493,20 @@ public:
         dirty = true;
     }
 
-    void rebuildRenderTarget() {
+    bool rebuildRenderTargets() {
+        scenePipeline.reset();
+        overlayPipeline.reset();
+        textPipeline.reset();
+        solidPipeline.reset();
+        sceneBindings.reset();
+        sceneRenderTarget.reset();
+        sceneRenderPassDescriptor.reset();
+        sceneTexture.reset();
         renderTarget.reset();
         renderPassDescriptor.reset();
         if (!rhi || !colorTexture)
-            return;
-        const QRhiTextureRenderTargetDescription targetDescription{
-            QRhiColorAttachment(colorTexture)};
-        renderTarget.reset(rhi->newTextureRenderTarget(targetDescription));
-        if (renderTarget) {
-            renderPassDescriptor.reset(renderTarget->newCompatibleRenderPassDescriptor());
-            renderTarget->setRenderPassDescriptor(renderPassDescriptor.get());
-            createPipelines(); // 旧 pipeline 引用旧 descriptor，必须重建
-            if (!renderTarget->create()) {
-                renderTarget.reset();
-                renderPassDescriptor.reset();
-                fail(QStringLiteral("failed to recreate render target after buffer swap"));
-            }
-        }
+            return false;
+        return createRenderTargets() && createSceneBindings() && createPipelines();
     }
 
     void invalidateTextures() {
@@ -485,19 +605,26 @@ public:
     void release() {
         resourcesReady = false;
         textureResources.clear();
+        scenePipeline.reset();
+        overlayPipeline.reset();
         textPipeline.reset();
         solidPipeline.reset();
+        sceneBindings.reset();
         fallbackTextBindings.reset();
+        overlayBindings.reset();
         solidBindings.reset();
+        sceneSampler.reset();
         sampler.reset();
         fallbackTexture.reset();
-        overlayBuffer.reset();
         solidBuffer.reset();
+        blitUniformBuffer.reset();
         uniformBuffer.reset();
         pendingUpdates.reset();
+        sceneRenderTarget.reset();
+        sceneRenderPassDescriptor.reset();
+        sceneTexture.reset();
         renderTarget.reset();
         renderPassDescriptor.reset();
-        overlayBufferCapacity = 0;
         solidBufferCapacity = 0;
         colorTexture = nullptr;
         rhi = nullptr;
@@ -506,24 +633,30 @@ public:
     EditorRhiWidget *q;
     QString diagnosticsTag;
     EditorRhiFrameData frame;
-    QVector<EditorRhiSolidVertex> overlayVertices;
+    QVector<EditorRhiOverlayRect> overlayRects;
     bool frameDirty = true;
-    bool overlayDirty = true;
     bool resourcesReady = false;
     bool failureRequested = false;
     QRhi *rhi = nullptr;
     QRhiTexture *colorTexture = nullptr;
-    qsizetype overlayBufferCapacity = 0;
     qsizetype solidBufferCapacity = 0;
     std::unique_ptr<QRhiTextureRenderTarget> renderTarget;
     std::unique_ptr<QRhiRenderPassDescriptor> renderPassDescriptor;
+    std::unique_ptr<QRhiTexture> sceneTexture;
+    std::unique_ptr<QRhiTextureRenderTarget> sceneRenderTarget;
+    std::unique_ptr<QRhiRenderPassDescriptor> sceneRenderPassDescriptor;
     std::unique_ptr<QRhiBuffer> uniformBuffer;
-    std::unique_ptr<QRhiBuffer> overlayBuffer;
+    std::unique_ptr<QRhiBuffer> blitUniformBuffer;
     std::unique_ptr<QRhiBuffer> solidBuffer;
     std::unique_ptr<QRhiShaderResourceBindings> solidBindings;
+    std::unique_ptr<QRhiShaderResourceBindings> overlayBindings;
+    std::unique_ptr<QRhiShaderResourceBindings> sceneBindings;
     std::unique_ptr<QRhiGraphicsPipeline> solidPipeline;
+    std::unique_ptr<QRhiGraphicsPipeline> overlayPipeline;
+    std::unique_ptr<QRhiGraphicsPipeline> scenePipeline;
     std::unique_ptr<QRhiTexture> fallbackTexture;
     std::unique_ptr<QRhiSampler> sampler;
+    std::unique_ptr<QRhiSampler> sceneSampler;
     std::unique_ptr<QRhiShaderResourceBindings> fallbackTextBindings;
     std::unique_ptr<QRhiGraphicsPipeline> textPipeline;
     std::unique_ptr<QRhiResourceUpdateBatch> pendingUpdates;
@@ -567,9 +700,8 @@ void EditorRhiWidget::submitFrame(EditorRhiFrameData frame) {
     d->submit(std::move(frame));
 }
 
-QVector<EditorRhiSolidVertex>
-    EditorRhiWidget::submitOverlay(QVector<EditorRhiSolidVertex> vertices) {
-    return d->submitOverlay(std::move(vertices));
+QVector<EditorRhiOverlayRect> EditorRhiWidget::submitOverlay(QVector<EditorRhiOverlayRect> rects) {
+    return d->submitOverlay(std::move(rects));
 }
 
 QPointF EditorRhiWidget::physicalWindowOffset() const {

--- a/src/app/UI/Views/Common/EditorRhiWidget.cpp
+++ b/src/app/UI/Views/Common/EditorRhiWidget.cpp
@@ -205,11 +205,23 @@ public:
         return true;
     }
 
+    EditorRhiFrameData acquireFrame() {
+        return std::move(frame);
+    }
+
     void submit(EditorRhiFrameData newFrame) {
         frame = std::move(newFrame);
         frameDirty = true;
         updateRequestedNs = clock.nsecsElapsed();
         q->update();
+    }
+
+    QVector<EditorRhiSolidVertex> submitOverlay(QVector<EditorRhiSolidVertex> newVertices) {
+        auto previousVertices = std::move(overlayVertices);
+        overlayVertices = std::move(newVertices);
+        overlayDirty = true;
+        q->update();
+        return previousVertices;
     }
 
     void render(QRhiCommandBuffer *cb) {
@@ -233,12 +245,24 @@ public:
 
         ensureBuffer(solidBuffer, solidBufferCapacity,
                      frame.solidVertices.size() *
-                         static_cast<qsizetype>(sizeof(EditorRhiSolidVertex)));
+                         static_cast<qsizetype>(sizeof(EditorRhiSolidVertex)),
+                     frameDirty);
         double uploadedBytes = 0.0;
         if (frameDirty && solidBuffer && !frame.solidVertices.isEmpty()) {
             const auto bytes = frame.solidVertices.size() * sizeof(EditorRhiSolidVertex);
             updates->updateDynamicBuffer(solidBuffer.get(), 0, static_cast<quint32>(bytes),
                                          frame.solidVertices.constData());
+            uploadedBytes += bytes;
+        }
+
+        ensureBuffer(overlayBuffer, overlayBufferCapacity,
+                     overlayVertices.size() *
+                         static_cast<qsizetype>(sizeof(EditorRhiSolidVertex)),
+                     overlayDirty);
+        if (overlayDirty && overlayBuffer && !overlayVertices.isEmpty()) {
+            const auto bytes = overlayVertices.size() * sizeof(EditorRhiSolidVertex);
+            updates->updateDynamicBuffer(overlayBuffer.get(), 0, static_cast<quint32>(bytes),
+                                         overlayVertices.constData());
             uploadedBytes += bytes;
         }
 
@@ -266,14 +290,15 @@ public:
         cb->setScissor(QRhiScissor(0, 0, outputSize.width(), outputSize.height()));
 
         int drawCalls = 0;
-        const auto drawSolid = [&](const qsizetype vertexOffset, const qsizetype vertexCount) {
-            if (!solidBuffer || vertexCount <= 0)
+        const auto drawSolid = [&](QRhiBuffer *buffer, const qsizetype vertexOffset,
+                                   const qsizetype vertexCount) {
+            if (!buffer || vertexCount <= 0)
                 return;
             cb->setGraphicsPipeline(solidPipeline.get());
             cb->setShaderResources(solidBindings.get());
             const auto byteOffset =
                 static_cast<quint32>(vertexOffset * sizeof(EditorRhiSolidVertex));
-            const QRhiCommandBuffer::VertexInput binding(solidBuffer.get(), byteOffset);
+            const QRhiCommandBuffer::VertexInput binding(buffer, byteOffset);
             cb->setVertexInput(0, 1, &binding);
             cb->draw(static_cast<quint32>(vertexCount));
             ++drawCalls;
@@ -302,17 +327,19 @@ public:
         if (!frame.drawList.commands.isEmpty()) {
             for (const auto &command : frame.drawList.commands) {
                 if (command.type == EditorRhiDrawCommand::Type::Solid)
-                    drawSolid(command.vertexOffset, command.vertexCount);
+                    drawSolid(solidBuffer.get(), command.vertexOffset, command.vertexCount);
                 else
                     drawTexture(command.pageId, command.vertexOffset, command.vertexCount,
                                 command.color);
             }
         } else {
-            drawSolid(0, frame.solidVertices.size());
+            drawSolid(solidBuffer.get(), 0, frame.solidVertices.size());
         }
+        drawSolid(overlayBuffer.get(), 0, overlayVertices.size());
         cb->endPass();
         const auto encodeMs = encodeTimer.nsecsElapsed() / 1000000.0;
         frameDirty = false;
+        overlayDirty = false;
 
         if (appOptions->developer()->enableDiagnostics) {
             uploadSamples.append(uploadMs);
@@ -325,7 +352,7 @@ public:
     }
 
     void ensureBuffer(std::unique_ptr<QRhiBuffer> &buffer, qsizetype &capacity,
-                      const qsizetype requiredBytes) {
+                      const qsizetype requiredBytes, bool &dirty) {
         if (requiredBytes <= 0 || requiredBytes <= capacity)
             return;
         qsizetype newCapacity = std::max<qsizetype>(4096, capacity);
@@ -339,7 +366,7 @@ public:
             return;
         }
         capacity = newCapacity;
-        frameDirty = true;
+        dirty = true;
     }
 
     void rebuildRenderTarget() {
@@ -402,7 +429,7 @@ public:
         }
         const auto required =
             batch.vertices.size() * static_cast<qsizetype>(sizeof(EditorRhiTextVertex));
-        ensureBuffer(resources.vertexBuffer, resources.vertexCapacity, required);
+        ensureBuffer(resources.vertexBuffer, resources.vertexCapacity, required, frameDirty);
         if (frameDirty && resources.vertexBuffer && !batch.vertices.isEmpty()) {
             updates->updateDynamicBuffer(resources.vertexBuffer.get(), 0,
                                          static_cast<quint32>(required),
@@ -464,11 +491,13 @@ public:
         solidBindings.reset();
         sampler.reset();
         fallbackTexture.reset();
+        overlayBuffer.reset();
         solidBuffer.reset();
         uniformBuffer.reset();
         pendingUpdates.reset();
         renderTarget.reset();
         renderPassDescriptor.reset();
+        overlayBufferCapacity = 0;
         solidBufferCapacity = 0;
         colorTexture = nullptr;
         rhi = nullptr;
@@ -477,15 +506,19 @@ public:
     EditorRhiWidget *q;
     QString diagnosticsTag;
     EditorRhiFrameData frame;
+    QVector<EditorRhiSolidVertex> overlayVertices;
     bool frameDirty = true;
+    bool overlayDirty = true;
     bool resourcesReady = false;
     bool failureRequested = false;
     QRhi *rhi = nullptr;
     QRhiTexture *colorTexture = nullptr;
+    qsizetype overlayBufferCapacity = 0;
     qsizetype solidBufferCapacity = 0;
     std::unique_ptr<QRhiTextureRenderTarget> renderTarget;
     std::unique_ptr<QRhiRenderPassDescriptor> renderPassDescriptor;
     std::unique_ptr<QRhiBuffer> uniformBuffer;
+    std::unique_ptr<QRhiBuffer> overlayBuffer;
     std::unique_ptr<QRhiBuffer> solidBuffer;
     std::unique_ptr<QRhiShaderResourceBindings> solidBindings;
     std::unique_ptr<QRhiGraphicsPipeline> solidPipeline;
@@ -526,12 +559,17 @@ EditorRhiWidget::EditorRhiWidget(QString diagnosticsTag, QWidget *parent)
 
 EditorRhiWidget::~EditorRhiWidget() = default;
 
+EditorRhiFrameData EditorRhiWidget::acquireFrame() {
+    return d->acquireFrame();
+}
+
 void EditorRhiWidget::submitFrame(EditorRhiFrameData frame) {
     d->submit(std::move(frame));
 }
 
-const EditorRhiFrameData &EditorRhiWidget::frameData() const {
-    return d->frame;
+QVector<EditorRhiSolidVertex>
+    EditorRhiWidget::submitOverlay(QVector<EditorRhiSolidVertex> vertices) {
+    return d->submitOverlay(std::move(vertices));
 }
 
 QPointF EditorRhiWidget::physicalWindowOffset() const {

--- a/src/app/UI/Views/Common/EditorRhiWidget.h
+++ b/src/app/UI/Views/Common/EditorRhiWidget.h
@@ -112,8 +112,7 @@ protected:
     // Reclaiming the submitted snapshot lets producers rebuild it in place before update().
     [[nodiscard]] EditorRhiFrameData acquireFrame();
     void submitFrame(EditorRhiFrameData frame);
-    [[nodiscard]] QVector<EditorRhiSolidVertex>
-        submitOverlay(QVector<EditorRhiSolidVertex> vertices);
+    [[nodiscard]] QVector<EditorRhiOverlayRect> submitOverlay(QVector<EditorRhiOverlayRect> rects);
     [[nodiscard]] QPointF physicalWindowOffset() const;
     void requestBackendFailure(const QString &reason);
 

--- a/src/app/UI/Views/Common/EditorRhiWidget.h
+++ b/src/app/UI/Views/Common/EditorRhiWidget.h
@@ -122,7 +122,6 @@ protected:
     bool event(QEvent *event) override;
 
     virtual void onRhiReady();
-    virtual void onFrameSubmitted();
     virtual void onDevicePixelRatioChanged();
 
 private:

--- a/src/app/UI/Views/Common/EditorRhiWidget.h
+++ b/src/app/UI/Views/Common/EditorRhiWidget.h
@@ -109,8 +109,11 @@ signals:
     void backendFailed(const QString &reason);
 
 protected:
+    // Reclaiming the submitted snapshot lets producers rebuild it in place before update().
+    [[nodiscard]] EditorRhiFrameData acquireFrame();
     void submitFrame(EditorRhiFrameData frame);
-    [[nodiscard]] const EditorRhiFrameData &frameData() const;
+    [[nodiscard]] QVector<EditorRhiSolidVertex>
+        submitOverlay(QVector<EditorRhiSolidVertex> vertices);
     [[nodiscard]] QPointF physicalWindowOffset() const;
     void requestBackendFailure(const QString &reason);
 

--- a/src/app/UI/Views/Common/EditorViewportController.cpp
+++ b/src/app/UI/Views/Common/EditorViewportController.cpp
@@ -158,17 +158,21 @@ bool EditorViewportController::ensureVisible(const QRectF &rect, const double xM
 bool EditorViewportController::setStartTick(const double tick) {
     if (!std::isfinite(tick))
         return false;
+    const auto previousOffset = QPointF(m_offsetX, m_offsetY);
     m_offsetX = tickToSceneX(tick);
     normalize(false);
-    notify(false);
+    if (QPointF(m_offsetX, m_offsetY) != previousOffset)
+        notify(false);
     return true;
 }
 
 void EditorViewportController::scrollBy(const QPointF &deltaPixels) {
+    const auto previousOffset = QPointF(m_offsetX, m_offsetY);
     m_offsetX += deltaPixels.x();
     m_offsetY += deltaPixels.y();
     normalize(false);
-    notify(false);
+    if (QPointF(m_offsetX, m_offsetY) != previousOffset)
+        notify(false);
 }
 
 void EditorViewportController::zoomHorizontal(const double wheelDelta, const double anchorX) {

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QCursor>
 #include <QHideEvent>
+#include <QPainter>
 #include <QScrollBar>
 #include <QShowEvent>
 #include <QWheelEvent>
@@ -33,13 +34,7 @@ TimeGraphicsView::TimeGraphicsView(TimeGraphicsScene *scene, bool showLastPlayba
                                    QWidget *parent)
     : QGraphicsView(parent), m_scene(scene) {
     setRenderHint(QPainter::Antialiasing);
-    // Full viewport repaint: with partial updates the fast-scrubbing playhead
-    // indicator leaves ghost lines behind (the antialiased 1px ink extends
-    // past Qt's computed damage rect, so old positions never get erased).
-    // TODO: rework to repaint only the indicator's swept span (a route via
-    // scene->invalidate() was tried and did not clear the ghosts) or use
-    // SmartViewportUpdate with a custom damage tracking, to drop CPU cost.
-    setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+    setViewportUpdateMode(QGraphicsView::MinimalViewportUpdate);
     setAttribute(Qt::WA_AcceptTouchEvents);
     setAttribute(Qt::WA_Hover);
     setMinimumHeight(150);
@@ -96,14 +91,6 @@ TimeGraphicsView::TimeGraphicsView(TimeGraphicsScene *scene, bool showLastPlayba
             [this](double sx, double sy) { m_scene->setScaleXY(sx, sy); });
     connect(m_scene, &TimeGraphicsScene::baseSizeChanged, this,
             &TimeGraphicsView::adjustScaleXToFillView);
-
-    m_scenePlayPosIndicator = new TimeIndicatorView;
-    m_scenePlayPosIndicator->setPixelsPerQuarterNote(m_pixelsPerQuarterNote);
-    QPen curPlayPosPen;
-    curPlayPosPen.setWidth(1);
-    curPlayPosPen.setColor(m_playPosIndicatorColor);
-    m_scenePlayPosIndicator->setPen(curPlayPosPen);
-    m_scene->addTimeIndicator(m_scenePlayPosIndicator);
 
     m_sceneLastPlayPosIndicator = new TimeIndicatorView;
     m_sceneLastPlayPosIndicator->setPixelsPerQuarterNote(m_pixelsPerQuarterNote);
@@ -282,6 +269,7 @@ void TimeGraphicsView::setScrollBarVisibility(Qt::Orientation orientation, bool 
 }
 
 void TimeGraphicsView::notifyVisibleRectChanged() {
+    viewport()->update();
     emit visibleRectChanged(visibleRect());
 }
 
@@ -476,6 +464,19 @@ void TimeGraphicsView::wheelEvent(QWheelEvent *event) {
     notifyVisibleRectChanged();
 }
 
+void TimeGraphicsView::drawForeground(QPainter *painter, const QRectF &rect) {
+    QGraphicsView::drawForeground(painter, rect);
+
+    QPen pen(m_playPosIndicatorColor);
+    pen.setWidthF(1.0);
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing);
+    painter->setPen(pen);
+    const auto x = tickToSceneX(m_playbackPosition - m_offset);
+    painter->drawLine(QLineF(x, rect.top(), x, rect.bottom()));
+    painter->restore();
+}
+
 void TimeGraphicsView::resizeEvent(QResizeEvent *event) {
     if (scene()) {
         if (m_ensureSceneFillViewX) {
@@ -595,6 +596,7 @@ void TimeGraphicsView::updateAnimationDuration() {
 }
 
 void TimeGraphicsView::afterSetScale() {
+    viewport()->update();
     emit scaleChanged(scaleX(), scaleY());
 }
 
@@ -619,21 +621,18 @@ void TimeGraphicsView::setOffset(int tick) {
     if (m_gridItem)
         m_gridItem->setOffset(tick);
     m_sceneLastPlayPosIndicator->setOffset(tick);
-    m_scenePlayPosIndicator->setOffset(tick);
+    viewport()->update();
     emit timeRangeChanged(startTick(), endTick());
 }
 
 void TimeGraphicsView::setPixelsPerQuarterNote(int px) {
     m_pixelsPerQuarterNote = px;
-    m_scenePlayPosIndicator->setPixelsPerQuarterNote(m_pixelsPerQuarterNote);
     m_sceneLastPlayPosIndicator->setPixelsPerQuarterNote(m_pixelsPerQuarterNote);
+    viewport()->update();
 }
 
 void TimeGraphicsView::setLeftMarginPx(int px) {
     m_scene->setLeftMarginPx(px);
-    // Reposition the indicators and grid against the shifted origin, and let
-    // the ruler/lanes resync their time range.
-    m_scenePlayPosIndicator->setPosition(m_playbackPosition);
     m_sceneLastPlayPosIndicator->setPosition(m_lastPlaybackPosition);
     if (m_gridItem)
         m_gridItem->update();
@@ -742,30 +741,54 @@ void TimeGraphicsView::onEdgeAutoScrollFrame(const QPoint &clampedViewportPos,
 }
 
 void TimeGraphicsView::setPlaybackPosition(double tick) {
+    const auto oldTick = m_playbackPosition;
     m_playbackPosition = tick;
-    if (m_scenePlayPosIndicator != nullptr)
-        m_scenePlayPosIndicator->setPosition(tick);
 
-    if (!m_autoTurnPage || !m_autoPageTurnAvailable ||
-        appStatus->currentEditObject != AppStatus::EditObjectType::None) {
-        return;
-    }
-    if (isEdgeAutoScrollActive())
-        return;
+    const bool canTurnPage =
+        m_autoTurnPage && m_autoPageTurnAvailable &&
+        appStatus->currentEditObject == AppStatus::EditObjectType::None &&
+        !isEdgeAutoScrollActive();
+    if (canTurnPage) {
+        const auto viewWidth = viewport()->width();
+        const auto hBarValue = horizontalBarValue();
+        const auto targetEndTick = sceneXToTick(hBarValue + viewWidth) + m_offset;
+        const auto tickRange = targetEndTick - sceneXToTick(hBarValue) - m_offset;
 
-    const auto viewWidth = viewport()->width();
-    const auto hBarValue = horizontalBarValue();
-    const auto targetEndTick = sceneXToTick(hBarValue + viewWidth) + m_offset;
-    const auto tickRange = targetEndTick - sceneXToTick(hBarValue) - m_offset;
-
-    if (m_playbackPosition > targetEndTick) {
-        if (m_playbackPosition > targetEndTick + tickRange)
+        if (m_playbackPosition > targetEndTick) {
+            if (m_playbackPosition > targetEndTick + tickRange)
+                setViewportStartTick(m_playbackPosition);
+            else
+                pageAdd();
+        } else if (m_playbackPosition < startTick()) {
             setViewportStartTick(m_playbackPosition);
-        else
-            pageAdd();
-    } else if (m_playbackPosition < startTick()) {
-        setViewportStartTick(m_playbackPosition);
+        }
     }
+
+    updatePlaybackIndicator(oldTick);
+}
+
+QRect TimeGraphicsView::playbackIndicatorViewportRect(double tick) const {
+    if (!viewport())
+        return {};
+
+    const auto sceneX = tickToSceneX(tick - m_offset);
+    const auto viewportX = viewportTransform().map(QPointF(sceneX, 0)).x();
+    if (!std::isfinite(viewportX))
+        return {};
+
+    constexpr qreal updateMargin = 2.0;
+    return QRectF(viewportX - updateMargin, 0, updateMargin * 2, viewport()->height())
+        .toAlignedRect()
+        .intersected(viewport()->rect());
+}
+
+void TimeGraphicsView::updatePlaybackIndicator(double oldTick) {
+    const auto oldRect = playbackIndicatorViewportRect(oldTick);
+    const auto newRect = playbackIndicatorViewportRect(m_playbackPosition);
+    if (!oldRect.isEmpty())
+        viewport()->update(oldRect);
+    if (!newRect.isEmpty() && newRect != oldRect)
+        viewport()->update(newRect);
 }
 
 void TimeGraphicsView::setLastPlaybackPosition(double tick) {
@@ -878,12 +901,7 @@ void TimeGraphicsView::setPlayPosIndicatorColor(const QColor &color) {
     if (m_playPosIndicatorColor == color)
         return;
     m_playPosIndicatorColor = color;
-    if (m_scenePlayPosIndicator) {
-        auto pen = m_scenePlayPosIndicator->pen();
-        pen.setColor(color);
-        m_scenePlayPosIndicator->setPen(pen);
-        m_scenePlayPosIndicator->update();
-    }
+    updatePlaybackIndicator(m_playbackPosition);
 }
 
 QColor TimeGraphicsView::lastPlayPosIndicatorColor() const {

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -127,35 +127,6 @@ TimeGraphicsView::TimeGraphicsView(TimeGraphicsScene *scene, bool showLastPlayba
     connect(appModel, &AppModel::timelineChanged, this,
             &TimeGraphicsView::updateAutoPageTurnAvailability);
 
-    m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
-    connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
-        double tick = m_pendingPosition;
-        m_playbackPosition = tick;
-        if (m_scenePlayPosIndicator != nullptr)
-            m_scenePlayPosIndicator->setPosition(tick);
-
-        if (!m_autoTurnPage || !m_autoPageTurnAvailable ||
-            appStatus->currentEditObject != AppStatus::EditObjectType::None)
-            return;
-        // Do not auto turn pages while edge auto scroll drives the viewport
-        if (isEdgeAutoScrollActive())
-            return;
-
-        auto viewWidth = viewport()->width();
-        auto hBarValue = horizontalBarValue();
-        auto targetEndTick = sceneXToTick(hBarValue + viewWidth) + m_offset;
-        auto tickRange = targetEndTick - sceneXToTick(hBarValue) - m_offset;
-
-        if (m_playbackPosition > targetEndTick) {
-            if (m_playbackPosition > targetEndTick + tickRange)
-                setViewportStartTick(m_playbackPosition);
-            else
-                pageAdd();
-        } else if (m_playbackPosition < startTick())
-            setViewportStartTick(m_playbackPosition);
-    });
-
     connect(&m_edgeAutoScroller, &EdgeAutoScroller::frame, this,
             &TimeGraphicsView::onEdgeAutoScrollTimerFrame);
     QTimer::singleShot(0, this, &TimeGraphicsView::updateAutoPageTurnAvailability);
@@ -771,9 +742,30 @@ void TimeGraphicsView::onEdgeAutoScrollFrame(const QPoint &clampedViewportPos,
 }
 
 void TimeGraphicsView::setPlaybackPosition(double tick) {
-    m_pendingPosition = tick;
-    if (!m_positionThrottle.isActive())
-        m_positionThrottle.start();
+    m_playbackPosition = tick;
+    if (m_scenePlayPosIndicator != nullptr)
+        m_scenePlayPosIndicator->setPosition(tick);
+
+    if (!m_autoTurnPage || !m_autoPageTurnAvailable ||
+        appStatus->currentEditObject != AppStatus::EditObjectType::None) {
+        return;
+    }
+    if (isEdgeAutoScrollActive())
+        return;
+
+    const auto viewWidth = viewport()->width();
+    const auto hBarValue = horizontalBarValue();
+    const auto targetEndTick = sceneXToTick(hBarValue + viewWidth) + m_offset;
+    const auto tickRange = targetEndTick - sceneXToTick(hBarValue) - m_offset;
+
+    if (m_playbackPosition > targetEndTick) {
+        if (m_playbackPosition > targetEndTick + tickRange)
+            setViewportStartTick(m_playbackPosition);
+        else
+            pageAdd();
+    } else if (m_playbackPosition < startTick()) {
+        setViewportStartTick(m_playbackPosition);
+    }
 }
 
 void TimeGraphicsView::setLastPlaybackPosition(double tick) {

--- a/src/app/UI/Views/Common/TimeGraphicsView.h
+++ b/src/app/UI/Views/Common/TimeGraphicsView.h
@@ -206,8 +206,6 @@ private:
     bool m_autoPageTurnAvailable = false;
     double m_playbackPosition = 0;
     double m_lastPlaybackPosition = 0;
-    double m_pendingPosition = 0;
-    QTimer m_positionThrottle;
 
     QColor m_barLineColor = {8, 9, 10};
     QColor m_beatLineColor = {22, 25, 28};

--- a/src/app/UI/Views/Common/TimeGraphicsView.h
+++ b/src/app/UI/Views/Common/TimeGraphicsView.h
@@ -18,6 +18,7 @@ class TimeGridView;
 class TimeIndicatorView;
 class OverlayScrollBar;
 class QHideEvent;
+class QPainter;
 class QShowEvent;
 
 class TimeGraphicsView : public QGraphicsView, public IScalable, public IAnimatable {
@@ -104,6 +105,7 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent *event) override;
     bool event(QEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
+    void drawForeground(QPainter *painter, const QRectF &rect) override;
     void resizeEvent(QResizeEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -162,6 +164,8 @@ private:
     void onEdgeAutoScrollTimerFrame(double dtMs);
     void updateEdgeAutoScrollState(const QPoint &viewportPos);
     void updateAutoPageTurnAvailability();
+    [[nodiscard]] QRect playbackIndicatorViewportRect(double tick) const;
+    void updatePlaybackIndicator(double oldTick);
 
     double m_hZoomingStep = 0.4;
     double m_vZoomingStep = 0.3;
@@ -197,7 +201,6 @@ private:
 
     TimeGraphicsScene *m_scene;
     TimeGridView *m_gridItem = nullptr;
-    TimeIndicatorView *m_scenePlayPosIndicator = nullptr;
     TimeIndicatorView *m_sceneLastPlayPosIndicator = nullptr;
 
     int m_offset = 0;

--- a/src/app/UI/Views/Common/TimelineView.cpp
+++ b/src/app/UI/Views/Common/TimelineView.cpp
@@ -44,13 +44,6 @@ TimelineView::TimelineView(QWidget *parent) : QWidget(parent) {
     m_pieceUpdateThrottle.setInterval(16);
     connect(&m_pieceUpdateThrottle, &QTimer::timeout, this, qOverload<>(&QWidget::update));
 
-    m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
-    connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
-        m_position = m_pendingPosition;
-        update();
-    });
-
     m_pulseTimer.setInterval(16);
     m_pulseTimer.setSingleShot(false);
     connect(&m_pulseTimer, &QTimer::timeout, this, qOverload<>(&QWidget::update));
@@ -59,7 +52,7 @@ TimelineView::TimelineView(QWidget *parent) : QWidget(parent) {
         playbackController->setLastPosition(tick);
         playbackController->setPosition(tick);
     });
-    connect(playbackController, &PlaybackController::positionChanged, this,
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
             &TimelineView::setPosition);
     connect(appModel, &AppModel::modelChanged, this, applyTimeline);
     connect(appModel, &AppModel::timelineChanged, this, applyTimeline);
@@ -81,9 +74,8 @@ void TimelineView::setTimeRange(double startTick, double endTick) {
 }
 
 void TimelineView::setPosition(double tick) {
-    m_pendingPosition = tick;
-    if (!m_positionThrottle.isActive())
-        m_positionThrottle.start();
+    m_position = tick;
+    update();
 }
 
 void TimelineView::setQuantize(int quantize) {

--- a/src/app/UI/Views/Common/TimelineView.cpp
+++ b/src/app/UI/Views/Common/TimelineView.cpp
@@ -52,7 +52,7 @@ TimelineView::TimelineView(QWidget *parent) : QWidget(parent) {
         playbackController->setLastPosition(tick);
         playbackController->setPosition(tick);
     });
-    connect(playbackController, &PlaybackController::visualPositionChanged, this,
+    connect(playbackController, &PlaybackController::positionChanged, this,
             &TimelineView::setPosition);
     connect(appModel, &AppModel::modelChanged, this, applyTimeline);
     connect(appModel, &AppModel::timelineChanged, this, applyTimeline);

--- a/src/app/UI/Views/Common/TimelineView.cpp
+++ b/src/app/UI/Views/Common/TimelineView.cpp
@@ -52,7 +52,7 @@ TimelineView::TimelineView(QWidget *parent) : QWidget(parent) {
         playbackController->setLastPosition(tick);
         playbackController->setPosition(tick);
     });
-    connect(playbackController, &PlaybackController::positionChanged, this,
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
             &TimelineView::setPosition);
     connect(appModel, &AppModel::modelChanged, this, applyTimeline);
     connect(appModel, &AppModel::timelineChanged, this, applyTimeline);
@@ -74,8 +74,15 @@ void TimelineView::setTimeRange(double startTick, double endTick) {
 }
 
 void TimelineView::setPosition(double tick) {
+    const auto oldX = tickToX(m_position);
     m_position = tick;
-    update();
+    const auto newX = tickToX(m_position);
+    const auto playheadRect = [this](const double x) {
+        return QRectF(x - 8, height() - 14, 16, 14).toAlignedRect();
+    };
+    update(playheadRect(oldX));
+    if (qRound(oldX) != qRound(newX))
+        update(playheadRect(newX));
 }
 
 void TimelineView::setQuantize(int quantize) {

--- a/src/app/UI/Views/Common/TimelineView.h
+++ b/src/app/UI/Views/Common/TimelineView.h
@@ -145,10 +145,8 @@ private:
     int m_loopRegionHeight = 10;
     int m_loopHandleWidth = 8;
     QTimer m_pieceUpdateThrottle;
-    QTimer m_positionThrottle;
     QTimer m_pulseTimer;
     QElapsedTimer m_pulseElapsed;
-    double m_pendingPosition = 0;
     mutable QMap<int, PieceColorTransition> m_transitions;
     QMap<int, InferStatus> m_previousStatus;
     void updatePulseTimer();

--- a/src/app/UI/Views/Common/shaders/overlay.frag
+++ b/src/app/UI/Views/Common/shaders/overlay.frag
@@ -1,0 +1,7 @@
+#version 440
+
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(1.0);
+}

--- a/src/app/UI/Views/Common/shaders/overlay.vert
+++ b/src/app/UI/Views/Common/shaders/overlay.vert
@@ -1,0 +1,6 @@
+#version 440
+
+void main() {
+    vec2 position = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    gl_Position = vec4(position * 2.0 - 1.0, 0.0, 1.0);
+}

--- a/src/app/UI/Views/Common/shaders/scene.frag
+++ b/src/app/UI/Views/Common/shaders/scene.frag
@@ -1,0 +1,9 @@
+#version 440
+
+layout(binding = 1) uniform sampler2D scene;
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+    fragColor = texture(scene, vTexCoord);
+}

--- a/src/app/UI/Views/Common/shaders/scene.vert
+++ b/src/app/UI/Views/Common/shaders/scene.vert
@@ -1,0 +1,15 @@
+#version 440
+
+layout(location = 0) out vec2 vTexCoord;
+
+layout(std140, binding = 0) uniform buf {
+    int flip;
+} ubuf;
+
+void main() {
+    vec2 position = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    vTexCoord = position;
+    if (ubuf.flip != 0)
+        vTexCoord.y = 1.0 - vTexCoord.y;
+    gl_Position = vec4(position * 2.0 - 1.0, 0.0, 1.0);
+}

--- a/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
+++ b/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
@@ -40,7 +40,7 @@ InfoLaneView::InfoLaneView(QWidget *parent) : QWidget(parent) {
 
     m_position = playbackController->position();
     m_lastPosition = playbackController->lastPosition();
-    connect(playbackController, &PlaybackController::visualPositionChanged, this,
+    connect(playbackController, &PlaybackController::positionChanged, this,
             &InfoLaneView::setPosition);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &InfoLaneView::setLastPosition);

--- a/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
+++ b/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
@@ -38,16 +38,9 @@ InfoLaneView::InfoLaneView(QWidget *parent) : QWidget(parent) {
     connect(appModel, &AppModel::modelChanged, this, applyTimeline);
     connect(appModel, &AppModel::timelineChanged, this, applyTimeline);
 
-    m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
-    connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
-        m_position = m_pendingPosition;
-        update();
-    });
     m_position = playbackController->position();
-    m_pendingPosition = m_position;
     m_lastPosition = playbackController->lastPosition();
-    connect(playbackController, &PlaybackController::positionChanged, this,
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
             &InfoLaneView::setPosition);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &InfoLaneView::setLastPosition);
@@ -126,9 +119,8 @@ void InfoLaneView::setHoveredChip(const int index) {
 }
 
 void InfoLaneView::setPosition(const double tick) {
-    m_pendingPosition = tick;
-    if (!m_positionThrottle.isActive())
-        m_positionThrottle.start();
+    m_position = tick;
+    update();
 }
 
 void InfoLaneView::setLastPosition(const double tick) {

--- a/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
+++ b/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
@@ -40,7 +40,7 @@ InfoLaneView::InfoLaneView(QWidget *parent) : QWidget(parent) {
 
     m_position = playbackController->position();
     m_lastPosition = playbackController->lastPosition();
-    connect(playbackController, &PlaybackController::positionChanged, this,
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
             &InfoLaneView::setPosition);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &InfoLaneView::setLastPosition);
@@ -119,8 +119,12 @@ void InfoLaneView::setHoveredChip(const int index) {
 }
 
 void InfoLaneView::setPosition(const double tick) {
+    const auto oldX = tickToX(m_position);
     m_position = tick;
-    update();
+    const auto newX = tickToX(m_position);
+    update(QRectF(oldX - 2, 0, 4, height()).toAlignedRect());
+    if (qRound(oldX) != qRound(newX))
+        update(QRectF(newX - 2, 0, 4, height()).toAlignedRect());
 }
 
 void InfoLaneView::setLastPosition(const double tick) {

--- a/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.h
+++ b/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.h
@@ -4,7 +4,6 @@
 #include "UI/Utils/ITimelinePainter.h"
 
 #include <QColor>
-#include <QTimer>
 #include <QWidget>
 
 // A horizontally-synced strip below the timeline ruler that displays one kind
@@ -107,9 +106,7 @@ private:
     QList<Chip> m_chips;
     int m_hoveredChip = -1;
     double m_position = 0;
-    double m_pendingPosition = 0;
     double m_lastPosition = 0;
-    QTimer m_positionThrottle;
 };
 
 #endif // INFOLANEVIEW_H

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
@@ -177,7 +177,15 @@ TrackEditorView::TrackEditorView(QWidget *parent) : PanelView(AppGlobal::TracksE
                 m_timeSignatureLane->setVisible(visible);
             });
     connect(playbackController, &PlaybackController::visualPositionChanged, this,
-            &TrackEditorView::onPositionChanged);
+            [this](const double tick) {
+                if (m_rhiView)
+                    onPositionChanged(tick);
+            });
+    connect(playbackController, &PlaybackController::positionChanged, this,
+            [this](const double tick) {
+                if (m_graphicsView)
+                    onPositionChanged(tick);
+            });
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &TrackEditorView::onLastPositionChanged);
     connect(appModel, &AppModel::modelChanged, this, &TrackEditorView::onModelChanged);

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
@@ -177,15 +177,7 @@ TrackEditorView::TrackEditorView(QWidget *parent) : PanelView(AppGlobal::TracksE
                 m_timeSignatureLane->setVisible(visible);
             });
     connect(playbackController, &PlaybackController::visualPositionChanged, this,
-            [this](const double tick) {
-                if (m_rhiView)
-                    onPositionChanged(tick);
-            });
-    connect(playbackController, &PlaybackController::positionChanged, this,
-            [this](const double tick) {
-                if (m_graphicsView)
-                    onPositionChanged(tick);
-            });
+            &TrackEditorView::onPositionChanged);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &TrackEditorView::onLastPositionChanged);
     connect(appModel, &AppModel::modelChanged, this, &TrackEditorView::onModelChanged);

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
@@ -176,7 +176,7 @@ TrackEditorView::TrackEditorView(QWidget *parent) : PanelView(AppGlobal::TracksE
                 m_timeSignatureLaneHeader->setVisible(visible);
                 m_timeSignatureLane->setVisible(visible);
             });
-    connect(playbackController, &PlaybackController::positionChanged, this,
+    connect(playbackController, &PlaybackController::visualPositionChanged, this,
             &TrackEditorView::onPositionChanged);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &TrackEditorView::onLastPositionChanged);

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -38,6 +38,7 @@
 #include <QHideEvent>
 #include <QKeyEvent>
 #include <QLocale>
+#include <QMetaObject>
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPainter>
@@ -809,6 +810,15 @@ void TracksRhiWidget::leaveEvent(QEvent *event) {
 
 void TracksRhiWidget::onRhiReady() {
     scheduleSnapshot();
+}
+
+void TracksRhiWidget::onFrameSubmitted() {
+    EditorRhiWidget::onFrameSubmitted();
+    if (playbackController->playbackStatus() != Playing)
+        return;
+    QMetaObject::invokeMethod(playbackController,
+                              &PlaybackController::requestVisualPositionUpdate,
+                              Qt::QueuedConnection);
 }
 
 void TracksRhiWidget::onDevicePixelRatioChanged() {

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -212,13 +212,6 @@ TracksRhiWidget::TracksRhiWidget(QWidget *parent)
                     scheduleSnapshot();
                 }
             });
-    m_positionThrottle.setSingleShot(true);
-    m_positionThrottle.setInterval(33);
-    connect(&m_positionThrottle, &QTimer::timeout, this, [this] {
-        m_playbackPosition = m_pendingPlaybackPosition;
-        handleAutoPageTurn();
-        scheduleSnapshot();
-    });
     rebuildModelConnections();
     QTimer::singleShot(0, this, [this] {
         updateScrollBars();
@@ -359,9 +352,10 @@ void TracksRhiWidget::setLeftMarginPx(const double px) {
 }
 
 void TracksRhiWidget::setPlaybackPosition(const double tick) {
-    m_pendingPlaybackPosition = tick;
-    if (!m_positionThrottle.isActive())
-        m_positionThrottle.start();
+    m_playbackPosition = tick;
+    handleAutoPageTurn();
+    if (!m_snapshotScheduled)
+        updatePlaybackOverlay();
 }
 
 void TracksRhiWidget::setLastPlaybackPosition(const double tick) {
@@ -825,14 +819,16 @@ void TracksRhiWidget::onDevicePixelRatioChanged() {
 
 void TracksRhiWidget::rebuildSnapshot() {
     const auto dpr = devicePixelRatioF();
-    EditorRhiFrameData frame;
+    auto frame = acquireFrame();
+    frame.solidVertices.clear();
+    frame.drawList.clear();
     frame.clearColor = m_backgroundColor;
     frame.physicalCameraOffset =
         QPointF(m_viewport.horizontalOffset(), m_viewport.verticalOffset()) * dpr;
     m_glyphAtlas.beginFrame();
     appendGrid(frame, dpr);
     appendClips(frame, dpr);
-    appendPlaybackIndicators(frame, dpr);
+    appendLastPlaybackIndicator(frame, dpr);
     appendDropOverlay(frame, dpr);
     if (m_dragMode == DragMode::RectSelect) {
         const auto rect = QRectF(m_rubberBandStart * dpr, m_rubberBandEnd * dpr).normalized();
@@ -843,8 +839,9 @@ void TracksRhiWidget::rebuildSnapshot() {
                                                    m_rubberBandBorderColor);
     }
     frame.drawList.finish(frame.solidVertices.size());
-    frame.textureBatches = m_glyphAtlas.textureBatches();
+    m_glyphAtlas.populateTextureBatches(frame.textureBatches);
     submitFrame(std::move(frame));
+    updatePlaybackOverlay();
 }
 
 void TracksRhiWidget::rebuildModelConnections() {
@@ -1205,7 +1202,8 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
     }
 }
 
-void TracksRhiWidget::appendPlaybackIndicators(EditorRhiFrameData &frame, const double dpr) const {
+void TracksRhiWidget::appendLastPlaybackIndicator(EditorRhiFrameData &frame,
+                                                  const double dpr) const {
     const auto visible = m_viewport.visibleSceneRect();
     const auto top = visible.top() * dpr;
     const auto bottom = visible.bottom() * dpr;
@@ -1215,9 +1213,17 @@ void TracksRhiWidget::appendPlaybackIndicators(EditorRhiFrameData &frame, const 
             frame.solidVertices, lastX, dashTop, std::min(dashTop + 4.0 * dpr, bottom), dpr,
             m_lastPlayPosIndicatorColor, m_viewport.horizontalOffset() * dpr);
     }
+}
+
+void TracksRhiWidget::updatePlaybackOverlay() {
+    const auto dpr = devicePixelRatioF();
+    const auto visible = m_viewport.visibleSceneRect();
+    m_playbackOverlayVertices.clear();
     EditorRhiGeometry::appendAntialiasedVerticalLine(
-        frame.solidVertices, m_viewport.tickToSceneX(m_playbackPosition) * dpr, top, bottom, dpr,
-        m_playPosIndicatorColor, m_viewport.horizontalOffset() * dpr);
+        m_playbackOverlayVertices, m_viewport.tickToSceneX(m_playbackPosition) * dpr,
+        visible.top() * dpr, visible.bottom() * dpr, dpr, m_playPosIndicatorColor,
+        m_viewport.horizontalOffset() * dpr);
+    m_playbackOverlayVertices = submitOverlay(std::move(m_playbackOverlayVertices));
 }
 
 TracksRhiWidget::ClipSnapshot TracksRhiWidget::buildClipSnapshot(const Clip *clip,
@@ -1629,7 +1635,7 @@ QColor TracksRhiWidget::playPosIndicatorColor() const {
 
 void TracksRhiWidget::setPlayPosIndicatorColor(const QColor &color) {
     m_playPosIndicatorColor = color;
-    scheduleSnapshot();
+    updatePlaybackOverlay();
 }
 
 QColor TracksRhiWidget::lastPlayPosIndicatorColor() const {

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -812,15 +812,6 @@ void TracksRhiWidget::onRhiReady() {
     scheduleSnapshot();
 }
 
-void TracksRhiWidget::onFrameSubmitted() {
-    EditorRhiWidget::onFrameSubmitted();
-    if (playbackController->playbackStatus() != Playing)
-        return;
-    QMetaObject::invokeMethod(playbackController,
-                              &PlaybackController::requestVisualPositionUpdate,
-                              Qt::QueuedConnection);
-}
-
 void TracksRhiWidget::onDevicePixelRatioChanged() {
     EditorRhiWidget::onDevicePixelRatioChanged();
     m_glyphAtlas.clear();

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -1227,13 +1227,12 @@ void TracksRhiWidget::appendLastPlaybackIndicator(EditorRhiFrameData &frame,
 
 void TracksRhiWidget::updatePlaybackOverlay() {
     const auto dpr = devicePixelRatioF();
-    const auto visible = m_viewport.visibleSceneRect();
-    m_playbackOverlayVertices.clear();
-    EditorRhiGeometry::appendAntialiasedVerticalLine(
-        m_playbackOverlayVertices, m_viewport.tickToSceneX(m_playbackPosition) * dpr,
-        visible.top() * dpr, visible.bottom() * dpr, dpr, m_playPosIndicatorColor,
-        m_viewport.horizontalOffset() * dpr);
-    m_playbackOverlayVertices = submitOverlay(std::move(m_playbackOverlayVertices));
+    m_playbackOverlayRects.clear();
+    EditorRhiGeometry::appendAntialiasedVerticalOverlay(
+        m_playbackOverlayRects,
+        (m_viewport.tickToSceneX(m_playbackPosition) - m_viewport.horizontalOffset()) * dpr, 0.0,
+        height() * dpr, dpr, m_playPosIndicatorColor);
+    m_playbackOverlayRects = submitOverlay(std::move(m_playbackOverlayRects));
 }
 
 TracksRhiWidget::ClipSnapshot TracksRhiWidget::buildClipSnapshot(const Clip *clip,

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
@@ -235,7 +235,7 @@ private:
     QHash<int, std::shared_ptr<AudioWaveformSampler>> m_audioWaveformSamplers;
     QVector<ClipSnapshot> m_clipSnapshots;
     QVector<ClipSnapshot> m_pastePreviewSnapshots;
-    QVector<EditorRhiSolidVertex> m_playbackOverlayVertices;
+    QVector<EditorRhiOverlayRect> m_playbackOverlayRects;
     bool m_snapshotScheduled = false;
     double m_playbackPosition = 0.0;
     double m_lastPlaybackPosition = 0.0;

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
@@ -117,7 +117,6 @@ protected:
     void dropEvent(QDropEvent *event) override;
     void leaveEvent(QEvent *event) override;
     void onRhiReady() override;
-    void onFrameSubmitted() override;
     void onDevicePixelRatioChanged() override;
 
 private:

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
@@ -117,6 +117,7 @@ protected:
     void dropEvent(QDropEvent *event) override;
     void leaveEvent(QEvent *event) override;
     void onRhiReady() override;
+    void onFrameSubmitted() override;
     void onDevicePixelRatioChanged() override;
 
 private:

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.h
@@ -15,7 +15,6 @@
 #include <lite/History/HistoryFocus.h>
 #include <lite/ProjectModel/AppModel/Clip.h>
 
-#include <QTimer>
 #include <QUrl>
 
 #include <memory>
@@ -158,7 +157,8 @@ private:
     void appendGrid(EditorRhiFrameData &frame, double dpr) const;
     void appendClips(EditorRhiFrameData &frame, double dpr);
     void appendClip(EditorRhiFrameData &frame, const ClipSnapshot &clip, double dpr);
-    void appendPlaybackIndicators(EditorRhiFrameData &frame, double dpr) const;
+    void appendLastPlaybackIndicator(EditorRhiFrameData &frame, double dpr) const;
+    void updatePlaybackOverlay();
     void appendDropOverlay(EditorRhiFrameData &frame, double dpr) const;
     [[nodiscard]] ClipSnapshot buildClipSnapshot(const Clip *clip, int trackIndex,
                                                  double dpr) const;
@@ -234,11 +234,10 @@ private:
     QHash<int, std::shared_ptr<AudioWaveformSampler>> m_audioWaveformSamplers;
     QVector<ClipSnapshot> m_clipSnapshots;
     QVector<ClipSnapshot> m_pastePreviewSnapshots;
+    QVector<EditorRhiSolidVertex> m_playbackOverlayVertices;
     bool m_snapshotScheduled = false;
     double m_playbackPosition = 0.0;
-    double m_pendingPlaybackPosition = 0.0;
     double m_lastPlaybackPosition = 0.0;
-    QTimer m_positionThrottle;
     bool m_autoTurnPage = true;
     bool m_autoPageTurnAvailable = false;
     double m_leftMarginPx = 0.0;

--- a/src/app/UI/Window/MainWindow.cpp
+++ b/src/app/UI/Window/MainWindow.cpp
@@ -654,9 +654,7 @@ void MainWindow::detachBottomPanel() {
     m_bottomPanelDetached = true;
     m_detachSplitterState = m_splitter->saveState();
 
-    m_splitter->widget(1)->setParent(nullptr);
-
-    m_bottomPanelView->setWindowFlags(Qt::Window);
+    m_bottomPanelView->setParent(nullptr, Qt::Window);
     m_bottomPanelView->titleBar()->setDetached(true, m_useNativeFrame);
 
     if (!m_useNativeFrame) {
@@ -737,10 +735,10 @@ void MainWindow::attachBottomPanel() {
 
     m_bottomPanelView->hide();
     m_bottomPanelView->titleBar()->setDetached(false, m_useNativeFrame);
-    m_bottomPanelView->setWindowFlags({});
+    m_bottomPanelView->setParent(m_splitter, Qt::Widget);
     m_bottomPanelView->setMinimumWidth(0);
 
-    m_splitter->addWidget(m_bottomPanelView);
+    m_splitter->insertWidget(1, m_bottomPanelView);
     ThemeManager::instance()->removeStyleRoot(m_bottomPanelView);
     m_splitter->restoreState(m_detachSplitterState);
     m_bottomPanelView->show();

--- a/src/tests/TestEditorGlyphAtlas/main.cpp
+++ b/src/tests/TestEditorGlyphAtlas/main.cpp
@@ -33,7 +33,8 @@ int main(int argc, char *argv[]) {
     atlas.appendText(text, font, QPointF(0, 0), Qt::white);
     atlas.appendText(distinctText, font, QPointF(0, 20), Qt::white);
 
-    const auto batches = atlas.textureBatches();
+    QVector<EditorRhiTextureBatch> batches;
+    atlas.populateTextureBatches(batches);
     expect(batches.size() == 1, "two small blocks must share one atlas page");
     if (batches.size() == 1) {
         bool hasCoverage = false;
@@ -71,7 +72,8 @@ int main(int argc, char *argv[]) {
     EditorGlyphAtlas fractionalAtlas(QSize(128, 128), 1);
     fractionalAtlas.beginFrame();
     fractionalAtlas.appendText(text, font, QPointF(0, 0), Qt::white, {}, 1.25);
-    const auto fractionalBatches = fractionalAtlas.textureBatches();
+    QVector<EditorRhiTextureBatch> fractionalBatches;
+    fractionalAtlas.populateTextureBatches(fractionalBatches);
     expect(fractionalBatches.size() == 1 && fractionalBatches.front().vertices.size() == 6,
            "fractional DPR text must emit one atlas quad");
     if (fractionalBatches.size() == 1 && fractionalBatches.front().vertices.size() == 6) {
@@ -85,7 +87,8 @@ int main(int argc, char *argv[]) {
         fractionalAtlas.clear();
         fractionalAtlas.beginFrame();
         fractionalAtlas.appendText(distinctText, font, QPointF(0, 0), Qt::white, {}, 1.25);
-        const auto clearedBatches = fractionalAtlas.textureBatches();
+        QVector<EditorRhiTextureBatch> clearedBatches;
+        fractionalAtlas.populateTextureBatches(clearedBatches);
         expect(clearedBatches.size() == 1 && clearedBatches.front().generation > previousGeneration,
                "clearing an atlas must force a replacement texture upload");
     }
@@ -95,7 +98,8 @@ int main(int argc, char *argv[]) {
     phaseAtlas.appendText(text, font, QPointF(10.1, 10), Qt::white);
     phaseAtlas.appendText(text, font, QPointF(10.109, 10), Qt::white);
     phaseAtlas.appendText(text, font, QPointF(10.3, 10), Qt::white);
-    const auto phaseBatches = phaseAtlas.textureBatches();
+    QVector<EditorRhiTextureBatch> phaseBatches;
+    phaseAtlas.populateTextureBatches(phaseBatches);
     expect(phaseBatches.size() == 1 && phaseBatches.front().vertices.size() == 18,
            "Qt fixed-point phases must emit all requested atlas quads");
     if (phaseBatches.size() == 1 && phaseBatches.front().vertices.size() == 18) {
@@ -113,7 +117,8 @@ int main(int argc, char *argv[]) {
     cameraAtlas.beginFrame();
     cameraAtlas.appendText(text, font, QPointF(20.4, 30.2), Qt::white, {}, 1.0, QPointF(10, 20));
     cameraAtlas.appendText(text, font, QPointF(21.4, 31.2), Qt::white, {}, 1.0, QPointF(11, 21));
-    const auto cameraBatches = cameraAtlas.textureBatches();
+    QVector<EditorRhiTextureBatch> cameraBatches;
+    cameraAtlas.populateTextureBatches(cameraBatches);
     expect(cameraBatches.size() == 1 && cameraBatches.front().vertices.size() == 12,
            "equal viewport phases must emit two atlas quads");
     if (cameraBatches.size() == 1 && cameraBatches.front().vertices.size() == 12) {
@@ -175,10 +180,12 @@ int main(int argc, char *argv[]) {
     EditorGlyphAtlas saturatedAtlas(QSize(64, 64), 1);
     saturatedAtlas.beginFrame();
     qsizetype previousVertexCount = 0;
+    QVector<EditorRhiTextureBatch> saturatedBatches;
     for (int i = 0; i < 100; ++i) {
         saturatedAtlas.appendText(QString::number(i), font, QPointF(0, i * 20), Qt::white);
         qsizetype vertexCount = 0;
-        for (const auto &batch : saturatedAtlas.textureBatches())
+        saturatedAtlas.populateTextureBatches(saturatedBatches);
+        for (const auto &batch : saturatedBatches)
             vertexCount += batch.vertices.size();
         expect(vertexCount >= previousVertexCount,
                "an atlas page referenced by the current frame must not be evicted");

--- a/src/tests/TestEditorRhiGeometry/main.cpp
+++ b/src/tests/TestEditorRhiGeometry/main.cpp
@@ -153,6 +153,25 @@ int main(int argc, char *argv[]) {
     expect(shortSquareCap.size() > simplifiedSquareCap.size(),
            "square caps must preserve endpoint joins outside their antialiasing region");
 
+    const QColor overlayColor(12, 34, 56, 192);
+    QVector<EditorRhiOverlayRect> overlayRects;
+    EditorRhiGeometry::appendAntialiasedVerticalOverlay(overlayRects, 4.25, 2.0, 12.0, 1.0,
+                                                        overlayColor);
+    expect(overlayRects.size() == 2,
+           "a subpixel vertical overlay must split coverage across adjacent pixels");
+    if (overlayRects.size() == 2) {
+        expect(overlayRects[0].physicalViewportRect == QRectF(3.0, 2.0, 1.0, 10.0) &&
+                   overlayRects[0].color == overlayColor && overlayRects[0].coverage == 0.25f,
+               "the leading overlay pixel must preserve its rectangle, color, and coverage");
+        expect(overlayRects[1].physicalViewportRect == QRectF(4.0, 2.0, 1.0, 10.0) &&
+                   overlayRects[1].color == overlayColor && overlayRects[1].coverage == 0.75f,
+               "the trailing overlay pixel must preserve its rectangle, color, and coverage");
+    }
+    QVector<EditorRhiOverlayRect> hiddenOverlayRects;
+    EditorRhiGeometry::appendAntialiasedVerticalOverlay(hiddenOverlayRects, 4.25, 2.0, 12.0, 1.0,
+                                                        Qt::transparent);
+    expect(hiddenOverlayRects.isEmpty(), "transparent overlays must not produce draw rectangles");
+
     QVector<EditorRhiSolidVertex> circle;
     const QPointF circleCenter(4.0, 5.0);
     EditorRhiGeometry::appendAntialiasedCircle(circle, circleCenter, 3.0, QColor(255, 255, 255));

--- a/src/tests/TestScrollBarInterplay/main.cpp
+++ b/src/tests/TestScrollBarInterplay/main.cpp
@@ -207,6 +207,22 @@ int main(int argc, char *argv[]) {
                qFuzzyCompare(focusViewport.verticalOffset(), 396.0) && focusViewportChanges == 2,
            "revealing toward the leading edges must preserve the requested margin");
 
+    EditorViewportController boundedViewport;
+    boundedViewport.setEnsureContentFillsViewport(false, false);
+    boundedViewport.setContentTickRange(0, 100000);
+    boundedViewport.setVerticalContent(2, 100);
+    boundedViewport.setViewportSize(QSizeF(800, 300));
+    int boundedViewportChanges = 0;
+    QObject::connect(&boundedViewport, &EditorViewportController::viewportChanged, &rhiViewport,
+                     [&boundedViewportChanges] { ++boundedViewportChanges; });
+    boundedViewport.setStartTick(1000000);
+    expect(boundedViewportChanges == 1,
+           "scrolling to the content boundary must notify the viewport once");
+    boundedViewport.setStartTick(1000000);
+    boundedViewport.scrollBy(QPointF(100, 100));
+    expect(boundedViewportChanges == 1,
+           "repeated scrolling beyond a clamped boundary must not notify the viewport");
+
     if (g_failures == 0) {
         QTextStream(stdout) << "All ScrollBarInterplay tests passed" << Qt::endl;
         return 0;


### PR DESCRIPTION
## 概要

统一 Legacy 与 RHI 两个后端的播放头视觉刷新节拍，并针对各自渲染路径减少普通播放帧的重绘与上传开销。所有播放界面统一使用 `visualPositionChanged`，没有新增平台特定实现、原生子窗口或播放头叠加层。

## 统一的视觉播放节拍

- `talcs::TransportAudioSource` 在实际音频读取后提供 `positionChanged`，`PlaybackController` 将它作为真实位置校准点。周期由 `bufferSize / sampleRate` 决定；本次配置 `1024 / 48000 Hz ≈ 21.3 ms`，实现不假定固定 30 ms。
- Qt 精确定时器从最近校准点按已流逝时间推算视觉位置，并按当前窗口所在显示器的 `QScreen::refreshRate()` 发送 `visualPositionChanged`；无有效屏幕信息时回退到 60 Hz。
- 轨道与钢琴卷帘主画布、时间轴、音素面板、参数面板以及曲速/拍号信息轨全部使用 `visualPositionChanged`。
- 启用循环时，视觉位置在音频循环的 `[start, end)` 毫秒区间内取模；跨曲速点同样按真实循环时长回绕。
- 播放开始前先确认音频设备可用，并同步音频传输与播放控制器状态。
- 钢琴卷帘负责自动翻页并将水平位置同步给参数面板，避免重复执行翻页判断。

## Legacy 渲染优化

- `TimeGraphicsView` 在视图自身的 `drawForeground()` 阶段绘制动态播放头，使播放头与场景内容处于同一次绘制提交中。
- 普通播放帧采用 `MinimalViewportUpdate`，只使播放头新旧位置各约 4 px 的竖条失效；缩放、翻页、滚动和尺寸变化等结构操作执行完整视口更新。
- 时间轴、音素面板和信息轨同样只刷新播放头的新旧窄区域，避免高频重绘整个 QWidget。
- 播放头在音素面板、钢琴卷帘和参数面板之间保持同步，播放中翻页或缩放时保持完整显示。

## RHI 渲染优化

- 将静态编辑器场景缓存到 RHI 纹理；普通播放帧只合成缓存并绘制播放头。
- 播放头使用无顶点/Uniform 上传的视口覆盖绘制，普通播放帧保持 0 字节 GPU 上传。
- 自动翻页或场景变化时才重新生成静态内容与字形纹理。
- 钢琴窗分离后关闭并重新合并时正常恢复渲染；实现只使用 Qt 父子窗口接口。
- 播放节拍不依赖任一 RHI 表面的 `frameSubmitted`，所以上方轨道面板隐藏或高度为零时，底部钢琴窗仍继续播放与翻页。

## 核显上的渲染性能

测试工程：`桃花诺.dspx`。显示器连接主板；测试时进程使用共享 GPU 内存，独显专用显存计数为 0。

| 构建 | main RHI | 本 PR RHI | 本 PR Legacy |
| --- | ---: | ---: | ---: |
| Debug | 15.2–17.0 FPS | 约 59–60 FPS | 约 28–29 FPS |
| Release | 18.1–19.5 FPS | 约 56.5–56.8 FPS | 约 58.9 FPS |

Debug 下 Legacy 的主画布软件绘制吞吐成为瓶颈；Release 下两个主后端都接近 60 Hz 显示器上限。Release RHI 的提交间隔中位数约 17.6–17.7 ms。

## 验证

- 当前提交 Release：`DsEditorLite` 构建通过
- Debug：26/26 自动化测试通过
- Debug / Release GUI：加载 `桃花诺.dspx`，确认播放、暂停、停止、播放头与自动翻页持续推进
- RHI：隐藏上方轨道面板后，底部钢琴窗仍持续播放并自动翻页
- RHI：钢琴窗分离 → 关闭 → 重新合并后正常渲染，无黑屏
- Legacy / RHI：时间轴、音素、参数、曲速和拍号轨使用统一的视觉位置流
- Legacy：音素面板与钢琴卷帘播放头对齐；播放时翻页、缩放无播放头消失或残缺
- Legacy / RHI：同时监控进程私有内存、共享 GPU 内存与独显专用显存
- `git diff --check` 通过
- 性能埋点、临时开关与监控代码均已清除
