### PR TITLE
feat(packaging): install PDBs and rework the portable Windows zip

### DIFF
--- a/.agents/skills/windows-installer/SKILL.md
+++ b/.agents/skills/windows-installer/SKILL.md
@@ -34,16 +34,18 @@ description: 为 DS Editor Lite 构建、检查或排查 Windows x64 DirectML In
 - 产品元数据只修改 `cmake/ProductMetadata.cmake`。AppId 一经发布不得更换。
 - 不安装生成的安装包，除非用户明确授权修改本机安装状态。
 
-## 绿色版（便携 zip）
+## 便携版（zip）
 
 用户要求"绿色版/便携版/zip 解压即用/带 PDB 可追踪"时，使用
-`packaging\windows\build-green-zip.ps1`（**不使用** build-installer.ps1）：
-- 构建 `package-dml-green` preset（`CMAKE_BUILD_TYPE=RelWithDebInfo`，
+`packaging\windows\build-portable.ps1`（**不使用** build-installer.ps1）：
+- 构建 `package-dml-portable` preset（`CMAKE_BUILD_TYPE=RelWithDebInfo`，
   `LITE_ENABLE_CUDA=OFF`，`LITE_ENABLE_FILE_LOG=ON`，独立目录
-  `build\GreenDmlRelease`）。
-- 从 `build\GreenDmlRelease\out\bin` 直接打 zip（不走 CMake install，保住 PDB）。
-- 文件名 `DsEditorLite-<yyyyMMdd-HHmm>-win-x64-dml-green.zip`，时间戳命名，
+  `build\PortableDmlRelease`）。
+- 必须经 CMake install 到 staging（**不从 build 输出目录直接打包**），再压缩
+  staging 的 `bin` 树成 zip。脚本随后补齐 vcpkg 依赖的 PDB；Qt 与 app 的 PDB
+  由 install 自带（windeployqt `--pdb` + `LITE_INSTALL_PDB`）。
+- 文件名 `DsEditorLite-<yyyyMMdd-HHmm>-win-x64-dml-portable.zip`，时间戳命名，
   **不含版本号**。
 - 用 **pwsh**（PowerShell 7）运行；git-bash 调 Windows PowerShell 5.1 会报
   `Get-FileHash is not recognized`。
-- 细节见 `packaging/windows/README.md`「绿色版（便携 zip）」一节。
+- 细节见 `packaging/windows/README.md`「便携版（zip）」一节。

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,15 +55,15 @@
       }
     },
     {
-      "name": "package-dml-green",
-      "displayName": "Package DML Green RelWithDebInfo",
-      "description": "Configure a RelWithDebInfo build for the Windows x64 DML portable zip (green version, PDB included).",
+      "name": "package-dml-portable",
+      "displayName": "Package DML Portable RelWithDebInfo",
+      "description": "Configure a RelWithDebInfo build for the Windows x64 DML portable zip (portable version, PDB included).",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/GreenDmlRelease",
+      "binaryDir": "${sourceDir}/build/PortableDmlRelease",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist/stage/green",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist/stage/portable",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "LITE_BUILD_TESTS": "OFF",
         "LITE_ENABLE_FILE_LOG": "ON",
@@ -102,10 +102,10 @@
       ]
     },
     {
-      "name": "package-dml-green",
-      "displayName": "Build Package DML Green RelWithDebInfo",
+      "name": "package-dml-portable",
+      "displayName": "Build Package DML Portable RelWithDebInfo",
       "description": "Build the RelWithDebInfo application target for the Windows x64 DML portable zip.",
-      "configurePreset": "package-dml-green",
+      "configurePreset": "package-dml-portable",
       "targets": [
         "DsEditorLite"
       ]

--- a/cmake/LiteBuildApi.cmake
+++ b/cmake/LiteBuildApi.cmake
@@ -81,6 +81,7 @@ function(lite_deploy_application _target)
                 --no-system-d3d-compiler
                 --no-compiler-runtime
                 --no-opengl-sw
+                --pdb # Also deploy the Qt modules' .pdb files
                 "$<TARGET_FILE:${_target}>"
             COMMENT "Deploy Qt"
         )
@@ -195,6 +196,7 @@ function(lite_deploy_application _target)
                     --no-system-d3d-compiler
                     --no-compiler-runtime
                     --no-opengl-sw
+                    --pdb
                     --force
                     --verbose 0
                     \"\${CMAKE_INSTALL_PREFIX}/${LITE_INSTALL_RUNTIME_DIR}/$<TARGET_FILE_NAME:${_target}>\"

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -61,31 +61,35 @@ C:\Program Files\OpenVPI\DS Editor Lite
 6. 仅将 staging 的 `bin` 目录交给 Inno Setup 7，排除头文件、导入库和 CMake 包文件。
 7. 输出安装包路径和 SHA-256。
 
