### PR TITLE
fix(rhi): preserve clipped piano viewport rounding

### DIFF
--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -1042,37 +1042,11 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
                         dpr,
                     overlayBottom - overlayTop);
                 const auto overlayColor = palette.clipBorder(clip.colorIndex);
-                if (preview.contains(overlay)) {
-                    EditorRhiGeometry::appendRoundedRectStroke(frame.solidVertices, overlay, radius,
-                                                               1.2 * dpr, overlayColor);
-                } else if (preview.intersects(overlay)) {
-                    const auto clipped = preview.intersected(overlay);
-                    const auto lineWidth = 1.2 * dpr;
-                    if (overlay.left() >= preview.left() && overlay.left() <= preview.right())
-                        EditorRhiGeometry::appendRect(frame.solidVertices,
-                                                      QRectF(overlay.left() - lineWidth * 0.5,
-                                                             clipped.top(), lineWidth,
-                                                             clipped.height()),
-                                                      overlayColor);
-                    if (overlay.right() >= preview.left() && overlay.right() <= preview.right())
-                        EditorRhiGeometry::appendRect(frame.solidVertices,
-                                                      QRectF(overlay.right() - lineWidth * 0.5,
-                                                             clipped.top(), lineWidth,
-                                                             clipped.height()),
-                                                      overlayColor);
-                    if (overlay.top() >= preview.top() && overlay.top() <= preview.bottom())
-                        EditorRhiGeometry::appendRect(frame.solidVertices,
-                                                      QRectF(clipped.left(),
-                                                             overlay.top() - lineWidth * 0.5,
-                                                             clipped.width(), lineWidth),
-                                                      overlayColor);
-                    if (overlay.bottom() >= preview.top() && overlay.bottom() <= preview.bottom())
-                        EditorRhiGeometry::appendRect(frame.solidVertices,
-                                                      QRectF(clipped.left(),
-                                                             overlay.bottom() - lineWidth * 0.5,
-                                                             clipped.width(), lineWidth),
-                                                      overlayColor);
-                }
+                QVector<EditorRhiSolidVertex> overlayVertices;
+                EditorRhiGeometry::appendRoundedRectStroke(overlayVertices, overlay, radius,
+                                                           1.2 * dpr, overlayColor);
+                EditorRhiGeometry::appendClippedTriangles(frame.solidVertices, overlayVertices,
+                                                          preview);
             }
         }
     } else if (clip.type == IClip::Audio) {

--- a/src/tests/TestEditorRhiGeometry/main.cpp
+++ b/src/tests/TestEditorRhiGeometry/main.cpp
@@ -3,6 +3,7 @@
 #include <QCoreApplication>
 #include <QTextStream>
 
+#include <algorithm>
 #include <cmath>
 
 namespace {
@@ -67,6 +68,21 @@ int main(int argc, char *argv[]) {
         expect(value.coverage >= 0.5f && value.coverage <= 0.7f,
                "clipping must interpolate coverage without leaving the source range");
     }
+
+    QVector<EditorRhiSolidVertex> roundedStroke;
+    EditorRhiGeometry::appendRoundedRectStroke(roundedStroke, QRectF(2.0, -2.0, 6.0, 8.0), 2.0,
+                                               1.2, QColor(255, 255, 255));
+    QVector<EditorRhiSolidVertex> clippedRoundedStroke;
+    EditorRhiGeometry::appendClippedTriangles(clippedRoundedStroke, roundedStroke, clipRect);
+    expect(!clippedRoundedStroke.isEmpty(),
+           "a partially visible rounded stroke must retain visible geometry");
+    for (const auto &value : clippedRoundedStroke) {
+        expect(clipRect.contains(QPointF(value.x, value.y)),
+               "clipped rounded-stroke vertices must stay inside the clip rectangle");
+    }
+    expect(std::any_of(clippedRoundedStroke.cbegin(), clippedRoundedStroke.cend(),
+                       [](const EditorRhiSolidVertex &value) { return value.coverage == 0.0f; }),
+           "clipping must preserve rounded-stroke antialiasing coverage");
 
     QVector<EditorRhiSolidVertex> hairline;
     EditorRhiGeometry::appendAntialiasedHairline(hairline,


### PR DESCRIPTION
## Summary

- remove the separate square-edge fallback used when the piano-roll viewport overlay crosses a clip preview boundary
- always tessellate the same antialiased rounded-rectangle stroke, then clip its triangles to the preview
- cover partial clipping of rounded-stroke geometry and its antialiasing coverage

## Root cause

The Legacy backend always draws one rounded rectangle and lets QPainter clipping hide the out-of-bounds portion. The RHI backend instead switched to four plain filled rectangles whenever any edge crossed the preview boundary, which changed both corner shape and apparent stroke weight.

## Validation

- `TestEditorRhiGeometry.exe`
- debug `DsEditorLite` target build through the project CMake preset script
- Computer Use regression check with the recent `桃花诺.dspx` project: vertically scrolled the piano roll until one overlay edge crossed the clip preview and confirmed the remaining corners and stroke weight stay intact

## Known unrelated issue

Building the aggregate `all` target still exposes the existing `TestInputConversion` link failure for missing `AppOptions::instance()` / `AppOptions::inference()`; this PR does not touch that test or inference code.