### PR TITLE
Fix Windows portable Qt deployment

### DIFF
--- a/cmake/LiteBuildApi.cmake
+++ b/cmake/LiteBuildApi.cmake
@@ -187,6 +187,8 @@ function(lite_deploy_application _target)
             )
         ")
 
+        # Do not force replacement here. Qt 6.11's PE dependency cache can keep an
+        # existing app-local system DLL mapped while windeployqt tries to replace it.
         install(CODE "
             execute_process(
                 COMMAND \"${_deploy_tool}\"
@@ -197,10 +199,10 @@ function(lite_deploy_application _target)
                     --no-compiler-runtime
                     --no-opengl-sw
                     --pdb
-                    --force
                     --verbose 0
                     \"\${CMAKE_INSTALL_PREFIX}/${LITE_INSTALL_RUNTIME_DIR}/$<TARGET_FILE_NAME:${_target}>\"
                 WORKING_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/${LITE_INSTALL_RUNTIME_DIR}\"
+                COMMAND_ERROR_IS_FATAL ANY
             )
         ")
     endif()


### PR DESCRIPTION
## Summary

- stop passing `--force` to the install-time `windeployqt` invocation
- make a non-zero `windeployqt` exit code fail the CMake install immediately

## Root cause

Qt 6.11 can keep an existing app-local PE dependency such as `icuuc.dll` mapped while scanning it. With `--force`, `windeployqt` then tries to remove that same mapped file and exits non-zero. The previous CMake install code did not propagate that failure, so packaging continued and produced an incomplete portable archive without required Qt plugins such as `platforms/qwindows.dll`.

## Impact

Windows portable packaging now avoids the self-locking replacement path, and deployment failures stop the install/package pipeline instead of producing a broken archive.

## Validation

- configured and built `package-dml-portable` through the project CMake preset helper
- ran the DirectML portable packaging workflow with `-NoBuild`
- confirmed configure, build, install, Qt deployment, and archive creation all exited successfully
- extracted the resulting archive with Windows `Expand-Archive`
- launched the packaged `DsEditorLite.exe` and confirmed the main window opened as `新工程 - DS Editor Lite`