-## 绿色版（便携 zip）
+## 便携版（zip）
 
-`package-dml-green` preset（RelWithDebInfo）配合
-`packaging\windows\build-green-zip.ps1` 产出解压即用的便携 zip，内置 PDB
+`package-dml-portable` preset（RelWithDebInfo）配合
+`packaging\windows\build-portable.ps1` 产出解压即用的便携 zip，内置 PDB
 符号，崩溃可追踪。
 
 ```powershell
-.\packaging\windows\build-green-zip.ps1
+.\packaging\windows\build-portable.ps1
 ```
 
 或复用已有构建产物、只重新打包：
 
 ```powershell
-.\packaging\windows\build-green-zip.ps1 -NoBuild
+.\packaging\windows\build-portable.ps1 -NoBuild
 ```
 
 特性：
 
 - RelWithDebInfo，优化 + 调试符号；MSVC `/Zi` 的 PDB 直接产出在 `out\bin`。
-- 直接压缩 `build\GreenDmlRelease\out\bin`（不走 CMake install，保住 PDB）。
+- 必须经 CMake install 到 staging（**不从 build 输出目录直接打包**），再压缩
+  staging 的 `bin` 树。install 自带 app 与 Qt 的 PDB（`LITE_INSTALL_PDB` +
+  windeployqt `--pdb`）；脚本随后从 `vcpkg\installed\x64-windows\bin` 按名补齐
+  各 vcpkg 依赖的 PDB（此逻辑刻意留在打包脚本里，不进 CMake，保持构建系统
+  不感知 vcpkg）。
 - zip 会校验 DsEditorLite.exe 与至少一个 PDB 存在，否则报错退出。
-- 文件名为 `DsEditorLite-<yyyyMMdd-HHmm>-win-x64-dml-green.zip`（时间戳，**不含版本号**）。
+- 文件名为 `DsEditorLite-<yyyyMMdd-HHmm>-win-x64-dml-portable.zip`（时间戳，**不含版本号**）。
 - 建议用 **pwsh**（PowerShell 7）运行；从 git-bash 调 Windows PowerShell 5.1
   会出现 `Get-FileHash is not recognized` 环境问题。
