### PR TITLE
fix: restore TestInputConversion linking

### DIFF
--- a/src/app/Modules/Inference/Tasks/InferRunSerializationGuard.cpp
+++ b/src/app/Modules/Inference/Tasks/InferRunSerializationGuard.cpp
@@ -1,0 +1,28 @@
+#include "InferTaskCommon.h"
+
+#include "Model/AppOptions/AppOptions.h"
+
+#include <mutex>
+
+namespace {
+    // Serializes ONNX inference Run() calls under the DirectML EP. DML's
+    // DmlCommandRecorder is not thread-safe across sessions: concurrent Run()
+    // from different inference tasks (e.g. two pieces' pipelines running in
+    // parallel on the task thread pool) crashes in the graphics driver.
+    // This lock is only acquired when the user selected DirectML, keeping the
+    // CUDA parallel execution intact. See InferRunSerializationGuard in the
+    // header.
+    std::mutex g_inferRunSerializationMutex;
+}
+
+InferRunSerializationGuard::InferRunSerializationGuard() {
+    if (appOptions->inference()->executionProvider == QStringLiteral("DirectML")) {
+        g_inferRunSerializationMutex.lock();
+        m_locked = true;
+    }
+}
+
+InferRunSerializationGuard::~InferRunSerializationGuard() {
+    if (m_locked)
+        g_inferRunSerializationMutex.unlock();
+}

--- a/src/app/Modules/Inference/Tasks/InferTaskCommon.cpp
+++ b/src/app/Modules/Inference/Tasks/InferTaskCommon.cpp
@@ -3,7 +3,6 @@
 #include <lite/ProjectModel/InferenceData/InferSpeakerMix.h>
 
 #include <utility>
-#include "Model/AppOptions/AppOptions.h"
 
 #include <QCoreApplication>
 
@@ -19,30 +18,6 @@ namespace {
     // so this does not become a bottleneck.
     std::mutex g_modelLoadMutex;
 
-    // Serializes ONNX inference Run() calls under the DirectML EP. DML's
-    // DmlCommandRecorder is not thread-safe across sessions: concurrent Run()
-    // from different inference tasks (e.g. two pieces' pipelines running in
-    // parallel on the task thread pool) crashes in the graphics driver.
-    // This lock is only acquired when the user selected DirectML, keeping the
-    // CUDA parallel execution intact. See InferRunSerializationGuard in the
-    // header.
-    std::mutex g_inferRunSerializationMutex;
-}
-
-InferRunSerializationGuard::InferRunSerializationGuard() {
-    if (appOptions->inference()->executionProvider == QStringLiteral("DirectML")) {
-        g_inferRunSerializationMutex.lock();
-        m_locked = true;
-    }
-}
-
-InferRunSerializationGuard::~InferRunSerializationGuard() {
-    if (m_locked)
-        g_inferRunSerializationMutex.unlock();
-}
-
-
-namespace {
     bool mapSpeakerName(const std::string &speakerName,
                         const std::map<std::string, std::string> &speakerMapping,
                         std::string &mappedSpeakerName) {


### PR DESCRIPTION
## Summary

- move `InferRunSerializationGuard` into its own translation unit
- keep `InferTaskCommon.cpp` free of the full `AppOptions` linkage required only by the runtime guard
- preserve the guard's behavior and existing explanatory comment

## Root cause

`TestInputConversion` compiles `InferTaskCommon.cpp` directly while intentionally avoiding the full application options dependency chain. The DirectML serialization guard was recently implemented in that same source file, which introduced unresolved references to `AppOptions::instance()` and `AppOptions::inference()` and caused MSVC `LNK2019` errors.

Separating the guard implementation restores the intended link boundary without adding test-only stubs or changing runtime behavior.

## Impact

The debug test target links and runs again. The main application continues to compile and link the guard implementation through its existing source glob.

## Validation

- `run-cmake-preset.ps1 -Mode Build -Preset debug -Target TestInputConversion`
- `TestInputConversion.exe` — passed
- `run-cmake-preset.ps1 -Mode Build -Preset debug -Target DsEditorLite` — passed with `CMAKE_BUILD_PARALLEL_LEVEL=4`
