### PR TITLE
fix(track-editor): accept vertical wheel input on track headers

### DIFF
--- a/src/app/UI/Views/Common/EditorWheelUtils.h
+++ b/src/app/UI/Views/Common/EditorWheelUtils.h
@@ -1,9 +1,15 @@
 #ifndef EDITORWHEELUTILS_H
 #define EDITORWHEELUTILS_H
 
+#include <QApplication>
 #include <QInputDevice>
+#include <QPointer>
 #include <QTimer>
+#include <QWidget>
 #include <QWheelEvent>
+
+#include <functional>
+#include <utility>
 
 namespace EditorWheelUtils {
 
@@ -40,6 +46,54 @@ namespace EditorWheelUtils {
             return static_cast<int>(startValue - axisValue(event->pixelDelta(), axis));
         return static_cast<int>(startValue - viewportLength * viewportFraction *
                                                  axisValue(event->angleDelta(), axis) / 120.0);
+    }
+
+    namespace Detail {
+
+        class ChildWheelEventFilter final : public QObject {
+        public:
+            ChildWheelEventFilter(QWidget *target, QObject *parent,
+                                  std::function<void(QWheelEvent *)> handler)
+                : QObject(parent), m_target(target), m_handler(std::move(handler)) {
+                qApp->installEventFilter(this);
+            }
+
+        protected:
+            bool eventFilter(QObject *watched, QEvent *event) override {
+                if (event->type() != QEvent::Wheel || !m_target)
+                    return false;
+
+                auto *source = qobject_cast<QWidget *>(watched);
+                if (!source || source == m_target || source->window() != m_target->window() ||
+                    !m_target->isAncestorOf(source)) {
+                    return false;
+                }
+
+                auto *wheelEvent = static_cast<QWheelEvent *>(event);
+                QWheelEvent mappedEvent(
+                    m_target->mapFromGlobal(wheelEvent->globalPosition()),
+                    wheelEvent->globalPosition(), wheelEvent->pixelDelta(), wheelEvent->angleDelta(),
+                    wheelEvent->buttons(), wheelEvent->modifiers(), wheelEvent->phase(),
+                    wheelEvent->inverted(), wheelEvent->source(), wheelEvent->pointingDevice());
+                mappedEvent.ignore();
+                m_handler(&mappedEvent);
+                if (!mappedEvent.isAccepted())
+                    return false;
+
+                event->accept();
+                return true;
+            }
+
+        private:
+            QPointer<QWidget> m_target;
+            std::function<void(QWheelEvent *)> m_handler;
+        };
+
+    } // namespace Detail
+
+    inline void forwardChildWheelEvents(QWidget *target, QObject *owner,
+                                        std::function<void(QWheelEvent *)> handler) {
+        new Detail::ChildWheelEventFilter(target, owner, std::move(handler));
     }
 
     class InputState final {

--- a/src/app/UI/Views/TrackEditor/TrackListView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackListView.cpp
@@ -4,6 +4,7 @@
 #include "TrackControlView.h"
 #include "Global/TracksEditorGlobal.h"
 #include "TrackAppendSlotView.h"
+#include "UI/Views/Common/EditorWheelUtils.h"
 
 #include <QDragMoveEvent>
 #include <QDropEvent>
@@ -20,6 +21,8 @@ TrackListView::TrackListView(QWidget *parent) : QListWidget(parent) {
     setVerticalScrollMode(ScrollPerPixel);
     setSelectionMode(SingleSelection);
     QScroller::grabGesture(this, QScroller::TouchGesture);
+    EditorWheelUtils::forwardChildWheelEvents(viewport(), this,
+                                              [this](QWheelEvent *event) { wheelEvent(event); });
 
     // Enable drag and drop for track reordering
     setDragEnabled(true);

--- a/src/tests/TestScrollBarInterplay/main.cpp
+++ b/src/tests/TestScrollBarInterplay/main.cpp
@@ -158,6 +158,30 @@ int main(int argc, char *argv[]) {
                140,
            "Shift-wheel gestures must continue mapping the vertical wheel to horizontal scroll");
 
+    QWidget wheelTarget;
+    wheelTarget.resize(300, 200);
+    QWidget wheelChild(&wheelTarget);
+    wheelChild.setGeometry(40, 30, 100, 80);
+    QWidget wheelGrandchild(&wheelChild);
+    wheelGrandchild.setGeometry(10, 15, 40, 30);
+    wheelTarget.show();
+    flush();
+    int forwardedWheelEvents = 0;
+    QPointF forwardedWheelPosition;
+    EditorWheelUtils::forwardChildWheelEvents(
+        &wheelTarget, &wheelTarget, [&](QWheelEvent *event) {
+            ++forwardedWheelEvents;
+            forwardedWheelPosition = event->position();
+            event->accept();
+        });
+    const QPoint targetWheelPosition(65, 55);
+    const auto globalWheelPosition = wheelTarget.mapToGlobal(targetWheelPosition);
+    QWheelEvent childWheel(QPointF(15, 10), globalWheelPosition, {}, QPoint(0, -120),
+                           Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+    QApplication::sendEvent(&wheelGrandchild, &childWheel);
+    expect(forwardedWheelEvents == 1 && forwardedWheelPosition == QPointF(targetWheelPosition),
+           "wheel input from an embedded editor control must be forwarded in target coordinates");
+
     EditorViewportController marginViewport;
     marginViewport.setContentTickRange(0, 20000);
     marginViewport.setLeftMarginPx(10);


### PR DESCRIPTION
## Summary

- forward wheel events from embedded track-header controls through the shared track-list wheel path
- preserve the existing modifier handling and legacy/RHI backend scroll connections
- add a regression test for nested child-wheel forwarding and coordinate mapping

## Verification

- built `DsEditorLite` with the project CMake preset script
- built and ran `TestScrollBarInterplay` (all tests passed)
- verified with Computer Use that wheel input over both the track index and nested track-header controls scrolls in sync on the RHI and legacy QGraphicsView backends