-- 产物目录：`dist\green\`，脚本输出路径、大小与 SHA-256。
+- 产物目录：`dist\portable\`，脚本输出路径、大小与 SHA-256。
 
 ## 产品元数据
 

--- a/packaging/windows/build-portable.ps1
+++ b/packaging/windows/build-portable.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$OutputDir = "dist\green",
+    [string]$OutputDir = "dist\portable",
     [switch]$SkipVcpkgInstall,
     [switch]$NoBuild
 )
@@ -128,50 +128,85 @@ if (-not $NoBuild) {
         Initialize-BuildEnvironment
     }
 
-    Invoke-Step "Configure CMake preset package-dml-green" {
-        Invoke-Process "cmake" @("--preset", "package-dml-green")
+    Invoke-Step "Configure CMake preset package-dml-portable" {
+        Invoke-Process "cmake" @("--preset", "package-dml-portable")
     }
 
-    Invoke-Step "Build package-dml-green" {
-        Invoke-Process "cmake" @("--build", "--preset", "package-dml-green")
+    Invoke-Step "Build package-dml-portable" {
+        Invoke-Process "cmake" @("--build", "--preset", "package-dml-portable")
     }
 }
 
-# The green zip is packaged directly from the build output directory, which
-# already contains the deployed Qt runtime, plugins, resources and PDB symbols
-# (RelWithDebInfo). This keeps the PDBs next to the binaries so crashes can be
-# traced after the user unzips and runs the app.
-$OutBinDir = Join-Path $RepoRoot "build\GreenDmlRelease\out\bin"
-if (-not (Test-Path -LiteralPath $OutBinDir)) {
-    throw "Build output directory not found: $OutBinDir"
-}
-if (-not (Test-Path -LiteralPath (Join-Path $OutBinDir "DsEditorLite.exe"))) {
-    throw "DsEditorLite.exe not found in $OutBinDir"
-}
-$PdbCount = (Get-ChildItem -LiteralPath $OutBinDir -Filter "*.pdb").Count
-if ($PdbCount -eq 0) {
-    throw "No PDB symbols found in $OutBinDir - build was not RelWithDebInfo?"
+# The portable zip is produced from a real CMake install (not the raw build
+# output): `cmake --install` lays down the app, the deployed Qt runtime,
+# plugins, resources, and the app's + Qt's PDB symbols (windeployqt --pdb +
+# LITE_INSTALL_PDB). We then add the vcpkg dependencies' PDBs, which vcpkg's
+# applocal deploy does not copy, and zip the runnable `bin` tree.
+$BuildDir = Join-Path $RepoRoot "build\PortableDmlRelease"
+if (-not (Test-Path -LiteralPath (Join-Path $BuildDir "out\bin\DsEditorLite.exe"))) {
+    throw "Build output not found in $BuildDir (run without -NoBuild first)."
 }
 
 $ResolvedOutputDir = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $OutputDir))
 New-Item -ItemType Directory -Force -Path $ResolvedOutputDir | Out-Null
+$StageDir = Join-Path $ResolvedOutputDir "stage"
+$AppDir = Join-Path $StageDir "bin"
+
+Invoke-Step "Install to a clean staging tree" {
+    if (Test-Path -LiteralPath $StageDir) {
+        Remove-Item -LiteralPath $StageDir -Recurse -Force
+    }
+    Invoke-Process "cmake" @("--install", $BuildDir, "--prefix", $StageDir)
+    if (-not (Test-Path -LiteralPath (Join-Path $AppDir "DsEditorLite.exe"))) {
+        throw "DsEditorLite.exe not found after install in $AppDir"
+    }
+}
+
+# windeployqt (--pdb) and LITE_INSTALL_PDB already installed the Qt and app
+# PDBs. vcpkg ships each dependency's PDB next to its DLL but its applocal
+# deploy copies only the DLLs, so for every installed DLL pull the same-named
+# PDB from the vcpkg release bin. Kept here (packaging), not in CMake, so the
+# build system stays vcpkg-agnostic.
+Invoke-Step "Copy vcpkg dependency PDBs" {
+    $vcpkgBin = Join-Path $RepoRoot "vcpkg\installed\x64-windows\bin"
+    if (-not (Test-Path -LiteralPath $vcpkgBin -PathType Container)) {
+        throw "vcpkg release bin not found: $vcpkgBin"
+    }
+    $copied = 0
+    Get-ChildItem -LiteralPath $AppDir -Recurse -Filter "*.dll" | ForEach-Object {
+        $pdbName = [System.IO.Path]::GetFileNameWithoutExtension($_.Name) + ".pdb"
+        $src = Join-Path $vcpkgBin $pdbName
+        $dst = Join-Path $_.DirectoryName $pdbName
+        if ((Test-Path -LiteralPath $src -PathType Leaf) -and
+            -not (Test-Path -LiteralPath $dst -PathType Leaf)) {
+            Copy-Item -LiteralPath $src -Destination $dst
+            $copied++
+        }
+    }
+    Write-Host "Copied $copied vcpkg dependency PDB(s)."
+}
+
+$PdbCount = (Get-ChildItem -LiteralPath $AppDir -Recurse -Filter "*.pdb").Count
+if ($PdbCount -eq 0) {
+    throw "No PDB symbols in the installed tree - build was not RelWithDebInfo?"
+}
 
 $Timestamp = Get-Date -Format "yyyyMMdd-HHmm"
-$ZipBaseName = "DsEditorLite-$Timestamp-win-x64-dml-green"
+$ZipBaseName = "DsEditorLite-$Timestamp-win-x64-dml-portable"
 $ZipPath = Join-Path $ResolvedOutputDir "$ZipBaseName.zip"
 
-Invoke-Step "Package green zip" {
+Invoke-Step "Package portable zip" {
     $tempZip = Join-Path $ResolvedOutputDir ".$ZipBaseName.tmp.zip"
     if (Test-Path -LiteralPath $tempZip) {
         Remove-Item -LiteralPath $tempZip -Force
     }
-    Compress-Archive -Path (Join-Path $OutBinDir "*\") -DestinationPath $tempZip -CompressionLevel Optimal
+    Compress-Archive -Path (Join-Path $AppDir "*") -DestinationPath $tempZip -CompressionLevel Optimal
     Move-Item -LiteralPath $tempZip -Destination $ZipPath -Force
 }
 
 $ZipSize = (Get-Item -LiteralPath $ZipPath).Length
 $ZipHash = (Get-FileHash -LiteralPath $ZipPath -Algorithm SHA256).Hash
 Write-Host ""
-Write-Host "Green zip created: $ZipPath" -ForegroundColor Green
+Write-Host "Portable zip created: $ZipPath" -ForegroundColor Green
 Write-Host "Size: $([math]::Round($ZipSize / 1MB, 1)) MB"
 Write-Host "SHA-256: $ZipHash"

--- a/packaging/windows/build-portable.ps1
+++ b/packaging/windows/build-portable.ps1
@@ -36,6 +36,18 @@ function Invoke-Process {
     }
 }
 
+function Get-ProductMetadata {
+    param([Parameter(Mandatory = $true)][string]$DestinationPath)
+
+    $generator = Join-Path $RepoRoot "cmake\GenerateProductMetadata.cmake"
+    Invoke-Process "cmake" @(
+        "-DOUTPUT_PATH=$DestinationPath",
+        "-P",
+        $generator
+    )
+    return Get-Content -LiteralPath $DestinationPath -Raw | ConvertFrom-Json
+}
+
 function Find-VisualStudio {
     $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path -LiteralPath $vswhere -PathType Leaf) {
@@ -123,6 +135,13 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $RepoRoot = [System.IO.Path]::GetFullPath((Join-Path $ScriptDir "..\.."))
 Set-Location $RepoRoot
 
+$ResolvedOutputDir = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $OutputDir))
+New-Item -ItemType Directory -Force -Path $ResolvedOutputDir | Out-Null
+
+$MetadataPath = Join-Path $ResolvedOutputDir "product-metadata.json"
+$ProductMetadata = Get-ProductMetadata -DestinationPath $MetadataPath
+$ExecutableName = "$($ProductMetadata.executableBaseName).exe"
+
 if (-not $NoBuild) {
     Invoke-Step "Initialize Visual Studio and Qt environment" {
         Initialize-BuildEnvironment
@@ -143,12 +162,10 @@ if (-not $NoBuild) {
 # LITE_INSTALL_PDB). We then add the vcpkg dependencies' PDBs, which vcpkg's
 # applocal deploy does not copy, and zip the runnable `bin` tree.
 $BuildDir = Join-Path $RepoRoot "build\PortableDmlRelease"
-if (-not (Test-Path -LiteralPath (Join-Path $BuildDir "out\bin\DsEditorLite.exe"))) {
+if (-not (Test-Path -LiteralPath (Join-Path $BuildDir "out\bin\$ExecutableName"))) {
     throw "Build output not found in $BuildDir (run without -NoBuild first)."
 }
 
-$ResolvedOutputDir = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $OutputDir))
-New-Item -ItemType Directory -Force -Path $ResolvedOutputDir | Out-Null
 $StageDir = Join-Path $ResolvedOutputDir "stage"
 $AppDir = Join-Path $StageDir "bin"
 
@@ -157,8 +174,8 @@ Invoke-Step "Install to a clean staging tree" {
         Remove-Item -LiteralPath $StageDir -Recurse -Force
     }
     Invoke-Process "cmake" @("--install", $BuildDir, "--prefix", $StageDir)
-    if (-not (Test-Path -LiteralPath (Join-Path $AppDir "DsEditorLite.exe"))) {
-        throw "DsEditorLite.exe not found after install in $AppDir"
+    if (-not (Test-Path -LiteralPath (Join-Path $AppDir "$ExecutableName"))) {
+        throw "$ExecutableName not found after install in $AppDir"
     }
 }
 

--- a/src/conf.cmake
+++ b/src/conf.cmake
@@ -9,6 +9,9 @@ set(LITE_POST_CONFIGURE_COMMANDS _lite_common_configure_target)
 set(LITE_BUILD_INFO_HEADER_PATH lite/BuildInfo.h)
 set(LITE_BUILD_INFO_HEADER_PREFIX LITE)
 
+# Install the application's debug symbols
+set(LITE_INSTALL_PDB ON)
+
 # Dependency Configurations
 set(TALCS_DSPX ON)
 set(TALCS_WIDGETS ON)


### PR DESCRIPTION
Make installed/packaged Windows builds debuggable, and rename the "green" zip to "portable".

Debug symbols now install:
- LITE_INSTALL_PDB installs DsEditorLite.pdb (the static lite::* libraries' symbols are already merged into it at link time).
- windeployqt runs with --pdb (both the build-time POST_BUILD and the install-time deploy) to bring the Qt modules' PDBs.

Portable packaging (packaging/windows/build-portable.ps1, renamed from build-green-zip.ps1) now packages a real `cmake --install` staging tree instead of the raw build output, then copies each vcpkg dependency's PDB from the vcpkg bin next to its DLL, then zips the bin tree. The vcpkg PDB step lives in the packaging script, not CMake, so the build system stays vcpkg-agnostic.

Rename green -> portable: preset package-dml-green -> package-dml-portable, build dir GreenDmlRelease -> PortableDmlRelease, dist/stage/green -> portable, zip suffix -dml-green -> -dml-portable; README and the windows-installer skill updated (install-then-package is now mandatory for the portable zip).

Verified end-to-end: the portable zip carries 57 PDBs (app + Qt + vcpkg deps).