### PR TITLE
fix(editor): prevent single-point draw curves

### DIFF
--- a/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.cpp
+++ b/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.cpp
@@ -22,7 +22,7 @@ QList<Curve *> AnchorEditor::replaceDrawCurves(const QList<Curve *> &existing,
                                                const QList<DrawCurve *> &replacementDrawCurves) {
     QList<Curve *> result;
     for (const auto *curve : replacementDrawCurves) {
-        if (curve)
+        if (curve && curve->values().size() >= 2)
             result.append(new DrawCurve(*curve));
     }
     for (const auto *curve : existing) {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsViewHelper.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsViewHelper.cpp
@@ -14,6 +14,7 @@
 #include "Model/AppOptions/AppOptions.h"
 #include "Model/AppStatus/AppStatus.h"
 #include "Modules/Inference/EditSessionManager.h"
+#include "UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.h"
 #include <lite/Support/Linq.h>
 #include <lite/Support/MathUtils.h>
 #include <lite/MusicBase/TimelineSnapUtils.h>
@@ -83,20 +84,14 @@ void PianoRollGraphicsViewHelper::splitNote(const int noteId, const int tick) {
 }
 
 void PianoRollGraphicsViewHelper::editPitch(const QList<DrawCurve *> &curves) {
-    QList<Curve *> list;
-    for (const auto curve : curves)
-        list.append(curve);
-
     auto *clip = dynamic_cast<SingingClip *>(clipController->clip());
-    if (clip) {
-        const auto &existing = clip->params.getParamByName(ParamInfo::Pitch)->curves(Param::Edited);
-        for (auto *curve : existing) {
-            if (curve->type() == Curve::Anchor)
-                list.append(new AnchorCurve(*dynamic_cast<AnchorCurve *>(curve)));
-        }
-    }
+    if (!clip)
+        return;
 
+    const auto &existing = clip->params.getParamByName(ParamInfo::Pitch)->curves(Param::Edited);
+    auto list = AnchorEditor::replaceDrawCurves(existing, curves);
     clipController->onParamEdited(ParamInfo::Pitch, list);
+    qDeleteAll(list);
 }
 
 NoteView *PianoRollGraphicsViewHelper::buildNoteView(const Note &note) {

--- a/src/tests/TestAnchorEditController/main.cpp
+++ b/src/tests/TestAnchorEditController/main.cpp
@@ -210,6 +210,30 @@ namespace {
         qDeleteAll(existing);
     }
 
+    void testCompositionRejectsSinglePointDrawCurves() {
+        auto *anchor = makeCurve({
+            {10, 20},
+            {20, 40}
+        });
+        auto *singlePoint = new DrawCurve;
+        singlePoint->setLocalStart(30);
+        singlePoint->setValues({60});
+        auto *draw = new DrawCurve;
+        draw->setLocalStart(40);
+        draw->setValues({70, 80});
+
+        auto result = AnchorEditor::replaceDrawCurves({anchor}, {singlePoint, draw});
+        expect(result.size() == 2 && result.first()->type() == Curve::Draw &&
+                   static_cast<DrawCurve *>(result.first())->values() == QList<int>({70, 80}) &&
+                   result.last()->type() == Curve::Anchor,
+               "draw replacement must reject single-point curves and preserve valid curves");
+
+        qDeleteAll(result);
+        delete draw;
+        delete singlePoint;
+        delete anchor;
+    }
+
     void testSelectionAndLastNodeMenu() {
         AnchorEditor::AnchorEditController controller;
         controller.setCoordinateMapper(mapper());
@@ -378,6 +402,7 @@ int main(int argc, char *argv[]) {
     testDragCancelRestoresSnapshot();
     testSelectionDeleteAndInterpolation();
     testCompositionPreservesOtherCurveKind();
+    testCompositionRejectsSinglePointDrawCurves();
     testSelectionAndLastNodeMenu();
     testBoundaryClippingAndRejectedMutation();
     testTransferAndMerge();


### PR DESCRIPTION
## Summary

- Reject single-point hand-drawn curve intervals at the shared draw-curve composition boundary.
- Route piano-roll pitch commits through the existing shared replacement logic while preserving anchor curves.
- Add regression coverage for filtering a singleton without affecting valid curves or anchors.

## Root cause

The DSPX sample contains a legal one-value free pitch curve at tick 3645. Draw/erase modes render edited curves separately, so the singleton has no visible segment. Other modes merge edited and original pitch first, making that effective sample appear as a spike. The same sample also participates in effective parameter calculation, so this is an editor-generation bug rather than only a raster artifact or malformed document.

## Verification

- `TestAnchorEditController.exe` passes.
- Debug `DsEditorLite` target builds successfully with the project CMake preset workflow.
- Computer Use reproduced the spike in track 2 near `002:04:287`; after cleanup, a one-sample-length hand-draw gesture no longer recreates a spike when returning to normal mode.
- The original `spike.dspx` was not saved or modified during GUI verification.