### PR TITLE
fix(track-editor): stabilize track header reordering

### DIFF
--- a/src/app/Resources/theme/lite-dark/colors.json
+++ b/src/app/Resources/theme/lite-dark/colors.json
@@ -171,6 +171,7 @@
         "editor.grid.subdivision": "{neutral.850}",
         "editor.playhead": "{neutral.200}",
         "editor.lastPlayhead": "{neutral.300}",
+        "editor.dropIndicator": "{neutral.200}",
         "editor.loop": "{accent.500}",
         "editor.loopDisabled": "{neutral.500}",
         "editor.selection.border": "{accent.alpha78}",

--- a/src/app/Resources/theme/lite-dark/track-editor.qss
+++ b/src/app/Resources/theme/lite-dark/track-editor.qss
@@ -185,6 +185,10 @@ TrackListView::item:selected {
     background: ${selection.inactiveFill}
 }
 
+TrackListView QWidget#trackDropIndicator {
+    background: ${editor.dropIndicator};
+}
+
 /* TrackSplitter */
 TrackEditorView>OverlaySplitter#trackSplitter {
     border-radius: 6px;

--- a/src/app/Resources/theme/lite-light/colors.json
+++ b/src/app/Resources/theme/lite-light/colors.json
@@ -180,6 +180,7 @@
         "editor.grid.subdivision": "{neutral.50}",
         "editor.playhead": "{neutral.600}",
         "editor.lastPlayhead": "{neutral.500}",
+        "editor.dropIndicator": "{neutral.600}",
         "editor.loop": "{accent.500}",
         "editor.loopDisabled": "{neutral.450}",
         "editor.selection.border": "{accent.alpha78}",

--- a/src/app/Resources/theme/lite-light/track-editor.qss
+++ b/src/app/Resources/theme/lite-light/track-editor.qss
@@ -185,6 +185,10 @@ TrackListView::item:selected {
     background: ${selection.inactiveFill}
 }
 
+TrackListView QWidget#trackDropIndicator {
+    background: ${editor.dropIndicator};
+}
+
 /* TrackSplitter */
 TrackEditorView>OverlaySplitter#trackSplitter {
     border-radius: 6px;

--- a/src/app/UI/Views/TrackEditor/TrackListView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackListView.cpp
@@ -155,7 +155,7 @@ void TrackListView::startDrag(Qt::DropActions supportedActions) {
 }
 
 void TrackListView::dropEvent(QDropEvent *event) {
-    const auto dropRow = m_dropInsertionIndex;
+    const auto dropRow = dropInsertionIndex(event->position().toPoint());
     const auto moved = moveDraggedTrack(dropRow);
     clearDropIndicator();
 
@@ -195,7 +195,6 @@ bool TrackListView::setDropInsertionIndex(const int insertionIndex) {
         return false;
     }
 
-    m_dropInsertionIndex = insertionIndex;
     updateDropIndicator(insertionIndex);
     return true;
 }
@@ -243,7 +242,6 @@ void TrackListView::updateDropIndicator(const int insertionIndex) {
 }
 
 void TrackListView::clearDropIndicator() {
-    m_dropInsertionIndex = -1;
     if (m_dropIndicator)
         m_dropIndicator->hide();
 }

--- a/src/app/UI/Views/TrackEditor/TrackListView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackListView.cpp
@@ -5,8 +5,10 @@
 #include "Global/TracksEditorGlobal.h"
 #include "TrackAppendSlotView.h"
 
+#include <QDrag>
 #include <QDragMoveEvent>
 #include <QDropEvent>
+#include <QPainter>
 #include <QScrollBar>
 #include <QScroller>
 #include <QTimer>
