### PR TITLE
fix(ui): preserve playback shortcut after piano roll interactions

### DIFF
--- a/src/app/UI/Views/Common/EditorShortcutUtils.h
+++ b/src/app/UI/Views/Common/EditorShortcutUtils.h
@@ -14,6 +14,7 @@
 #include <QTextEdit>
 #include <QWidget>
 
+#include <functional>
 #include <utility>
 
 namespace EditorShortcutUtils {
@@ -36,8 +37,10 @@ namespace EditorShortcutUtils {
 
         class ApplicationShortcutOverrideFilter final : public QObject {
         public:
-            explicit ApplicationShortcutOverrideFilter(QShortcut *shortcut)
-                : QObject(shortcut), m_shortcut(shortcut) {
+            ApplicationShortcutOverrideFilter(
+                QShortcut *shortcut, std::function<bool(const QWidget *)> isWindowAllowed)
+                : QObject(shortcut), m_shortcut(shortcut),
+                  m_isWindowAllowed(std::move(isWindowAllowed)) {
                 qApp->installEventFilter(this);
             }
 
@@ -52,7 +55,8 @@ namespace EditorShortcutUtils {
                 if (!m_shortcut->keys().contains(QKeySequence(keyEvent->keyCombination())))
                     return false;
 
-                if (isTextInput(QApplication::focusWidget()) ||
+                if (!m_isWindowAllowed(QApplication::activeWindow()) ||
+                    isTextInput(QApplication::focusWidget()) ||
                     QApplication::activePopupWidget() || QApplication::activeModalWidget() ||
                     qobject_cast<QDialog *>(QApplication::activeWindow())) {
                     event->accept();
@@ -65,6 +69,7 @@ namespace EditorShortcutUtils {
 
         private:
             QShortcut *m_shortcut;
+            std::function<bool(const QWidget *)> m_isWindowAllowed;
         };
 
     } // namespace Detail
@@ -78,12 +83,13 @@ namespace EditorShortcutUtils {
         return shortcut;
     }
 
-    template <typename Receiver, typename Slot>
-    QShortcut *addApplication(QWidget *owner, const QKeySequence &key, Receiver *receiver,
-                              Slot &&slot) {
+    template <typename WindowPredicate, typename Receiver, typename Slot>
+    QShortcut *addApplication(QWidget *owner, const QKeySequence &key,
+                              WindowPredicate &&isWindowAllowed, Receiver *receiver, Slot &&slot) {
         auto *shortcut = new QShortcut(key, owner);
         shortcut->setContext(Qt::ApplicationShortcut);
-        new Detail::ApplicationShortcutOverrideFilter(shortcut);
+        new Detail::ApplicationShortcutOverrideFilter(
+            shortcut, std::forward<WindowPredicate>(isWindowAllowed));
         QObject::connect(shortcut, &QShortcut::activated, receiver, std::forward<Slot>(slot));
         return shortcut;
     }

--- a/src/app/UI/Views/Common/EditorShortcutUtils.h
+++ b/src/app/UI/Views/Common/EditorShortcutUtils.h
@@ -3,8 +3,12 @@
 
 #include <QAbstractSpinBox>
 #include <QApplication>
+#include <QDialog>
+#include <QEvent>
+#include <QKeyEvent>
 #include <QKeySequence>
 #include <QLineEdit>
+#include <QObject>
 #include <QPlainTextEdit>
 #include <QShortcut>
 #include <QTextEdit>
@@ -20,15 +24,66 @@ namespace EditorShortcutUtils {
                qobject_cast<const QAbstractSpinBox *>(widget);
     }
 
-    template <typename Receiver, typename Slot>
-    QShortcut *add(QWidget *owner, const QKeySequence &key, Receiver *receiver, Slot &&slot) {
-        auto *shortcut = new QShortcut(key, owner);
-        shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+    inline void guardTextInput(QShortcut *shortcut) {
         shortcut->setEnabled(!isTextInput(QApplication::focusWidget()));
         QObject::connect(qApp, &QApplication::focusChanged, shortcut,
                          [shortcut](QWidget *, QWidget *current) {
                              shortcut->setEnabled(!isTextInput(current));
                          });
+    }
+
+    namespace Detail {
+
+        class ApplicationShortcutOverrideFilter final : public QObject {
+        public:
+            explicit ApplicationShortcutOverrideFilter(QShortcut *shortcut)
+                : QObject(shortcut), m_shortcut(shortcut) {
+                qApp->installEventFilter(this);
+            }
+
+        protected:
+            bool eventFilter(QObject *watched, QEvent *event) override {
+                Q_UNUSED(watched)
+                if (event->type() != QEvent::ShortcutOverride || !m_shortcut->isEnabled()) {
+                    return false;
+                }
+
+                const auto *keyEvent = static_cast<QKeyEvent *>(event);
+                if (!m_shortcut->keys().contains(QKeySequence(keyEvent->keyCombination())))
+                    return false;
+
+                if (isTextInput(QApplication::focusWidget()) ||
+                    QApplication::activePopupWidget() || QApplication::activeModalWidget() ||
+                    qobject_cast<QDialog *>(QApplication::activeWindow())) {
+                    event->accept();
+                    return true;
+                }
+
+                event->ignore();
+                return true;
+            }
+
+        private:
+            QShortcut *m_shortcut;
+        };
+
+    } // namespace Detail
+
+    template <typename Receiver, typename Slot>
+    QShortcut *add(QWidget *owner, const QKeySequence &key, Receiver *receiver, Slot &&slot) {
+        auto *shortcut = new QShortcut(key, owner);
+        shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+        guardTextInput(shortcut);
+        QObject::connect(shortcut, &QShortcut::activated, receiver, std::forward<Slot>(slot));
+        return shortcut;
+    }
+
+    template <typename Receiver, typename Slot>
+    QShortcut *addApplication(QWidget *owner, const QKeySequence &key, Receiver *receiver,
+                              Slot &&slot) {
+        auto *shortcut = new QShortcut(key, owner);
+        shortcut->setContext(Qt::ApplicationShortcut);
+        new Detail::ApplicationShortcutOverrideFilter(shortcut);
         QObject::connect(shortcut, &QShortcut::activated, receiver, std::forward<Slot>(slot));
         return shortcut;
     }

--- a/src/app/UI/Views/MainTitleBar/PlaybackView.cpp
+++ b/src/app/UI/Views/MainTitleBar/PlaybackView.cpp
@@ -14,6 +14,7 @@
 #include "TempoComboBox.h"
 #include "TimeSignatureComboBox.h"
 #include "Global/AppGlobal.h"
+#include "UI/Views/Common/EditorShortcutUtils.h"
 
 #include <QColor>
 #include <QEvent>
@@ -105,14 +106,8 @@ PlaybackView::PlaybackView(QWidget *parent) : QWidget(parent) {
     });
     m_btnPlayPause->setFixedSize(0, 0);
 
-    auto playPauseShortcut = new QShortcut(Qt::Key_Space, this);
-    playPauseShortcut->setContext(Qt::ApplicationShortcut);
-    connect(playPauseShortcut, &QShortcut::activated, this, [this] {
-        if (m_status == Paused || m_status == Stopped)
-            playTriggered();
-        else if (m_status == Playing)
-            pauseTriggered();
-    });
+    EditorShortcutUtils::addApplication(this, QKeySequence(Qt::Key_Space), m_btnPlayPause,
+                                        &QPushButton::click);
 
     m_btnLoop = new QPushButton;
     m_btnLoop->setObjectName("btnLoop");

--- a/src/app/UI/Views/MainTitleBar/PlaybackView.cpp
+++ b/src/app/UI/Views/MainTitleBar/PlaybackView.cpp
@@ -14,7 +14,9 @@
 #include "TempoComboBox.h"
 #include "TimeSignatureComboBox.h"
 #include "Global/AppGlobal.h"
+#include "UI/Views/BottomPanelView.h"
 #include "UI/Views/Common/EditorShortcutUtils.h"
+#include "UI/Window/MainWindow.h"
 
 #include <QColor>
 #include <QEvent>
@@ -106,8 +108,13 @@ PlaybackView::PlaybackView(QWidget *parent) : QWidget(parent) {
     });
     m_btnPlayPause->setFixedSize(0, 0);
 
-    EditorShortcutUtils::addApplication(this, QKeySequence(Qt::Key_Space), m_btnPlayPause,
-                                        &QPushButton::click);
+    EditorShortcutUtils::addApplication(
+        this, QKeySequence(Qt::Key_Space),
+        [](const QWidget *window) {
+            return qobject_cast<const MainWindow *>(window) ||
+                   qobject_cast<const BottomPanelView *>(window);
+        },
+        m_btnPlayPause, &QPushButton::click);
 
     m_btnLoop = new QPushButton;
     m_btnLoop->setObjectName("btnLoop");

--- a/src/tests/TestEditorShortcuts/CMakeLists.txt
+++ b/src/tests/TestEditorShortcuts/CMakeLists.txt
@@ -9,11 +9,12 @@ target_include_directories(${PROJECT_NAME} PRIVATE
         ../../app
 )
 
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Test Widgets)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
         Qt${QT_VERSION_MAJOR}::Core
         Qt${QT_VERSION_MAJOR}::Gui
+        Qt${QT_VERSION_MAJOR}::Test
         Qt${QT_VERSION_MAJOR}::Widgets
 )
 

--- a/src/tests/TestEditorShortcuts/main.cpp
+++ b/src/tests/TestEditorShortcuts/main.cpp
@@ -2,18 +2,47 @@
 #include "UI/Views/Common/EditorMenuPreviewGuard.h"
 
 #include <QApplication>
+#include <QDialog>
 #include <QEvent>
 #include <QLineEdit>
 #include <QMenu>
 #include <QPlainTextEdit>
+#include <QPushButton>
 #include <QSpinBox>
 #include <QTextEdit>
 #include <QTextStream>
 #include <QVBoxLayout>
+#include <QtTest/QTest>
 
 namespace {
 
     int failures = 0;
+
+    class SpaceOverrideButton final : public QPushButton {
+    protected:
+        bool event(QEvent *event) override {
+            if (event->type() == QEvent::ShortcutOverride) {
+                const auto *keyEvent = static_cast<QKeyEvent *>(event);
+                if (keyEvent->key() == Qt::Key_Space) {
+                    event->accept();
+                    return true;
+                }
+            }
+            return QPushButton::event(event);
+        }
+    };
+
+    class SpaceKeyWidget final : public QWidget {
+    public:
+        int spacePressCount = 0;
+
+    protected:
+        void keyPressEvent(QKeyEvent *event) override {
+            if (event->key() == Qt::Key_Space)
+                ++spacePressCount;
+            QWidget::keyPressEvent(event);
+        }
+    };
 
     void expect(const bool condition, const char *message) {
         if (condition)
@@ -31,8 +60,10 @@ int main(int argc, char *argv[]) {
     auto *layout = new QVBoxLayout(&owner);
     auto *canvas = new QWidget(&owner);
     auto *lineEdit = new QLineEdit(&owner);
+    auto *dockedToolButton = new SpaceOverrideButton;
     layout->addWidget(canvas);
     layout->addWidget(lineEdit);
+    layout->addWidget(dockedToolButton);
     owner.show();
 
     int activationCount = 0;
@@ -53,6 +84,101 @@ int main(int argc, char *argv[]) {
     expect(EditorShortcutUtils::isTextInput(new QSpinBox(&owner)),
            "QAbstractSpinBox subclasses must be recognized as text input");
     expect(activationCount == 0, "focus changes must not activate editor commands");
+
+    QWidget detachedWindow;
+    auto *detachedLayout = new QVBoxLayout(&detachedWindow);
+    auto *toolButton = new SpaceOverrideButton;
+    auto *detachedLineEdit = new QLineEdit;
+    detachedLayout->addWidget(toolButton);
+    detachedLayout->addWidget(detachedLineEdit);
+    detachedWindow.show();
+
+    int applicationActivationCount = 0;
+    int toolClickCount = 0;
+    auto *applicationShortcut =
+        EditorShortcutUtils::addApplication(&owner, QKeySequence(Qt::Key_Space), &owner,
+                                            [&applicationActivationCount] {
+                                                ++applicationActivationCount;
+                                            });
+    QObject::connect(dockedToolButton, &QPushButton::clicked, &owner,
+                     [&toolClickCount] { ++toolClickCount; });
+    QObject::connect(toolButton, &QPushButton::clicked, &owner,
+                     [&toolClickCount] { ++toolClickCount; });
+
+    owner.activateWindow();
+    dockedToolButton->setFocus();
+    application.processEvents();
+    QTest::keyClick(dockedToolButton, Qt::Key_Space);
+    application.processEvents();
+    expect(applicationActivationCount == 1,
+           "application shortcut must override focused tools in its owner window");
+    expect(toolClickCount == 0, "space playback shortcut must not click a docked tool");
+
+    detachedWindow.activateWindow();
+    toolButton->setFocus();
+    application.processEvents();
+    QTest::keyClick(toolButton, Qt::Key_Space);
+    application.processEvents();
+    expect(applicationActivationCount == 2,
+           "application shortcut must override focused tools in a detached window");
+    expect(toolClickCount == 0, "space playback shortcut must not click a detached tool");
+
+    detachedLineEdit->setFocus();
+    application.processEvents();
+    QTest::keyClick(detachedLineEdit, Qt::Key_Space);
+    application.processEvents();
+    expect(detachedLineEdit->text() == QStringLiteral(" "),
+           "application shortcut must preserve space in text input");
+    expect(applicationActivationCount == 2,
+           "application shortcut must stay disabled while editing text");
+
+    applicationShortcut->setEnabled(false);
+    owner.activateWindow();
+    dockedToolButton->setFocus();
+    application.processEvents();
+    QTest::keyClick(dockedToolButton, Qt::Key_Space);
+    application.processEvents();
+    expect(applicationActivationCount == 2,
+           "disabled application shortcut must preserve embedded panel input");
+    expect(toolClickCount == 1,
+           "disabled application shortcut must allow embedded panel controls to handle space");
+    applicationShortcut->setEnabled(true);
+
+    QDialog dialog(&owner);
+    auto *dialogLayout = new QVBoxLayout(&dialog);
+    auto *dialogControl = new SpaceKeyWidget;
+    dialogControl->setFocusPolicy(Qt::StrongFocus);
+    dialogLayout->addWidget(dialogControl);
+    dialog.show();
+    dialog.activateWindow();
+    dialogControl->setFocus();
+    application.processEvents();
+    QTest::keyClick(dialogControl, Qt::Key_Space);
+    application.processEvents();
+    expect(applicationActivationCount == 2,
+           "application shortcut must preserve dialog key handling");
+    expect(dialogControl->spacePressCount == 1,
+           "dialog controls must receive their own space key press");
+    dialog.close();
+    application.processEvents();
+
+    QWidget popup(nullptr, Qt::Popup);
+    auto *popupLayout = new QVBoxLayout(&popup);
+    auto *popupControl = new SpaceKeyWidget;
+    popupControl->setFocusPolicy(Qt::StrongFocus);
+    popupLayout->addWidget(popupControl);
+    popup.show();
+    popup.activateWindow();
+    popupControl->setFocus();
+    application.processEvents();
+    QTest::keyClick(popupControl, Qt::Key_Space);
+    application.processEvents();
+    expect(applicationActivationCount == 2,
+           "application shortcut must preserve popup key handling");
+    expect(popupControl->spacePressCount == 1,
+           "popup controls must receive their own space key press");
+    popup.close();
+    application.processEvents();
 
     QMenu menu;
     auto *pasteAction = menu.addAction(QStringLiteral("Paste"));

--- a/src/tests/TestEditorShortcuts/main.cpp
+++ b/src/tests/TestEditorShortcuts/main.cpp
@@ -95,11 +95,12 @@ int main(int argc, char *argv[]) {
 
     int applicationActivationCount = 0;
     int toolClickCount = 0;
-    auto *applicationShortcut =
-        EditorShortcutUtils::addApplication(&owner, QKeySequence(Qt::Key_Space), &owner,
-                                            [&applicationActivationCount] {
-                                                ++applicationActivationCount;
-                                            });
+    auto *applicationShortcut = EditorShortcutUtils::addApplication(
+        &owner, QKeySequence(Qt::Key_Space),
+        [&owner, &detachedWindow](const QWidget *window) {
+            return window == &owner || window == &detachedWindow;
+        },
+        &owner, [&applicationActivationCount] { ++applicationActivationCount; });
     QObject::connect(dockedToolButton, &QPushButton::clicked, &owner,
                      [&toolClickCount] { ++toolClickCount; });
     QObject::connect(toolButton, &QPushButton::clicked, &owner,
@@ -131,6 +132,24 @@ int main(int argc, char *argv[]) {
            "application shortcut must preserve space in text input");
     expect(applicationActivationCount == 2,
            "application shortcut must stay disabled while editing text");
+
+    QWidget unrelatedWindow;
+    auto *unrelatedLayout = new QVBoxLayout(&unrelatedWindow);
+    auto *unrelatedControl = new SpaceKeyWidget;
+    unrelatedControl->setFocusPolicy(Qt::StrongFocus);
+    unrelatedLayout->addWidget(unrelatedControl);
+    unrelatedWindow.show();
+    unrelatedWindow.activateWindow();
+    unrelatedControl->setFocus();
+    application.processEvents();
+    QTest::keyClick(unrelatedControl, Qt::Key_Space);
+    application.processEvents();
+    expect(applicationActivationCount == 2,
+           "application shortcut must preserve unrelated window key handling");
+    expect(unrelatedControl->spacePressCount == 1,
+           "unrelated window controls must receive their own space key press");
+    unrelatedWindow.close();
+    application.processEvents();
 
     applicationShortcut->setEnabled(false);
     owner.activateWindow();


### PR DESCRIPTION
## 概要

- 在编辑工作区内阻止按钮、钢琴窗额头和工具栏抢占空格快捷键
- 停靠与分离钢琴窗共用同一套应用级快捷键处理
- 保留文本输入、对话框、下拉/弹出面板及内嵌设置面板对空格的处理
- 复用已有隐藏播放/暂停按钮逻辑，避免重复状态判断
- 增加停靠、分离与例外场景的快捷键回归测试

## 验证

- Debug preset 完整配置与构建通过
- `TestEditorShortcuts` 通过
- 除现有 `TestInputConversion` 链接问题外，其余 25/25 项 CTest 通过
- Computer Use：停靠钢琴窗播放 → 工具栏交互 → 空格暂停，通过
- Computer Use：分离钢琴窗播放 → 工具栏交互 → 空格暂停，通过
- 用户手动测试通过

## 已知无关问题

`TestInputConversion` 当前因缺少 `AppOptions::instance()` / `AppOptions::inference()` 链接实现而无法生成测试可执行文件；本次修改未涉及该目标。