### PR TITLE
fix(rhi): show lyrics while drawing notes

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/DrawNoteHandler.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/DrawNoteHandler.cpp
@@ -12,7 +12,6 @@
 #include "PronunciationView.h"
 #include "Controller/ClipController.h"
 #include <lite/ProjectModel/AppModel/SingingClip.h>
-#include "Model/AppOptions/AppOptions.h"
 #include "Model/AppStatus/AppStatus.h"
 #include "Modules/Inference/EditSessionManager.h"
 #include <lite/MusicBase/TimelineSnapUtils.h>
@@ -147,9 +146,8 @@ void DrawNoteHandler::prepareForDrawingNote(const int tick, const int keyIndex,
                                          singingClip ? singingClip->id() : -1, {}, {}, {}, {},
                                          true);
     appStatus->currentEditObject = AppStatus::EditObjectType::Note;
-    const auto language = singingClip ? singingClip->effectiveDefaultLanguage()
-                                      : appOptions->general()->defaultSingingLanguage;
-    m_currentDrawingNote->setLyric(appOptions->general()->defaultLyricForLanguage(language));
+    m_currentDrawingNote->setLyric(
+        PianoRollGraphicsViewHelper::defaultLyricForNewNote(singingClip));
     m_currentDrawingNote->setRStart(snappedTick - d->m_offset);
     const int length = initialLength >= 0
                            ? initialLength

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsViewHelper.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsViewHelper.cpp
@@ -18,6 +18,12 @@
 #include <lite/Support/MathUtils.h>
 #include <lite/MusicBase/TimelineSnapUtils.h>
 
+QString PianoRollGraphicsViewHelper::defaultLyricForNewNote(const SingingClip *clip) {
+    const auto language = clip ? clip->effectiveDefaultLanguage()
+                               : appOptions->general()->defaultSingingLanguage;
+    return appOptions->general()->defaultLyricForLanguage(language);
+}
+
 void PianoRollGraphicsViewHelper::drawNote(const int rStart, const int length, const int keyIndex) {
     qDebug() << "Note drawn rStart:" << rStart << "len:" << length << "key:" << keyIndex;
     const auto singingClip = dynamic_cast<SingingClip *>(clipController->clip());
@@ -26,10 +32,8 @@ void PianoRollGraphicsViewHelper::drawNote(const int rStart, const int length, c
     note->setLocalStart(rStart);
     note->setLength(length);
     note->setKeyIndex(keyIndex);
-    // keep language auto (empty), resolved at inference; pick the default lyric by the effective
-    // language
-    note->setLyric(
-        appOptions->general()->defaultLyricForLanguage(singingClip->effectiveDefaultLanguage()));
+    // keep language auto (empty), resolved at inference
+    note->setLyric(defaultLyricForNewNote(singingClip));
     note->setPronunciation(Pronunciation("", ""));
     clipController->onInsertNote(note);
     clipController->selectNotes(QList({note->id()}), true);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsViewHelper.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsViewHelper.h
@@ -4,6 +4,7 @@
 #include <lite/ProjectModel/AppModel/Params.h>
 
 #include <QList>
+#include <QString>
 
 class PitchEditorView;
 class EditPitchAnchorHandler;
@@ -16,6 +17,7 @@ class NoteView;
 class SingingClip;
 
 namespace PianoRollGraphicsViewHelper {
+    QString defaultLyricForNewNote(const SingingClip *clip);
     void drawNote(int rStart, int length, int keyIndex);
     void splitNote(int noteId, int tick);
     void editPitch(const QList<DrawCurve *> &curves);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -1564,6 +1564,14 @@ public:
         return false;
     }
 
+    void beginDrawNote(const QPointF &viewportPosition) {
+        interaction = Interaction::Draw;
+        drawStart = snapLocalTick(localTickAt(viewportPosition));
+        drawEnd = drawStart + TimelineSnapUtils::quantizeToTicks(appStatus->pianoRollQuantize);
+        drawKey = keyAt(viewportPosition);
+        scheduleSnapshot();
+    }
+
     void mousePress(QMouseEvent *event) {
         if (!clip || event->button() != Qt::LeftButton)
             return;
@@ -1594,11 +1602,7 @@ public:
         if (!noteEditingEnabled())
             return;
         if (editMode == DrawNote && !note) {
-            interaction = Interaction::Draw;
-            drawStart = snapLocalTick(localTickAt(event->position()));
-            drawEnd = drawStart + TimelineSnapUtils::quantizeToTicks(appStatus->pianoRollQuantize);
-            drawKey = keyAt(event->position());
-            scheduleSnapshot();
+            beginDrawNote(event->position());
             return;
         }
         if (!note) {
@@ -2141,10 +2145,14 @@ private:
         if (interaction == Interaction::Draw && drawEnd > drawStart) {
             const QRectF rect(drawStart * pixelsPerTick(), (127 - drawKey) * noteHeight * scaleY,
                               (drawEnd - drawStart) * pixelsPerTick(), noteHeight * scaleY);
-            if (scaleX < 0.3)
+            if (scaleX < 0.3) {
                 appendCompactNoteShape(rect, selectedFill);
-            else
+            } else {
                 appendFullNoteShape(rect, selectedFill, selectedBorder);
+                appendNoteText(
+                    rect, PianoRollGraphicsViewHelper::defaultLyricForNewNote(clip), {},
+                    normalForeground, q->pronunciationTextColor(), false, false);
+            }
         }
     }
 
@@ -2978,13 +2986,8 @@ void PianoRollRhiWidget::mouseDoubleClickEvent(QMouseEvent *event) {
             return;
         }
         if (d->editMode == Select) {
-            d->interaction = Private::Interaction::Draw;
-            d->drawStart = d->snapLocalTick(d->localTickAt(event->position()));
-            d->drawEnd =
-                d->drawStart + TimelineSnapUtils::quantizeToTicks(appStatus->pianoRollQuantize);
-            d->drawKey = d->keyAt(event->position());
+            d->beginDrawNote(event->position());
             d->prepareEdgeAutoScroll(event->position());
-            d->scheduleSnapshot();
             event->accept();
             return;
         }


### PR DESCRIPTION
## Summary

- render the new note's default lyric in the RHI draw preview from the first frame
- share new-note lyric resolution between Legacy preview, RHI preview, and committed notes
- consolidate RHI draw initialization used by Draw mode and Select-mode double-click creation

## Root cause

The Legacy backend creates a temporary `NoteView`, which already carries and paints the default lyric while the mouse is held. The RHI backend had a separate geometry-only preview branch and did not submit text glyphs until the note was committed to the model on mouse release.

The render carriers still differ by necessity (`QGraphicsItem` versus RHI vertex/glyph batches), while the default-lyric policy and the existing RHI text path are now reused.

## User impact

New notes drawn with the RHI backend display their lyric immediately, matching the Legacy backend.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File .agents/skills/scripts/run-cmake-preset.ps1 -Mode ConfigureAndBuild -Preset debug`