@@ -65,6 +67,7 @@ void TrackListView::setAppendSlotHeight(const int height) {
 
 void TrackListView::mousePressEvent(QMouseEvent *event) {
     // Check if the click is in the drag area (track index label)
+    m_dragStartPosition = event->pos();
     m_canStartDrag = isInDragArea(event->pos());
     QListWidget::mousePressEvent(event);
     event->ignore();
@@ -100,7 +103,33 @@ void TrackListView::dragMoveEvent(QDragMoveEvent *event) {
 void TrackListView::startDrag(Qt::DropActions supportedActions) {
     // Save scroll position before drag starts
     m_scrollPosBeforeDrag = verticalScrollBar()->value();
-    QListWidget::startDrag(supportedActions);
+
+    const auto indexes = selectedIndexes();
+    if (indexes.isEmpty())
+        return;
+
+    auto *mimeData = model()->mimeData(indexes);
+    if (!mimeData)
+        return;
+
+    auto *drag = new QDrag(this);
+    drag->setMimeData(mimeData);
+    const auto dragRow = indexes.first().row();
+    if (const auto *dragItem = item(dragRow)) {
+        const auto rowRect = visualItemRect(dragItem);
+        const auto rowPixmap = viewport()->grab(rowRect);
+        QPixmap dragPixmap(rowPixmap.size());
+        dragPixmap.setDevicePixelRatio(rowPixmap.devicePixelRatio());
+        dragPixmap.fill(Qt::transparent);
+        {
+            QPainter painter(&dragPixmap);
+            painter.setOpacity(0.65);
+            painter.drawPixmap(QPoint{}, rowPixmap);
+        }
+        drag->setPixmap(dragPixmap);
+        drag->setHotSpot(m_dragStartPosition - rowRect.topLeft());
+    }
+    drag->exec(supportedActions & ~Qt::CopyAction, Qt::MoveAction);
 }
 
 void TrackListView::dropEvent(QDropEvent *event) {

--- a/src/app/UI/Views/TrackEditor/TrackListView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackListView.cpp
@@ -26,9 +26,16 @@ TrackListView::TrackListView(QWidget *parent) : QListWidget(parent) {
     // Enable drag and drop for track reordering
     setDragEnabled(true);
     viewport()->setAcceptDrops(true);
-    setDropIndicatorShown(true);
+    setDropIndicatorShown(false);
     setDragDropMode(QAbstractItemView::InternalMove);
     setDefaultDropAction(Qt::MoveAction);
+
+    m_dropIndicator = new QWidget(viewport());
+    m_dropIndicator->setObjectName("trackDropIndicator");
+    m_dropIndicator->setAttribute(Qt::WA_TransparentForMouseEvents);
+    m_dropIndicator->setAttribute(Qt::WA_StyledBackground);
+    m_dropIndicator->setAutoFillBackground(true);
+    m_dropIndicator->hide();
 
     // Enable auto-scroll during drag operations
     setAutoScroll(true);
@@ -98,6 +105,19 @@ void TrackListView::wheelEvent(QWheelEvent *event) {
 
 void TrackListView::dragMoveEvent(QDragMoveEvent *event) {
     QListWidget::dragMoveEvent(event);
+
+    if (!setDropInsertionIndex(dropInsertionIndex(event->position().toPoint()))) {
+        event->ignore();
+        return;
+    }
+
+    event->setDropAction(Qt::MoveAction);
+    event->accept();
+}
+
+void TrackListView::dragLeaveEvent(QDragLeaveEvent *event) {
+    QListWidget::dragLeaveEvent(event);
+    clearDropIndicator();
 }
 
 void TrackListView::startDrag(Qt::DropActions supportedActions) {
@@ -114,8 +134,8 @@ void TrackListView::startDrag(Qt::DropActions supportedActions) {
 
     auto *drag = new QDrag(this);
     drag->setMimeData(mimeData);
-    const auto dragRow = indexes.first().row();
-    if (const auto *dragItem = item(dragRow)) {
+    m_dragRow = indexes.first().row();
+    if (const auto *dragItem = item(m_dragRow)) {
         const auto rowRect = visualItemRect(dragItem);
         const auto rowPixmap = viewport()->grab(rowRect);
         QPixmap dragPixmap(rowPixmap.size());
@@ -130,49 +150,102 @@ void TrackListView::startDrag(Qt::DropActions supportedActions) {
         drag->setHotSpot(m_dragStartPosition - rowRect.topLeft());
     }
     drag->exec(supportedActions & ~Qt::CopyAction, Qt::MoveAction);
+    m_dragRow = -1;
+    clearDropIndicator();
 }
 
 void TrackListView::dropEvent(QDropEvent *event) {
-    const auto selectedItems = selectedIndexes();
-    if (selectedItems.isEmpty()) {
+    const auto dropRow = m_dropInsertionIndex;
+    const auto moved = moveDraggedTrack(dropRow);
+    clearDropIndicator();
+
+    if (!moved) {
         event->ignore();
         return;
     }
 
-    const auto dragRow = selectedItems.first().row();
-    auto dropRow = indexAt(event->position().toPoint()).row();
-    const auto dropIndicator = dropIndicatorPosition();
-
-    // The append-slot placeholder row is not a valid drop target; dropping on
-    // it (or past the last real track) appends to the end of the list.
-    if (dropRow < 0 || dropRow >= trackCount()) {
-        dropRow = trackCount();
-    } else if (dropIndicator == BelowItem) {
-        dropRow++;
-    } else if (dropIndicator == AboveItem && dragRow < dropRow) {
-        dropRow++;
-    }
-
-    if (dragRow == dropRow || (dragRow + 1 == dropRow && dragRow < trackCount() - 1)) {
-        event->ignore();
-        return;
-    }
-
-    // Save current scroll position before the move operation
-    const int currentScrollPos = verticalScrollBar()->value();
-    // Moving downward removes the source row first, so the destination index shifts up by one.
-    const auto finalRow = dropRow > dragRow ? dropRow - 1 : dropRow;
-
-    event->setDropAction(Qt::IgnoreAction);
+    event->setDropAction(Qt::MoveAction);
     event->accept();
+}
 
-    TrackController::onMoveTrack(dragRow, dropRow);
+int TrackListView::dropInsertionIndex(const QPoint &pos) const {
+    const auto count = trackCount();
+    if (m_dragRow < 0 || count == 0)
+        return -1;
 
-    // Restore scroll position after the model update
+    const auto targetItem = itemAt(pos);
+    if (!targetItem) {
+        const auto lastTrackRect = visualItemRect(item(count - 1));
+        return pos.y() >= lastTrackRect.center().y() ? count : -1;
+    }
+
+    const auto targetRow = row(targetItem);
+    if (targetRow == count)
+        return count;
+    if (targetRow < 0 || targetRow > count)
+        return -1;
+
+    const auto targetRect = visualItemRect(targetItem);
+    return pos.y() < targetRect.center().y() ? targetRow : targetRow + 1;
+}
+
+bool TrackListView::setDropInsertionIndex(const int insertionIndex) {
+    if (!isValidDropInsertionIndex(insertionIndex)) {
+        clearDropIndicator();
+        return false;
+    }
+
+    m_dropInsertionIndex = insertionIndex;
+    updateDropIndicator(insertionIndex);
+    return true;
+}
+
+bool TrackListView::isValidDropInsertionIndex(const int insertionIndex) const {
+    return m_dragRow >= 0 && m_dragRow < trackCount() && insertionIndex >= 0 &&
+           insertionIndex <= trackCount() && insertionIndex != m_dragRow &&
+           insertionIndex != m_dragRow + 1;
+}
+
+bool TrackListView::moveDraggedTrack(const int insertionIndex) {
+    if (!isValidDropInsertionIndex(insertionIndex))
+        return false;
+
+    const auto dragRow = m_dragRow;
+    const auto currentScrollPos = verticalScrollBar()->value();
+    // Moving downward removes the source row first, so the destination index shifts up by one.
+    const auto finalRow = insertionIndex > dragRow ? insertionIndex - 1 : insertionIndex;
+
+    TrackController::onMoveTrack(dragRow, insertionIndex);
+
     QTimer::singleShot(0, this, [this, currentScrollPos, finalRow]() {
         setCurrentRow(finalRow);
         verticalScrollBar()->setValue(currentScrollPos);
     });
+    return true;
+}
+
+void TrackListView::updateDropIndicator(const int insertionIndex) {
+    const auto count = trackCount();
+    if (!m_dropIndicator || insertionIndex < 0 || insertionIndex > count || count == 0) {
+        clearDropIndicator();
+        return;
+    }
+
+    const auto boundary = insertionIndex == count
+                              ? visualItemRect(item(count - 1)).bottom() + 1
+                              : visualItemRect(item(insertionIndex)).top();
+    constexpr auto indicatorHeight = 2;
+    const auto top = qBound(0, boundary - indicatorHeight / 2,
+                            viewport()->height() - indicatorHeight);
+    m_dropIndicator->setGeometry(0, top, viewport()->width(), indicatorHeight);
+    m_dropIndicator->raise();
+    m_dropIndicator->show();
+}
+
+void TrackListView::clearDropIndicator() {
+    m_dropInsertionIndex = -1;
+    if (m_dropIndicator)
+        m_dropIndicator->hide();
 }
 
 bool TrackListView::isInDragArea(const QPoint &pos) const {

--- a/src/app/UI/Views/TrackEditor/TrackListView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackListView.cpp
@@ -51,14 +51,9 @@ bool TrackListView::moveTrackRow(const int from, const int to) {
         return true;
     if (from < 0 || from >= trackCount() || to < 0 || to >= trackCount())
         return false;
-    auto *item = takeItem(from);
-    if (!item)
-        return false;
-    auto *widget = itemWidget(item);
-    insertItem(to, item);
-    if (widget)
-        setItemWidget(item, widget);
-    return true;
+
+    const auto destination = to > from ? to + 1 : to;
+    return model()->moveRow({}, from, {}, destination);
 }
 
 void TrackListView::setAppendSlotHeight(const int height) {

--- a/src/app/UI/Views/TrackEditor/TrackListView.h
+++ b/src/app/UI/Views/TrackEditor/TrackListView.h
@@ -5,6 +5,7 @@
 
 class QWheelEvent;
 class QListWidgetItem;
+class QDragLeaveEvent;
 
 class TrackListView : public QListWidget {
     Q_OBJECT
@@ -30,15 +31,25 @@ protected:
     void mouseMoveEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
+    void dragLeaveEvent(QDragLeaveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void startDrag(Qt::DropActions supportedActions) override;
 
 private:
     bool isInDragArea(const QPoint &pos) const;
+    int dropInsertionIndex(const QPoint &pos) const;
+    bool isValidDropInsertionIndex(int insertionIndex) const;
+    bool setDropInsertionIndex(int insertionIndex);
+    bool moveDraggedTrack(int insertionIndex);
+    void updateDropIndicator(int insertionIndex);
+    void clearDropIndicator();
 
     int m_scrollPosBeforeDrag = 0;
     QPoint m_dragStartPosition;
+    int m_dragRow = -1;
+    int m_dropInsertionIndex = -1;
     bool m_canStartDrag = false;
+    QWidget *m_dropIndicator = nullptr;
     // Disabled, non-selectable, non-draggable placeholder row mirroring the
     // canvas append slot. Always the last row.
     QListWidgetItem *m_appendSlotItem = nullptr;

--- a/src/app/UI/Views/TrackEditor/TrackListView.h
+++ b/src/app/UI/Views/TrackEditor/TrackListView.h
@@ -47,7 +47,6 @@ private:
     int m_scrollPosBeforeDrag = 0;
     QPoint m_dragStartPosition;
     int m_dragRow = -1;
-    int m_dropInsertionIndex = -1;
     bool m_canStartDrag = false;
     QWidget *m_dropIndicator = nullptr;
     // Disabled, non-selectable, non-draggable placeholder row mirroring the

--- a/src/app/UI/Views/TrackEditor/TrackListView.h
+++ b/src/app/UI/Views/TrackEditor/TrackListView.h
@@ -37,6 +37,7 @@ private:
     bool isInDragArea(const QPoint &pos) const;
 
     int m_scrollPosBeforeDrag = 0;
+    QPoint m_dragStartPosition;
     bool m_canStartDrag = false;
     // Disabled, non-selectable, non-draggable placeholder row mirroring the
     // canvas append slot. Always the last row.


### PR DESCRIPTION
## Summary

- move track-list rows through the underlying model so embedded track-header widgets stay attached
- render the complete track header as a semi-transparent drag preview
- replace the default list indicator with an accurate, theme-aware insertion cursor
- treat each track's upper and lower halves as before/after targets, while keeping the append area below the final track valid
- keep the fixed tempo and time-signature lanes outside the track reorder target area
- preserve mix-console channel completeness and ordering during track moves

## Root cause

`TrackListView::moveTrackRow()` removed a list item before looking up its item widget. Once removed, the item no longer had a valid model index, so the embedded track-control widget mapping was lost and could enter Qt's deferred deletion path.

Qt's default list drag preview also did not capture the embedded row widget, and its drop-position reporting did not match the permanent append-slot row or the intended half-row insertion semantics. The track list now captures its composed row for the preview and computes one normalized insertion index for both feedback and the final move.

## Validation

- Debug build: `DsEditorLite`
- Theme validation: `TestThemeColors`
- RHI GUI: upward and downward reordering with panels and clips preserved
- RHI GUI: first/last insertion, no-op positions, and the append area below the final track
- RHI GUI: tempo and time-signature lanes rejected as drop targets
- RHI GUI: complete semi-transparent preview with the insertion cursor remaining visible
- System dark and light themes: semantic grayscale insertion cursor and successful theme switching
- Undo/redo after reordering: panels preserved
- Mix console visible during reordering: channels preserved, with colors and indices synchronized

The implementation is shared Qt Widgets/model code and does not depend on the rendering backend.