### PR TITLE
fix(editor): unify focus and edit command routing

### DIFF
--- a/src/app/Controller/EditorViewController.cpp
+++ b/src/app/Controller/EditorViewController.cpp
@@ -108,6 +108,19 @@ void EditorViewController::setActivePanel(AppGlobal::PanelType panel) {
     setActiveContext(panel, EditorInteraction::defaultTargetForPanel(panel));
 }
 
+void EditorViewController::syncPanelVisibility(const bool trackPanelVisible,
+                                               const bool bottomPanelVisible,
+                                               const AppGlobal::PanelType bottomPanelType) {
+    if (!trackPanelVisible && !bottomPanelVisible)
+        return;
+    if (!bottomPanelVisible) {
+        setActivePanel(AppGlobal::TracksEditor);
+        return;
+    }
+    if (!trackPanelVisible && m_activePanel != bottomPanelType)
+        setActivePanel(bottomPanelType);
+}
+
 AppGlobal::PanelType EditorViewController::activePanel() const {
     return m_activePanel;
 }

--- a/src/app/Controller/EditorViewController.cpp
+++ b/src/app/Controller/EditorViewController.cpp
@@ -3,12 +3,21 @@
 #include "Interface/IEditorView.h"
 #include "Interface/IPanel.h"
 
+#include <QCoreApplication>
+#include <QEvent>
+
+#include <algorithm>
 #include <utility>
 
 EditorViewController::EditorViewController(QObject *parent) : QObject(parent) {
+    if (qApp)
+        qApp->installEventFilter(this);
 }
 
-EditorViewController::~EditorViewController() = default;
+EditorViewController::~EditorViewController() {
+    if (qApp)
+        qApp->removeEventFilter(this);
+}
 
 LITE_SINGLETON_IMPLEMENT_INSTANCE(EditorViewController)
 
@@ -96,8 +105,84 @@ void EditorViewController::unregisterPanel(IPanel *panel) {
 }
 
 void EditorViewController::setActivePanel(AppGlobal::PanelType panel) {
-    for (const auto registeredPanel : std::as_const(m_panels))
-        registeredPanel->setPanelActive(registeredPanel->panelType() == panel);
-    m_activePanel = panel;
-    emit activePanelChanged(panel);
+    setActiveContext(panel, EditorInteraction::defaultTargetForPanel(panel));
+}
+
+AppGlobal::PanelType EditorViewController::activePanel() const {
+    return m_activePanel;
+}
+
+void EditorViewController::registerInteractionArea(QObject *area, const AppGlobal::PanelType panel,
+                                                   const EditorInteraction::Target target) {
+    if (!area)
+        return;
+    updateInteractionArea(area, panel, target);
+}
+
+void EditorViewController::updateInteractionArea(QObject *area, const AppGlobal::PanelType panel,
+                                                 const EditorInteraction::Target target) {
+    if (!area)
+        return;
+    m_interactionAreas.erase(
+        std::remove_if(m_interactionAreas.begin(), m_interactionAreas.end(),
+                       [](const InteractionArea &entry) { return entry.object.isNull(); }),
+        m_interactionAreas.end());
+    for (auto &entry : m_interactionAreas) {
+        if (entry.object == area) {
+            entry.panel = panel;
+            entry.target = target;
+            return;
+        }
+    }
+    m_interactionAreas.append({area, panel, target});
+}
+
+void EditorViewController::unregisterInteractionArea(QObject *area) {
+    m_interactionAreas.erase(std::remove_if(m_interactionAreas.begin(), m_interactionAreas.end(),
+                                            [area](const InteractionArea &entry) {
+                                                return entry.object.isNull() ||
+                                                       entry.object == area;
+                                            }),
+                             m_interactionAreas.end());
+}
+
+EditorInteraction::Target EditorViewController::activeEditTarget() const {
+    return m_activeEditTarget;
+}
+
+void EditorViewController::requestEditCommand(const EditorInteraction::Command command) {
+    emit editCommandRequested(m_activeEditTarget, command);
+}
+
+bool EditorViewController::eventFilter(QObject *watched, QEvent *event) {
+    if (event->type() != QEvent::MouseButtonPress && event->type() != QEvent::FocusIn)
+        return QObject::eventFilter(watched, event);
+
+    for (auto *object = watched; object; object = object->parent()) {
+        for (const auto &entry : std::as_const(m_interactionAreas)) {
+            if (entry.object == object) {
+                setActiveContext(entry.panel, entry.target);
+                return QObject::eventFilter(watched, event);
+            }
+        }
+    }
+    return QObject::eventFilter(watched, event);
+}
+
+void EditorViewController::setActiveContext(const AppGlobal::PanelType panel,
+                                            const EditorInteraction::Target target) {
+    if (m_activePanel != panel) {
+        m_activePanel = panel;
+        for (const auto registeredPanel : std::as_const(m_panels))
+            registeredPanel->setPanelActive(registeredPanel->panelType() == panel);
+        emit activePanelChanged(panel);
+    }
+    setActiveEditTarget(target);
+}
+
+void EditorViewController::setActiveEditTarget(const EditorInteraction::Target target) {
+    if (m_activeEditTarget == target)
+        return;
+    m_activeEditTarget = target;
+    emit activeEditTargetChanged(target);
 }

--- a/src/app/Controller/EditorViewController.cpp
+++ b/src/app/Controller/EditorViewController.cpp
@@ -121,6 +121,13 @@ void EditorViewController::syncPanelVisibility(const bool trackPanelVisible,
         setActivePanel(bottomPanelType);
 }
 
+void EditorViewController::syncEditTargetVisibility(const EditorInteraction::Target target,
+                                                    const bool visible,
+                                                    const AppGlobal::PanelType fallbackPanel) {
+    if (!visible && m_activeEditTarget == target)
+        setActivePanel(fallbackPanel);
+}
+
 AppGlobal::PanelType EditorViewController::activePanel() const {
     return m_activePanel;
 }

--- a/src/app/Controller/EditorViewController.cpp
+++ b/src/app/Controller/EditorViewController.cpp
@@ -108,6 +108,13 @@ void EditorViewController::setActivePanel(AppGlobal::PanelType panel) {
     setActiveContext(panel, EditorInteraction::defaultTargetForPanel(panel));
 }
 
+void EditorViewController::activatePanelContext(const AppGlobal::PanelType panel) {
+    const auto target = panel == AppGlobal::ClipEditor
+                            ? m_lastClipEditTarget
+                            : EditorInteraction::defaultTargetForPanel(panel);
+    setActiveContext(panel, target);
+}
+
 void EditorViewController::syncPanelVisibility(const bool trackPanelVisible,
                                                const bool bottomPanelVisible,
                                                const AppGlobal::PanelType bottomPanelType) {
@@ -118,7 +125,7 @@ void EditorViewController::syncPanelVisibility(const bool trackPanelVisible,
         return;
     }
     if (!trackPanelVisible && m_activePanel != bottomPanelType)
-        setActivePanel(bottomPanelType);
+        activatePanelContext(bottomPanelType);
 }
 
 void EditorViewController::syncEditTargetVisibility(const EditorInteraction::Target target,
@@ -191,6 +198,11 @@ bool EditorViewController::eventFilter(QObject *watched, QEvent *event) {
 
 void EditorViewController::setActiveContext(const AppGlobal::PanelType panel,
                                             const EditorInteraction::Target target) {
+    if (panel == AppGlobal::ClipEditor &&
+        (target == EditorInteraction::Target::PianoRoll ||
+         target == EditorInteraction::Target::Parameters)) {
+        m_lastClipEditTarget = target;
+    }
     if (m_activePanel != panel) {
         m_activePanel = panel;
         for (const auto registeredPanel : std::as_const(m_panels))

--- a/src/app/Controller/EditorViewController.h
+++ b/src/app/Controller/EditorViewController.h
@@ -4,11 +4,13 @@
 #define editorViewController EditorViewController::instance()
 
 #include "Global/AppGlobal.h"
+#include "Interface/EditorInteraction.h"
 #include "Interface/EditorViewState.h"
 #include <lite/History/HistoryFocus.h>
 #include <lite/Core/Singleton.h>
 
 #include <QObject>
+#include <QPointer>
 #include <optional>
 
 class IEditorView;
@@ -48,14 +50,37 @@ public:
     void registerPanel(IPanel *panel);
     void unregisterPanel(IPanel *panel);
     void setActivePanel(AppGlobal::PanelType panel);
+    [[nodiscard]] AppGlobal::PanelType activePanel() const;
+
+    void registerInteractionArea(QObject *area, AppGlobal::PanelType panel,
+                                 EditorInteraction::Target target);
+    void updateInteractionArea(QObject *area, AppGlobal::PanelType panel,
+                               EditorInteraction::Target target);
+    void unregisterInteractionArea(QObject *area);
+    [[nodiscard]] EditorInteraction::Target activeEditTarget() const;
+    void requestEditCommand(EditorInteraction::Command command);
 
 signals:
     void activePanelChanged(AppGlobal::PanelType panel);
+    void activeEditTargetChanged(EditorInteraction::Target target);
+    void editCommandRequested(EditorInteraction::Target target, EditorInteraction::Command command);
 
 private:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+    void setActiveContext(AppGlobal::PanelType panel, EditorInteraction::Target target);
+    void setActiveEditTarget(EditorInteraction::Target target);
+
+    struct InteractionArea {
+        QPointer<QObject> object;
+        AppGlobal::PanelType panel = AppGlobal::Generic;
+        EditorInteraction::Target target = EditorInteraction::Target::None;
+    };
+
     IEditorView *m_view = nullptr;
     QList<IPanel *> m_panels;
+    QList<InteractionArea> m_interactionAreas;
     AppGlobal::PanelType m_activePanel = AppGlobal::TracksEditor;
+    EditorInteraction::Target m_activeEditTarget = EditorInteraction::Target::Tracks;
 };
 
 #endif // EDITORVIEWCONTROLLER_H

--- a/src/app/Controller/EditorViewController.h
+++ b/src/app/Controller/EditorViewController.h
@@ -50,6 +50,7 @@ public:
     void registerPanel(IPanel *panel);
     void unregisterPanel(IPanel *panel);
     void setActivePanel(AppGlobal::PanelType panel);
+    void activatePanelContext(AppGlobal::PanelType panel);
     void syncPanelVisibility(bool trackPanelVisible, bool bottomPanelVisible,
                              AppGlobal::PanelType bottomPanelType);
     void syncEditTargetVisibility(EditorInteraction::Target target, bool visible,
@@ -85,6 +86,7 @@ private:
     QList<InteractionArea> m_interactionAreas;
     AppGlobal::PanelType m_activePanel = AppGlobal::TracksEditor;
     EditorInteraction::Target m_activeEditTarget = EditorInteraction::Target::Tracks;
+    EditorInteraction::Target m_lastClipEditTarget = EditorInteraction::Target::PianoRoll;
 };
 
 #endif // EDITORVIEWCONTROLLER_H

--- a/src/app/Controller/EditorViewController.h
+++ b/src/app/Controller/EditorViewController.h
@@ -52,6 +52,8 @@ public:
     void setActivePanel(AppGlobal::PanelType panel);
     void syncPanelVisibility(bool trackPanelVisible, bool bottomPanelVisible,
                              AppGlobal::PanelType bottomPanelType);
+    void syncEditTargetVisibility(EditorInteraction::Target target, bool visible,
+                                  AppGlobal::PanelType fallbackPanel);
     [[nodiscard]] AppGlobal::PanelType activePanel() const;
 
     void registerInteractionArea(QObject *area, AppGlobal::PanelType panel,

--- a/src/app/Controller/EditorViewController.h
+++ b/src/app/Controller/EditorViewController.h
@@ -50,6 +50,8 @@ public:
     void registerPanel(IPanel *panel);
     void unregisterPanel(IPanel *panel);
     void setActivePanel(AppGlobal::PanelType panel);
+    void syncPanelVisibility(bool trackPanelVisible, bool bottomPanelVisible,
+                             AppGlobal::PanelType bottomPanelType);
     [[nodiscard]] AppGlobal::PanelType activePanel() const;
 
     void registerInteractionArea(QObject *area, AppGlobal::PanelType panel,

--- a/src/app/Interface/EditorInteraction.h
+++ b/src/app/Interface/EditorInteraction.h
@@ -9,6 +9,13 @@ namespace EditorInteraction {
 
     enum class Command { Cut, Copy, Paste, SelectAll, DeleteSelection };
 
+    [[nodiscard]] constexpr bool supportsCommand(const Target target,
+                                                 const Command command) noexcept {
+        if (target == Target::Parameters)
+            return command == Command::DeleteSelection;
+        return target == Target::Tracks || target == Target::PianoRoll;
+    }
+
     [[nodiscard]] constexpr Target
         defaultTargetForPanel(const AppGlobal::PanelType panel) noexcept {
         switch (panel) {

--- a/src/app/Interface/EditorInteraction.h
+++ b/src/app/Interface/EditorInteraction.h
@@ -1,0 +1,27 @@
+#ifndef EDITORINTERACTION_H
+#define EDITORINTERACTION_H
+
+#include "Global/AppGlobal.h"
+
+namespace EditorInteraction {
+
+    enum class Target { None, Tracks, PianoRoll, Parameters };
+
+    enum class Command { Cut, Copy, Paste, SelectAll, DeleteSelection };
+
+    [[nodiscard]] constexpr Target
+        defaultTargetForPanel(const AppGlobal::PanelType panel) noexcept {
+        switch (panel) {
+            case AppGlobal::TracksEditor:
+                return Target::Tracks;
+            case AppGlobal::ClipEditor:
+                return Target::PianoRoll;
+            case AppGlobal::Generic:
+                return Target::None;
+        }
+        return Target::None;
+    }
+
+} // namespace EditorInteraction
+
+#endif // EDITORINTERACTION_H

--- a/src/app/UI/Views/BottomPanelView.cpp
+++ b/src/app/UI/Views/BottomPanelView.cpp
@@ -2,6 +2,7 @@
 
 #include "Controller/EditorViewController.h"
 #include "UI/Views/ClipEditor/ClipEditorView.h"
+#include "UI/Views/Common/TabPanelTitleBar.h"
 #include "UI/Views/MixConsole/MixConsoleView.h"
 
 BottomPanelView::BottomPanelView(QWidget *parent) : TabPanelView(AppGlobal::ClipEditor, parent) {
@@ -11,19 +12,19 @@ BottomPanelView::BottomPanelView(QWidget *parent) : TabPanelView(AppGlobal::Clip
 
     setPanelType(currentPagePanelType());
     editorViewController->registerInteractionArea(
-        this, panelType(), EditorInteraction::defaultTargetForPanel(panelType()));
+        titleBar(), panelType(), EditorInteraction::defaultTargetForPanel(panelType()));
     connect(this, &TabPanelView::currentPageChanged, this,
             [this](const QString &, const AppGlobal::PanelType panelType) {
                 setPanelType(panelType);
                 editorViewController->updateInteractionArea(
-                    this, panelType, EditorInteraction::defaultTargetForPanel(panelType));
+                    titleBar(), panelType, EditorInteraction::defaultTargetForPanel(panelType));
                 editorViewController->setActivePanel(panelType);
             });
     editorViewController->registerPanel(this);
 }
 
 BottomPanelView::~BottomPanelView() {
-    editorViewController->unregisterInteractionArea(this);
+    editorViewController->unregisterInteractionArea(titleBar());
     editorViewController->unregisterPanel(this);
 }
 

--- a/src/app/UI/Views/BottomPanelView.cpp
+++ b/src/app/UI/Views/BottomPanelView.cpp
@@ -10,15 +10,20 @@ BottomPanelView::BottomPanelView(QWidget *parent) : TabPanelView(AppGlobal::Clip
     registerPage(new MixConsoleView);
 
     setPanelType(currentPagePanelType());
+    editorViewController->registerInteractionArea(
+        this, panelType(), EditorInteraction::defaultTargetForPanel(panelType()));
     connect(this, &TabPanelView::currentPageChanged, this,
             [this](const QString &, const AppGlobal::PanelType panelType) {
                 setPanelType(panelType);
+                editorViewController->updateInteractionArea(
+                    this, panelType, EditorInteraction::defaultTargetForPanel(panelType));
                 editorViewController->setActivePanel(panelType);
             });
     editorViewController->registerPanel(this);
 }
 
 BottomPanelView::~BottomPanelView() {
+    editorViewController->unregisterInteractionArea(this);
     editorViewController->unregisterPanel(this);
 }
 

--- a/src/app/UI/Views/ClipEditor/ClipEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/ClipEditorView.cpp
@@ -15,7 +15,6 @@
 
 #include <QLabel>
 #include <QEvent>
-#include <QMouseEvent>
 #include <QRectF>
 #include <QVBoxLayout>
 
@@ -66,8 +65,6 @@ ClipEditorView::ClipEditorView(QWidget *parent) : TabPanelPage(parent) {
     mainLayout->setSpacing(0);
     mainLayout->setContentsMargins({1, 0, 1, 1});
     setLayout(mainLayout);
-
-    installEventFilter(this);
 
     connect(m_toolbarView, &ClipEditorToolBarView::editModeChanged,
             m_pianoRollEditorView->pianoRollView(), &PianoRollView::onEditModeChanged);
@@ -163,12 +160,6 @@ void ClipEditorView::onActiveClipChanged(const int clipId) {
     if (hadActiveClip != m_hasActiveClip) {
         emit toolBarVisibilityChanged();
     }
-}
-
-bool ClipEditorView::eventFilter(QObject *watched, QEvent *event) {
-    if (event->type() == QMouseEvent::MouseButtonPress)
-        editorViewController->setActivePanel(AppGlobal::ClipEditor);
-    return QWidget::eventFilter(watched, event);
 }
 
 void ClipEditorView::moveToSingingClipState(SingingClip *clip) const {

--- a/src/app/UI/Views/ClipEditor/ClipEditorView.h
+++ b/src/app/UI/Views/ClipEditor/ClipEditorView.h
@@ -48,7 +48,6 @@ public slots:
 
 private:
     void changeEvent(QEvent *event) override;
-    bool eventFilter(QObject *watched, QEvent *event) override;
     void moveToSingingClipState(SingingClip *clip) const;
     void moveToAudioClipState(const AudioClip *clip) const;
     void moveToNullClipState() const;

--- a/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorGraphicsView.cpp
@@ -404,7 +404,7 @@ bool ParamEditorGraphicsView::event(QEvent *event) {
                 return true;
             }
             if (key == Qt::Key_Delete) {
-                m_anchorController.deleteSelectedNodes();
+                deleteSelection();
                 event->accept();
                 return true;
             }
@@ -420,6 +420,14 @@ bool ParamEditorGraphicsView::event(QEvent *event) {
         }
     }
     return TimeGraphicsView::event(event);
+}
+
+void ParamEditorGraphicsView::deleteSelection() {
+    if (m_speakerMixMode) {
+        m_speakerMixView->deleteSelection();
+    } else if (m_editMode == ParamEditorEditMode::Anchor) {
+        m_anchorController.deleteSelectedNodes();
+    }
 }
 
 void ParamEditorGraphicsView::onEdgeAutoScrollFrame(const QPoint &clampedViewportPos,

--- a/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorGraphicsView.h
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorGraphicsView.h
@@ -54,6 +54,7 @@ public:
     void setBackgroundBaseCurveVisible(bool visible);
 
 public slots:
+    void deleteSelection();
     void setForeground(ParamInfo::Name name, const ParamProperties &properties);
     void setBackground(ParamInfo::Name name, const ParamProperties &properties);
     void updateForeground(Param::Type type, const Param &param);

--- a/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.cpp
@@ -23,6 +23,7 @@
 #include <QEvent>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QResizeEvent>
 #include <QVBoxLayout>
 
 using namespace SpeakerMixModel;
@@ -158,6 +159,13 @@ void ParamEditorView::changeEvent(QEvent *event) {
         refreshSpeakerMixToolBar();
         refreshParameterSupportState();
     }
+}
+
+void ParamEditorView::resizeEvent(QResizeEvent *event) {
+    QWidget::resizeEvent(event);
+    editorViewController->syncEditTargetVisibility(
+        EditorInteraction::Target::Parameters, event->size().height() > 0,
+        AppGlobal::ClipEditor);
 }
 
 void ParamEditorView::onForegroundChanged(const ParamInfo::Name name) {

--- a/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.cpp
@@ -8,6 +8,7 @@
 #include <lite/GUI/Controls/Button.h>
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
 
+#include "Controller/EditorViewController.h"
 #include "Controller/Actions/AppModel/SpeakerMix/SpeakerMixActions.h"
 #include <lite/ProjectModel/AppModel/AppModel.h>
 #include <lite/ProjectModel/AppModel/SingingClip.h>
@@ -27,6 +28,8 @@
 using namespace SpeakerMixModel;
 
 ParamEditorView::ParamEditorView(QWidget *parent) : QWidget(parent) {
+    editorViewController->registerInteractionArea(this, AppGlobal::ClipEditor,
+                                                  EditorInteraction::Target::Parameters);
     const auto option = appOptions->general();
     const auto foregroundParam = option->defaultForegroundParam;
     const auto backgroundParam = option->defaultBackgroundParam;
@@ -105,6 +108,12 @@ ParamEditorView::ParamEditorView(QWidget *parent) : QWidget(parent) {
             &ParamEditorView::onStopDynamicMix);
     connect(m_emptyStateActionButton, &Button::clicked, this,
             &ParamEditorView::onEmptyStateAction);
+    connect(
+        editorViewController, &EditorViewController::editCommandRequested, this,
+        [this](const EditorInteraction::Target target, const EditorInteraction::Command command) {
+            if (target == EditorInteraction::Target::Parameters)
+                executeEditCommand(command);
+        });
 
     auto *mixView = m_graphicsView->speakerMixView();
     connect(mixView, &SpeakerMixEditorView::speakerMixEdited, this,
@@ -113,6 +122,15 @@ ParamEditorView::ParamEditorView(QWidget *parent) : QWidget(parent) {
         m_unsupportedParameterPromptState.resetForProject();
         hideEmptyState();
     });
+}
+
+ParamEditorView::~ParamEditorView() {
+    editorViewController->unregisterInteractionArea(this);
+}
+
+void ParamEditorView::executeEditCommand(const EditorInteraction::Command command) const {
+    if (command == EditorInteraction::Command::DeleteSelection)
+        m_graphicsView->deleteSelection();
 }
 
 void ParamEditorView::setDataContext(SingingClip *clip) {

--- a/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.h
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.h
@@ -4,6 +4,7 @@
 #include <lite/ProjectModel/AppModel/ParamProperties.h>
 #include <lite/ProjectModel/AppModel/Params.h>
 #include <lite/ProjectModel/AppModel/SpeakerMixData.h>
+#include "Interface/EditorInteraction.h"
 #include "UnsupportedParameterPromptState.h"
 
 #include <QWidget>
@@ -23,6 +24,7 @@ class ParamEditorView final : public QWidget {
 
 public:
     explicit ParamEditorView(QWidget *parent = nullptr);
+    ~ParamEditorView() override;
     void setDataContext(SingingClip *clip);
     [[nodiscard]] ParamEditorGraphicsView *graphicsView() const;
 
@@ -61,6 +63,7 @@ private:
         dataWithDynamicEnabled(const SpeakerMixModel::SpeakerMixData &data);
     static SpeakerMixModel::SpeakerMixData
         dataWithDynamicStopped(const SpeakerMixModel::SpeakerMixData &data);
+    void executeEditCommand(EditorInteraction::Command command) const;
 
     SingingClip *m_clip = nullptr;
     ParamEditorGraphicsView *m_graphicsView;

--- a/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.h
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.h
@@ -17,6 +17,7 @@ class ParamEditorGraphicsView;
 class ParamEditorToolBarView;
 class Button;
 class QLabel;
+class QResizeEvent;
 class QVBoxLayout;
 
 class ParamEditorView final : public QWidget {
@@ -34,6 +35,7 @@ public slots:
 
 protected:
     void changeEvent(QEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
 private slots:
     void onPreviousKeyframe() const;

--- a/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.cpp
@@ -333,11 +333,7 @@ void SpeakerMixEditorView::keyPressEvent(QKeyEvent *event) {
     }
 
     if (event->key() == Qt::Key_Delete) {
-        const auto before = workingMixData();
-        deleteSelectedKeyframe();
-        if (workingMixData() != before)
-            commit();
-        update();
+        deleteSelection();
         event->accept();
         return;
     }
@@ -374,16 +370,20 @@ void SpeakerMixEditorView::contextMenuEvent(QGraphicsSceneContextMenuEvent *even
 
     auto *deleteAction = menu->addAction(tr("Delete"));
     deleteAction->setEnabled(!isInitial);
-    connect(deleteAction, &QAction::triggered, this, [this] {
-        const auto before = workingMixData();
-        deleteSelectedKeyframe();
-        if (workingMixData() != before)
-            commit();
-        update();
-    });
+    connect(deleteAction, &QAction::triggered, this, &SpeakerMixEditorView::deleteSelection);
 
     menu->exec(event->screenPos());
     menu->deleteLater();
+}
+
+void SpeakerMixEditorView::deleteSelection() {
+    if (!m_editable)
+        return;
+    const auto before = workingMixData();
+    deleteSelectedKeyframe();
+    if (workingMixData() != before)
+        commit();
+    update();
 }
 
 QList<double> SpeakerMixEditorView::interpolateWeights(const double tick) const {

--- a/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.h
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.h
@@ -47,6 +47,7 @@ public:
 
     void commit();
     void discard();
+    void deleteSelection();
 
     const QList<SpeakerMixSpeaker> &speakers() const;
     const QList<SpeakerMixKeyframe> &keyframes() const;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
@@ -7,11 +7,11 @@
 #include "PianoRollRhiWidget.h"
 #include "PhonemeView.h"
 #include "Controller/ClipController.h"
+#include "Controller/EditorViewController.h"
 #include "Model/AppOptions/AppOptions.h"
 #include "Model/AppStatus/AppStatus.h"
 #include "UI/Views/Common/TimeGraphicsView.h"
 #include "UI/Views/Common/TimelineView.h"
-#include "UI/Views/Common/EditorShortcutUtils.h"
 
 #include <QLabel>
 #include <QEvent>
@@ -104,7 +104,12 @@ PianoRollView::PianoRollView(QWidget *parent) : QWidget(parent) {
         connectRhiBackend();
     else
         connectLegacyBackend();
-    registerEditorShortcuts();
+    connect(
+        editorViewController, &EditorViewController::editCommandRequested, this,
+        [this](const EditorInteraction::Target target, const EditorInteraction::Command command) {
+            if (target == EditorInteraction::Target::PianoRoll)
+                executeEditCommand(command);
+        });
     // 底部面板折叠（docked 模式为 splitter 高度归零，不触发 hideEvent）时
     // 使轨道侧叠加层失效；展开且本视图可见时恢复
     connect(appStatus, &AppStatus::bottomPanelCollapseStateChanged, this,
@@ -116,28 +121,31 @@ PianoRollView::PianoRollView(QWidget *parent) : QWidget(parent) {
             });
 }
 
-void PianoRollView::registerEditorShortcuts() {
-    using EditorShortcutUtils::add;
-    add(this, QKeySequence::Cut, m_contextMenuController,
-        &PianoRollContextMenuController::cutSelection);
-    add(this, QKeySequence::Copy, m_contextMenuController,
-        &PianoRollContextMenuController::copySelection);
-    add(this, QKeySequence::Paste, m_contextMenuController,
-        &PianoRollContextMenuController::pasteSelection);
-    add(this, QKeySequence::SelectAll, m_contextMenuController,
-        &PianoRollContextMenuController::selectAll);
-    const auto remove = [this] {
-        if (m_editMode == EditPitchAnchor) {
-            if (m_rhiView)
-                m_rhiView->deleteSelectedAnchors();
-            else if (m_graphicsView)
-                m_graphicsView->deleteSelectedAnchors();
-        } else {
-            m_contextMenuController->deleteSelection();
-        }
-    };
-    add(this, QKeySequence::Delete, this, remove);
-    add(this, QKeySequence(Qt::Key_Backspace), this, remove);
+void PianoRollView::executeEditCommand(const EditorInteraction::Command command) const {
+    switch (command) {
+        case EditorInteraction::Command::Cut:
+            m_contextMenuController->cutSelection();
+            break;
+        case EditorInteraction::Command::Copy:
+            m_contextMenuController->copySelection();
+            break;
+        case EditorInteraction::Command::Paste:
+            m_contextMenuController->pasteSelection();
+            break;
+        case EditorInteraction::Command::SelectAll:
+            m_contextMenuController->selectAll();
+            break;
+        case EditorInteraction::Command::DeleteSelection:
+            if (m_editMode == EditPitchAnchor) {
+                if (m_rhiView)
+                    m_rhiView->deleteSelectedAnchors();
+                else if (m_graphicsView)
+                    m_graphicsView->deleteSelectedAnchors();
+            } else {
+                m_contextMenuController->deleteSelection();
+            }
+            break;
+    }
 }
 
 void PianoRollView::createLegacyBackend() {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
@@ -26,6 +26,8 @@
 PianoRollView::PianoRollView(QWidget *parent) : QWidget(parent) {
     setAttribute(Qt::WA_StyledBackground);
     setMinimumHeight(128);
+    editorViewController->registerInteractionArea(this, AppGlobal::ClipEditor,
+                                                  EditorInteraction::Target::PianoRoll);
     m_contextMenuController = new PianoRollContextMenuController(this);
 
     const auto useRhi = appOptions->developer()->editorRenderBackend ==
@@ -119,6 +121,10 @@ PianoRollView::PianoRollView(QWidget *parent) : QWidget(parent) {
                 else if (isVisible())
                     updatePianoRollVisibleRect();
             });
+}
+
+PianoRollView::~PianoRollView() {
+    editorViewController->unregisterInteractionArea(this);
 }
 
 void PianoRollView::executeEditCommand(const EditorInteraction::Command command) const {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.h
@@ -2,6 +2,7 @@
 #define PIANOROLLVIEW_H
 
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
+#include "Interface/EditorInteraction.h"
 #include "Interface/EditorViewState.h"
 
 #include <lite/History/HistoryFocus.h>
@@ -59,7 +60,7 @@ private:
     void connectLegacyBackend();
     void connectRhiBackend();
     void fallbackToLegacy();
-    void registerEditorShortcuts();
+    void executeEditCommand(EditorInteraction::Command command) const;
     void updateAutoPageTurnButtonView(bool available);
     void updatePianoRollVisibleRect() const;
     [[nodiscard]] double startTick() const;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.h
@@ -28,6 +28,7 @@ class PianoRollView final : public QWidget {
 
 public:
     explicit PianoRollView(QWidget *parent = nullptr);
+    ~PianoRollView() override;
     void setDataContext(SingingClip *clip) const;
     void setTrackColorIndex(int index) const;
     [[nodiscard]] PianoRollViewState viewState() const;

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
@@ -1,6 +1,5 @@
 #include "PianoRollEditorView.h"
 
-#include "Controller/EditorViewController.h"
 #include "Controller/PlaybackController.h"
 #include "ParamEditor/ParamEditorGraphicsView.h"
 #include "ParamEditor/ParamEditorView.h"
@@ -15,8 +14,6 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
     m_paramEditorView = new ParamEditorView;
     addWidget(m_pianoRollView);
     addWidget(m_paramEditorView);
-    editorViewController->registerInteractionArea(m_paramEditorView, AppGlobal::ClipEditor,
-                                                  EditorInteraction::Target::Parameters);
 
     setCollapsible(0, false);
     // 让参数面板在剪辑编辑器调整高度时尽量保持高度不变，优先调整钢琴卷帘区域的高度
@@ -50,10 +47,6 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
             &PianoRollView::onWheelHorScale);
     connect(paramGraphicsView, &ParamEditorGraphicsView::wheelHorScroll, m_pianoRollView,
             &PianoRollView::onWheelHorScroll);
-}
-
-PianoRollEditorView::~PianoRollEditorView() {
-    editorViewController->unregisterInteractionArea(m_paramEditorView);
 }
 
 PianoRollView *PianoRollEditorView::pianoRollView() const {

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.cpp
@@ -1,5 +1,6 @@
 #include "PianoRollEditorView.h"
 
+#include "Controller/EditorViewController.h"
 #include "Controller/PlaybackController.h"
 #include "ParamEditor/ParamEditorGraphicsView.h"
 #include "ParamEditor/ParamEditorView.h"
@@ -14,6 +15,8 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
     m_paramEditorView = new ParamEditorView;
     addWidget(m_pianoRollView);
     addWidget(m_paramEditorView);
+    editorViewController->registerInteractionArea(m_paramEditorView, AppGlobal::ClipEditor,
+                                                  EditorInteraction::Target::Parameters);
 
     setCollapsible(0, false);
     // 让参数面板在剪辑编辑器调整高度时尽量保持高度不变，优先调整钢琴卷帘区域的高度
@@ -47,6 +50,10 @@ PianoRollEditorView::PianoRollEditorView(QWidget *parent) : OverlaySplitter(Qt::
             &PianoRollView::onWheelHorScale);
     connect(paramGraphicsView, &ParamEditorGraphicsView::wheelHorScroll, m_pianoRollView,
             &PianoRollView::onWheelHorScroll);
+}
+
+PianoRollEditorView::~PianoRollEditorView() {
+    editorViewController->unregisterInteractionArea(m_paramEditorView);
 }
 
 PianoRollView *PianoRollEditorView::pianoRollView() const {

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.h
@@ -12,7 +12,6 @@ class PianoRollEditorView : public OverlaySplitter {
     Q_OBJECT
 public:
     explicit PianoRollEditorView(QWidget *parent = nullptr);
-    ~PianoRollEditorView() override;
     [[nodiscard]] PianoRollView *pianoRollView() const;
     [[nodiscard]] ParamEditorView *paramEditorView() const;
     void setDataContext(SingingClip *clip) const;

--- a/src/app/UI/Views/ClipEditor/PianoRollEditorView.h
+++ b/src/app/UI/Views/ClipEditor/PianoRollEditorView.h
@@ -12,6 +12,7 @@ class PianoRollEditorView : public OverlaySplitter {
     Q_OBJECT
 public:
     explicit PianoRollEditorView(QWidget *parent = nullptr);
+    ~PianoRollEditorView() override;
     [[nodiscard]] PianoRollView *pianoRollView() const;
     [[nodiscard]] ParamEditorView *paramEditorView() const;
     void setDataContext(SingingClip *clip) const;

--- a/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
@@ -663,8 +663,7 @@ void MainMenuViewPrivate::initEditShortcuts() {
             q, key, isEditorWindow, editorViewController,
             [command] { editorViewController->requestEditCommand(command); });
         const auto updateEnabled = [shortcut](const EditorInteraction::Target target) {
-            shortcut->setEnabled(target == EditorInteraction::Target::Tracks ||
-                                 target == EditorInteraction::Target::PianoRoll);
+            shortcut->setEnabled(target != EditorInteraction::Target::None);
         };
         QObject::connect(editorViewController, &EditorViewController::activeEditTargetChanged,
                          shortcut, updateEnabled);

--- a/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
@@ -278,12 +278,16 @@ void MainMenuViewPrivate::onActiveEditTargetChanged(const EditorInteraction::Tar
         exitClipEditorState();
     else if (m_editTarget == EditorInteraction::Target::Tracks)
         exitTracksEditorState();
+    else if (m_editTarget == EditorInteraction::Target::Parameters)
+        exitParametersEditorState();
 
     m_editTarget = target;
     if (target == EditorInteraction::Target::PianoRoll)
         enterClipEditorState();
     else if (target == EditorInteraction::Target::Tracks)
         enterTracksEditorState();
+    else if (target == EditorInteraction::Target::Parameters)
+        enterParametersEditorState();
 }
 
 void MainMenuViewPrivate::onSelectAll() {
@@ -479,6 +483,26 @@ void MainMenuViewPrivate::exitTracksEditorState() {
     actionSelectAll->setEnabled(false);
 }
 
+void MainMenuViewPrivate::enterParametersEditorState() {
+    using EditorInteraction::Command;
+    using EditorInteraction::Target;
+    actionCut->setEnabled(EditorInteraction::supportsCommand(Target::Parameters, Command::Cut));
+    actionCopy->setEnabled(EditorInteraction::supportsCommand(Target::Parameters, Command::Copy));
+    actionPaste->setEnabled(EditorInteraction::supportsCommand(Target::Parameters, Command::Paste));
+    actionSelectAll->setEnabled(
+        EditorInteraction::supportsCommand(Target::Parameters, Command::SelectAll));
+    actionDelete->setEnabled(
+        EditorInteraction::supportsCommand(Target::Parameters, Command::DeleteSelection));
+}
+
+void MainMenuViewPrivate::exitParametersEditorState() {
+    actionCut->setEnabled(false);
+    actionCopy->setEnabled(false);
+    actionPaste->setEnabled(false);
+    actionSelectAll->setEnabled(false);
+    actionDelete->setEnabled(false);
+}
+
 void MainMenuViewPrivate::updatePasteActionState() {
     const auto mimeData = QGuiApplication::clipboard()->mimeData();
     if (!mimeData) {
@@ -662,8 +686,8 @@ void MainMenuViewPrivate::initEditShortcuts() {
         auto *shortcut = EditorShortcutUtils::addApplication(
             q, key, isEditorWindow, editorViewController,
             [command] { editorViewController->requestEditCommand(command); });
-        const auto updateEnabled = [shortcut](const EditorInteraction::Target target) {
-            shortcut->setEnabled(target != EditorInteraction::Target::None);
+        const auto updateEnabled = [shortcut, command](const EditorInteraction::Target target) {
+            shortcut->setEnabled(EditorInteraction::supportsCommand(target, command));
         };
         QObject::connect(editorViewController, &EditorViewController::activeEditTargetChanged,
                          shortcut, updateEnabled);

--- a/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
@@ -7,9 +7,7 @@
 #include "Modules/Import/DocumentImportController.h"
 #include "Modules/ProjectFormats/IProjectFormatHandler.h"
 #include "Modules/ProjectFormats/ProjectFormatRegistry.h"
-#include "Controller/ClipboardController.h"
 #include "Controller/ClipController.h"
-#include "Controller/TrackController.h"
 #include "Global/ControllerGlobal.h"
 #include <lite/ProjectModel/AppModel/AppModel.h>
 #include <lite/ProjectModel/AppModel/AudioClip.h>
@@ -20,6 +18,7 @@
 #include <QDialog>
 #include <QGuiApplication>
 #include <QMimeData>
+#include <QShortcut>
 #include "Modules/Extractors/MidiExtractController.h"
 #include "Modules/Extractors/PitchExtractController.h"
 #include <lite/History/HistoryManager.h>
@@ -33,6 +32,8 @@
 #include "UI/Dialogs/PackageManager/PackageManagerDialog.h"
 #include <lite/GUI/Utils/IconUtils.h>
 #include "UI/Dialogs/Help/AboutDialog.h"
+#include "UI/Views/BottomPanelView.h"
+#include "UI/Views/Common/EditorShortcutUtils.h"
 #include "Utils/AppLogDirectory.h"
 
 #include <QFile>
@@ -51,13 +52,14 @@ MainMenuView::MainMenuView(MainWindow *mainWindow)
 
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
-    connect(editorViewController, &EditorViewController::activePanelChanged, this,
-            [=](AppGlobal::PanelType panel) { d->onActivatedPanelChanged(panel); });
+    connect(editorViewController, &EditorViewController::activeEditTargetChanged, this,
+            [=](const EditorInteraction::Target target) { d->onActiveEditTargetChanged(target); });
 
     connect(QGuiApplication::clipboard(), &QClipboard::dataChanged, this,
             [this] { d_ptr->updatePasteActionState(); });
 
     d->initActions();
+    d->onActiveEditTargetChanged(editorViewController->activeEditTarget());
     connect(documentWorkflowController, &DocumentWorkflowController::busyChanged, this,
             [d](const bool busy) {
                 d->actionNew->setEnabled(!busy);
@@ -268,58 +270,40 @@ void MainMenuViewPrivate::onUndoRedoChanged(bool canUndo, const QString &undoNam
     actionRedo->setText(tr("&Redo") + " " + redoName);
 }
 
-void MainMenuViewPrivate::onActivatedPanelChanged(AppGlobal::PanelType panel) {
-    Q_Q(MainMenuView);
-    m_panelType = panel;
-    if (panel == AppGlobal::ClipEditor) {
+void MainMenuViewPrivate::onActiveEditTargetChanged(const EditorInteraction::Target target) {
+    if (m_editTarget == target)
+        return;
+
+    if (m_editTarget == EditorInteraction::Target::PianoRoll)
+        exitClipEditorState();
+    else if (m_editTarget == EditorInteraction::Target::Tracks)
         exitTracksEditorState();
+
+    m_editTarget = target;
+    if (target == EditorInteraction::Target::PianoRoll)
         enterClipEditorState();
-    } else if (panel == AppGlobal::TracksEditor) {
-        exitClipEditorState();
+    else if (target == EditorInteraction::Target::Tracks)
         enterTracksEditorState();
-    } else {
-        exitClipEditorState();
-        exitTracksEditorState();
-    }
 }
 
 void MainMenuViewPrivate::onSelectAll() {
-    Q_Q(MainMenuView);
-    qDebug() << "MainMenuView::onSelectAll";
-    if (m_panelType == AppGlobal::ClipEditor)
-        clipController->onSelectAllNotes();
-    else if (m_panelType == AppGlobal::TracksEditor)
-        qDebug() << "MainMenuView::onSelectAll: not implemented for TracksEditor";
+    editorViewController->requestEditCommand(EditorInteraction::Command::SelectAll);
 }
 
 void MainMenuViewPrivate::onDelete() {
-    Q_Q(MainMenuView);
-    qDebug() << "MainMenuView::onDelete";
-    if (m_panelType == AppGlobal::ClipEditor)
-        clipController->onDeleteSelectedNotes();
-    else if (m_panelType == AppGlobal::TracksEditor)
-        trackController->onRemoveClips(appStatus->selectedClips.get());
+    editorViewController->requestEditCommand(EditorInteraction::Command::DeleteSelection);
 }
 
 void MainMenuViewPrivate::onCut() {
-    if (m_panelType == AppGlobal::ClipEditor)
-        clipboardController->cut();
-    else if (m_panelType == AppGlobal::TracksEditor)
-        trackController->cutSelectedClips();
+    editorViewController->requestEditCommand(EditorInteraction::Command::Cut);
 }
 
 void MainMenuViewPrivate::onCopy() {
-    if (m_panelType == AppGlobal::ClipEditor)
-        clipboardController->copy();
-    else if (m_panelType == AppGlobal::TracksEditor)
-        trackController->copySelectedClips();
+    editorViewController->requestEditCommand(EditorInteraction::Command::Copy);
 }
 
 void MainMenuViewPrivate::onPaste() {
-    if (m_panelType == AppGlobal::ClipEditor)
-        clipboardController->paste();
-    else if (m_panelType == AppGlobal::TracksEditor)
-        clipboardController->paste();
+    editorViewController->requestEditCommand(EditorInteraction::Command::Paste);
 }
 
 void MainMenuViewPrivate::onExtractPitchParam() {
@@ -471,12 +455,13 @@ void MainMenuViewPrivate::enterTracksEditorState() {
     updatePasteActionState();
     actionSelectAll->setEnabled(true);
 
-    connect(appStatus, &AppStatus::clipSelectionChanged, q, [this](const QList<int> &clips) {
-        const auto hasSelection = !clips.isEmpty();
-        actionCut->setEnabled(hasSelection);
-        actionCopy->setEnabled(hasSelection);
-        actionDelete->setEnabled(hasSelection);
-    });
+    m_clipSelectionConnection =
+        connect(appStatus, &AppStatus::clipSelectionChanged, q, [this](const QList<int> &clips) {
+            const auto hasSelection = !clips.isEmpty();
+            actionCut->setEnabled(hasSelection);
+            actionCopy->setEnabled(hasSelection);
+            actionDelete->setEnabled(hasSelection);
+        });
 
     actionOctaveUp->setEnabled(false);
     actionOctaveDown->setEnabled(false);
@@ -484,7 +469,8 @@ void MainMenuViewPrivate::enterTracksEditorState() {
 }
 
 void MainMenuViewPrivate::exitTracksEditorState() {
-    disconnect(appStatus, &AppStatus::clipSelectionChanged, nullptr, nullptr);
+    disconnect(m_clipSelectionConnection);
+    m_clipSelectionConnection = {};
 
     actionCut->setEnabled(false);
     actionCopy->setEnabled(false);
@@ -499,10 +485,10 @@ void MainMenuViewPrivate::updatePasteActionState() {
         actionPaste->setEnabled(false);
         return;
     }
-    if (m_panelType == AppGlobal::ClipEditor)
+    if (m_editTarget == EditorInteraction::Target::PianoRoll)
         actionPaste->setEnabled(mimeData->hasFormat(
             ControllerGlobal::ElemMimeType.at(ControllerGlobal::NoteWithParams)));
-    else if (m_panelType == AppGlobal::TracksEditor)
+    else if (m_editTarget == EditorInteraction::Target::Tracks)
         actionPaste->setEnabled(
             mimeData->hasFormat(ControllerGlobal::ElemMimeType.at(ControllerGlobal::Clip)));
     else
@@ -512,6 +498,7 @@ void MainMenuViewPrivate::updatePasteActionState() {
 void MainMenuViewPrivate::initActions() {
     initFileActions();
     initEditActions();
+    initEditShortcuts();
 }
 
 void MainMenuViewPrivate::initFileActions() {
@@ -662,6 +649,34 @@ void MainMenuViewPrivate::initEditActions() {
     actionQuantize->setShortcutContext(Qt::WidgetShortcut);
     actionQuantize->setEnabled(false);
     connect(actionQuantize, &QAction::triggered, this, [this] { onQuantize(); });
+}
+
+void MainMenuViewPrivate::initEditShortcuts() {
+    Q_Q(MainMenuView);
+    const auto isEditorWindow = [](const QWidget *window) {
+        return qobject_cast<const MainWindow *>(window) ||
+               qobject_cast<const BottomPanelView *>(window);
+    };
+    const auto addShortcut = [q, isEditorWindow](const QKeySequence &key,
+                                                 const EditorInteraction::Command command) {
+        auto *shortcut = EditorShortcutUtils::addApplication(
+            q, key, isEditorWindow, editorViewController,
+            [command] { editorViewController->requestEditCommand(command); });
+        const auto updateEnabled = [shortcut](const EditorInteraction::Target target) {
+            shortcut->setEnabled(target == EditorInteraction::Target::Tracks ||
+                                 target == EditorInteraction::Target::PianoRoll);
+        };
+        QObject::connect(editorViewController, &EditorViewController::activeEditTargetChanged,
+                         shortcut, updateEnabled);
+        updateEnabled(editorViewController->activeEditTarget());
+    };
+
+    addShortcut(QKeySequence::Cut, EditorInteraction::Command::Cut);
+    addShortcut(QKeySequence::Copy, EditorInteraction::Command::Copy);
+    addShortcut(QKeySequence::Paste, EditorInteraction::Command::Paste);
+    addShortcut(QKeySequence::SelectAll, EditorInteraction::Command::SelectAll);
+    addShortcut(QKeySequence::Delete, EditorInteraction::Command::DeleteSelection);
+    addShortcut(QKeySequence(Qt::Key_Backspace), EditorInteraction::Command::DeleteSelection);
 }
 
 Menu *MainMenuViewPrivate::buildFileMenu() {

--- a/src/app/UI/Views/MainTitleBar/MainMenuView_p.h
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView_p.h
@@ -2,6 +2,7 @@
 #define MAINMENUVIEW_P_H
 
 #include "Global/AppGlobal.h"
+#include "Interface/EditorInteraction.h"
 
 #include <QColor>
 #include <QHash>
@@ -84,7 +85,8 @@ public:
     QString m_undoName;
     QString m_redoName;
 
-    AppGlobal::PanelType m_panelType = AppGlobal::Generic;
+    EditorInteraction::Target m_editTarget = EditorInteraction::Target::None;
+    QMetaObject::Connection m_clipSelectionConnection;
 
     void onNew() const;
     void onOpen();
@@ -100,7 +102,7 @@ public:
     void onUndoRedoChanged(bool canUndo, const QString &undoName, bool canRedo,
                            const QString &redoName);
 
-    void onActivatedPanelChanged(AppGlobal::PanelType panel);
+    void onActiveEditTargetChanged(EditorInteraction::Target target);
     void onSelectAll();
     void onDelete();
     void onCut();
@@ -121,6 +123,7 @@ public:
     void initActions();
     void initFileActions();
     void initEditActions();
+    void initEditShortcuts();
 
     Menu *buildFileMenu();
     Menu *buildEditMenu();

--- a/src/app/UI/Views/MainTitleBar/MainMenuView_p.h
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView_p.h
@@ -118,6 +118,8 @@ public:
     void exitClipEditorState();
     void enterTracksEditorState();
     void exitTracksEditorState();
+    void enterParametersEditorState();
+    void exitParametersEditorState();
     void updatePasteActionState();
 
     void initActions();

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
@@ -242,6 +242,8 @@ void TrackEditorView::connectLegacyBackend() {
             &TrackEditorBackgroundView::onTrackCountChanged);
     connect(appStatus, &AppStatus::selectedTrackIndexChanged, m_gridItem,
             &TrackEditorBackgroundView::onTrackSelectionChanged);
+    connect(appStatus, &AppStatus::clipSelectionChanged, m_graphicsView,
+            &TracksGraphicsView::setClipSelection);
     connect(m_graphicsView, &TimeGraphicsView::timeRangeChanged, m_timeline,
             &TimelineView::setTimeRange);
     connect(m_graphicsView, &TimeGraphicsView::timeRangeChanged, m_tempoLane,
@@ -296,6 +298,7 @@ void TrackEditorView::connectLegacyBackend() {
     connect(m_graphicsView, &TracksGraphicsView::externalDropRequested, this,
             &TrackEditorView::handleExternalDrop);
     m_graphicsView->setAutoTurnPage(appStatus->trackAutoPageTurnEnabled);
+    m_graphicsView->setClipSelection(appStatus->selectedClips.get());
 }
 
 void TrackEditorView::connectRhiBackend() {
@@ -399,6 +402,7 @@ void TrackEditorView::populateLegacyClipItems() {
         for (auto *clip : trackViewModel->dsTrack->clips())
             onClipInserted(clip, trackViewModel, trackIndex);
     }
+    m_graphicsView->setClipSelection(appStatus->selectedClips.get());
 }
 
 double TrackEditorView::activeScaleY() const {
@@ -564,6 +568,8 @@ void TrackEditorView::onModelChanged() {
         onTrackInserted(track, index);
         index++;
     }
+    if (m_graphicsView)
+        m_graphicsView->setClipSelection(appStatus->selectedClips.get());
     emit trackCountChanged(m_viewModel.tracks.count());
 }
 

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.cpp
@@ -30,11 +30,9 @@
 #include "AppContext.h"
 #include "UI/Utils/SpeakerMixDisplayUtils.h"
 #include "UI/Views/Common/TimelineView.h"
-#include "UI/Views/Common/EditorShortcutUtils.h"
 
 #include <QFileDialog>
 #include <QHBoxLayout>
-#include <QMouseEvent>
 #include <QScrollBar>
 #include <QSignalBlocker>
 #include <lite/GUI/Controls/OverlaySplitter.h>
@@ -151,7 +149,8 @@ TrackEditorView::TrackEditorView(QWidget *parent) : PanelView(AppGlobal::TracksE
     setLayout(mainLayout);
     setPanelActive(true);
     editorViewController->registerPanel(this);
-    installEventFilter(this);
+    editorViewController->registerInteractionArea(this, AppGlobal::TracksEditor,
+                                                  EditorInteraction::Target::Tracks);
 
     connect(m_trackListView, &QListWidget::currentRowChanged, this,
             &TrackEditorView::setSelectedTrackIndex);
@@ -165,7 +164,12 @@ TrackEditorView::TrackEditorView(QWidget *parent) : PanelView(AppGlobal::TracksE
         connectRhiBackend();
     else
         connectLegacyBackend();
-    registerEditorShortcuts();
+    connect(
+        editorViewController, &EditorViewController::editCommandRequested, this,
+        [this](const EditorInteraction::Target target, const EditorInteraction::Command command) {
+            if (target == EditorInteraction::Target::Tracks)
+                executeEditCommand(command);
+        });
     connect(trackListHeader, &TrackListHeaderView::tempoLaneToggled, this,
             [this](const bool visible) {
                 m_tempoLaneHeader->setVisible(visible);
@@ -185,23 +189,28 @@ TrackEditorView::TrackEditorView(QWidget *parent) : PanelView(AppGlobal::TracksE
     connect(appModel, &AppModel::trackMoved, this, &TrackEditorView::onTrackMoved);
 }
 
-void TrackEditorView::registerEditorShortcuts() {
-    using EditorShortcutUtils::add;
-    add(this, QKeySequence::Cut, m_contextMenuController,
-        &TrackEditorContextMenuController::cutSelection);
-    add(this, QKeySequence::Copy, m_contextMenuController,
-        &TrackEditorContextMenuController::copySelection);
-    add(this, QKeySequence::Paste, m_contextMenuController,
-        &TrackEditorContextMenuController::pasteSelection);
-    add(this, QKeySequence::SelectAll, m_contextMenuController,
-        &TrackEditorContextMenuController::selectAll);
-    add(this, QKeySequence::Delete, m_contextMenuController,
-        [this] { m_contextMenuController->deleteSelection(); });
-    add(this, QKeySequence(Qt::Key_Backspace), m_contextMenuController,
-        [this] { m_contextMenuController->deleteSelection(); });
+void TrackEditorView::executeEditCommand(const EditorInteraction::Command command) const {
+    switch (command) {
+        case EditorInteraction::Command::Cut:
+            m_contextMenuController->cutSelection();
+            break;
+        case EditorInteraction::Command::Copy:
+            m_contextMenuController->copySelection();
+            break;
+        case EditorInteraction::Command::Paste:
+            m_contextMenuController->pasteSelection();
+            break;
+        case EditorInteraction::Command::SelectAll:
+            m_contextMenuController->selectAll();
+            break;
+        case EditorInteraction::Command::DeleteSelection:
+            m_contextMenuController->deleteSelection();
+            break;
+    }
 }
 
 TrackEditorView::~TrackEditorView() {
+    editorViewController->unregisterInteractionArea(this);
     editorViewController->unregisterPanel(this);
 }
 
@@ -678,14 +687,6 @@ void TrackEditorView::updateAutoPageTurnButtonView(const bool available) {
 
 void TrackEditorView::onRemoveTrackTriggered(const int id) {
     trackController->onRemoveTrack(id);
-}
-
-bool TrackEditorView::eventFilter(QObject *watched, QEvent *event) {
-    if (event->type() == QMouseEvent::MouseButtonPress) {
-        editorViewController->setActivePanel(AppGlobal::TracksEditor);
-    }
-
-    return QWidget::eventFilter(watched, event);
 }
 
 TrackViewModel *TrackEditorView::ViewModel::findTrack(const Track *dsTrack) {

--- a/src/app/UI/Views/TrackEditor/TrackEditorView.h
+++ b/src/app/UI/Views/TrackEditor/TrackEditorView.h
@@ -3,6 +3,7 @@
 
 #include <lite/ProjectModel/AppModel/AppModel.h>
 #include <lite/ProjectModel/AppModel/Track.h>
+#include "Interface/EditorInteraction.h"
 #include "Interface/EditorViewState.h"
 #include <lite/History/HistoryFocus.h>
 #include "TracksGraphicsScene.h"
@@ -62,13 +63,12 @@ private slots:
     static void onRemoveTrackTriggered(int id);
 
 private:
-    bool eventFilter(QObject *watched, QEvent *event) override;
     void changeEvent(QEvent *event) override;
     void createLegacyBackend();
     void connectLegacyBackend();
     void connectRhiBackend();
     void fallbackToLegacy();
-    void registerEditorShortcuts();
+    void executeEditCommand(EditorInteraction::Command command) const;
     void populateLegacyClipItems();
     void handleExternalDrop(const TrackDropSlot &slot, const QList<QUrl> &urls);
     [[nodiscard]] double activeScaleY() const;

--- a/src/app/UI/Views/TrackEditor/TracksGraphicsView.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksGraphicsView.cpp
@@ -98,6 +98,10 @@ void TracksGraphicsView::setClipSelectedBorderColor(const QColor &color) {
             clip->update();
 }
 
+void TracksGraphicsView::setClipSelection(const QList<int> &selected) const {
+    applyClipSelection(selected);
+}
+
 int TracksGraphicsView::snapStep(const bool snapOff, const int atTick) const {
     if (snapOff)
         return 1;

--- a/src/app/UI/Views/TrackEditor/TracksGraphicsView.h
+++ b/src/app/UI/Views/TrackEditor/TracksGraphicsView.h
@@ -44,6 +44,9 @@ public:
     void clearTrackPastePreview() override;
     [[nodiscard]] int snapStep(bool snapOff, int atTick = 0) const;
 
+public slots:
+    void setClipSelection(const QList<int> &selected) const;
+
 signals:
     void contextMenuRequested(const TrackEditorMenuContext &context);
     // Emitted when an external file drag is dropped on the canvas. Phase 1

--- a/src/app/UI/Window/MainWindow.cpp
+++ b/src/app/UI/Window/MainWindow.cpp
@@ -483,8 +483,8 @@ bool MainWindow::restoreEditorViewState(const EditorViewState &state) {
         return false;
     }
 
-    setEditorPanelVisibility(state.layout.trackPanelVisible, state.layout.bottomPanelVisible);
     m_bottomPanelView->setCurrentPageId(state.layout.bottomPanelPageId);
+    setEditorPanelVisibility(state.layout.trackPanelVisible, state.layout.bottomPanelVisible);
     m_trackEditorView->setViewScale(state.trackPanel.horizontalScale,
                                     state.trackPanel.verticalScale);
     m_trackEditorView->centerAt(state.trackPanel.centerTick, state.trackPanel.centerTrackIndex);
@@ -534,8 +534,7 @@ bool MainWindow::setEditorPanelVisibility(const bool trackPanelVisible,
         }
     }
 
-    appStatus->trackPanelCollapsed = !trackPanelVisible;
-    appStatus->bottomPanelCollapsed = !bottomPanelVisible;
+    updatePanelVisibilityState(trackPanelVisible, bottomPanelVisible);
     return true;
 }
 
@@ -635,16 +634,21 @@ void MainWindow::onSplitterMoved(int pos, int index) {
     qDebug() << "MainWindow::onSplitterMoved"
              << "size 0:" << sizes.at(0) << "size 1:" << sizes.at(1);
     if (sizes.at(0) == 0) {
-        appStatus->trackPanelCollapsed = true;
-        appStatus->bottomPanelCollapsed = false;
+        updatePanelVisibilityState(false, true);
     } else if (sizes.at(1) == 0) {
-        appStatus->trackPanelCollapsed = false;
-        appStatus->bottomPanelCollapsed = true;
+        updatePanelVisibilityState(true, false);
     } else {
         m_splitterState = m_splitter->saveState();
-        appStatus->trackPanelCollapsed = false;
-        appStatus->bottomPanelCollapsed = false;
+        updatePanelVisibilityState(true, true);
     }
+}
+
+void MainWindow::updatePanelVisibilityState(const bool trackPanelVisible,
+                                            const bool bottomPanelVisible) {
+    appStatus->trackPanelCollapsed = !trackPanelVisible;
+    appStatus->bottomPanelCollapsed = !bottomPanelVisible;
+    editorViewController->syncPanelVisibility(trackPanelVisible, bottomPanelVisible,
+                                              m_bottomPanelView->panelType());
 }
 
 void MainWindow::detachBottomPanel() {

--- a/src/app/UI/Window/MainWindow.cpp
+++ b/src/app/UI/Window/MainWindow.cpp
@@ -285,6 +285,12 @@ void MainWindow::changeEvent(QEvent *event) {
     QMainWindow::changeEvent(event);
     if (event->type() == QEvent::LanguageChange)
         updateWindowTitle();
+    else if (event->type() == QEvent::ActivationChange && isActiveWindow() &&
+             m_bottomPanelDetached) {
+        editorViewController->activatePanelContext(m_trackEditorView->isVisible()
+                                                       ? AppGlobal::TracksEditor
+                                                       : AppGlobal::Generic);
+    }
 }
 
 void MainWindow::resizeEvent(QResizeEvent *event) {
@@ -750,6 +756,10 @@ void MainWindow::attachBottomPanel() {
 }
 
 bool MainWindow::eventFilter(QObject *watched, QEvent *event) {
+    if (watched == m_bottomPanelView && event->type() == QEvent::WindowActivate) {
+        editorViewController->activatePanelContext(m_bottomPanelView->panelType());
+        return false;
+    }
     if (watched == m_bottomPanelView && event->type() == QEvent::Close) {
         event->ignore();
         attachBottomPanel();

--- a/src/app/UI/Window/MainWindow.h
+++ b/src/app/UI/Window/MainWindow.h
@@ -90,6 +90,7 @@ private slots:
 
 private:
     bool navigateToFocus(const HistoryFocus &focus, bool animated);
+    void updatePanelVisibilityState(bool trackPanelVisible, bool bottomPanelVisible);
     void closeEvent(QCloseEvent *event) override;
     bool eventFilter(QObject *watched, QEvent *event) override;
     bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result) override;

--- a/src/tests/TestEditorViewController/main.cpp
+++ b/src/tests/TestEditorViewController/main.cpp
@@ -454,6 +454,59 @@ namespace {
         controller->setActivePanel(AppGlobal::TracksEditor);
     }
 
+    void testPanelVisibilityRouting(EditorViewController *controller) {
+        controller->setActivePanel(AppGlobal::TracksEditor);
+        FakePanel trackPanel(AppGlobal::TracksEditor);
+        FakePanel bottomPanel(AppGlobal::ClipEditor);
+        controller->registerPanel(&trackPanel);
+        controller->registerPanel(&bottomPanel);
+
+        QObject parameterArea;
+        controller->registerInteractionArea(&parameterArea, AppGlobal::ClipEditor,
+                                            EditorInteraction::Target::Parameters);
+        QEvent parameterPress(QEvent::MouseButtonPress);
+        QCoreApplication::sendEvent(&parameterArea, &parameterPress);
+
+        controller->syncPanelVisibility(true, true, AppGlobal::ClipEditor);
+        expect(controller->activePanel() == AppGlobal::ClipEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::Parameters,
+               "showing both panels must preserve the focused visual editor");
+
+        controller->syncPanelVisibility(true, false, AppGlobal::ClipEditor);
+        expect(controller->activePanel() == AppGlobal::TracksEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::Tracks &&
+                   trackPanel.panelActive() && !bottomPanel.panelActive(),
+               "hiding the bottom panel must transfer focus and commands to tracks");
+
+        controller->syncPanelVisibility(true, true, AppGlobal::ClipEditor);
+        expect(controller->activePanel() == AppGlobal::TracksEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::Tracks,
+               "reopening the bottom panel must not steal track focus");
+
+        controller->syncPanelVisibility(false, true, AppGlobal::ClipEditor);
+        expect(controller->activePanel() == AppGlobal::ClipEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::PianoRoll &&
+                   !trackPanel.panelActive() && bottomPanel.panelActive(),
+               "hiding tracks must transfer focus and commands to the visible bottom page");
+
+        QCoreApplication::sendEvent(&parameterArea, &parameterPress);
+        controller->syncPanelVisibility(false, true, AppGlobal::ClipEditor);
+        expect(controller->activeEditTarget() == EditorInteraction::Target::Parameters,
+               "visibility sync must preserve a focused parameter editor");
+
+        controller->setActivePanel(AppGlobal::TracksEditor);
+        bottomPanel.setPanelType(AppGlobal::Generic);
+        controller->syncPanelVisibility(false, true, AppGlobal::Generic);
+        expect(controller->activePanel() == AppGlobal::Generic &&
+                   controller->activeEditTarget() == EditorInteraction::Target::None,
+               "a visible non-editor bottom page must disable edit commands");
+
+        controller->unregisterInteractionArea(&parameterArea);
+        controller->unregisterPanel(&bottomPanel);
+        controller->unregisterPanel(&trackPanel);
+        controller->setActivePanel(AppGlobal::TracksEditor);
+    }
+
 } // namespace
 
 int main(int argc, char *argv[]) {
@@ -464,6 +517,7 @@ int main(int argc, char *argv[]) {
     testForwardingAndSnapshots(controller);
     testActivePanels(controller);
     testInteractionRouting(controller);
+    testPanelVisibilityRouting(controller);
 
     controller->setView(nullptr);
     if (g_failures == 0) {

--- a/src/tests/TestEditorViewController/main.cpp
+++ b/src/tests/TestEditorViewController/main.cpp
@@ -231,6 +231,22 @@ namespace {
         controller->clearFocusPreview();
     }
 
+    void testCommandCapabilities() {
+        using EditorInteraction::Command;
+        using EditorInteraction::Target;
+        expect(EditorInteraction::supportsCommand(Target::Tracks, Command::Cut) &&
+                   EditorInteraction::supportsCommand(Target::PianoRoll, Command::SelectAll),
+               "track and piano-roll editors must expose their complete edit command set");
+        expect(EditorInteraction::supportsCommand(Target::Parameters, Command::DeleteSelection) &&
+                   !EditorInteraction::supportsCommand(Target::Parameters, Command::Cut) &&
+                   !EditorInteraction::supportsCommand(Target::Parameters, Command::Copy) &&
+                   !EditorInteraction::supportsCommand(Target::Parameters, Command::Paste) &&
+                   !EditorInteraction::supportsCommand(Target::Parameters, Command::SelectAll),
+               "the parameter editor must expose only its implemented delete command");
+        expect(!EditorInteraction::supportsCommand(Target::None, Command::DeleteSelection),
+               "a non-editor target must not expose edit commands");
+    }
+
     void testForwardingAndSnapshots(EditorViewController *controller) {
         FakeEditorView view;
         view.state = sampleState();
@@ -529,6 +545,7 @@ int main(int argc, char *argv[]) {
     auto *controller = editorViewController;
 
     testNoView(controller);
+    testCommandCapabilities();
     testForwardingAndSnapshots(controller);
     testActivePanels(controller);
     testInteractionRouting(controller);

--- a/src/tests/TestEditorViewController/main.cpp
+++ b/src/tests/TestEditorViewController/main.cpp
@@ -488,6 +488,12 @@ namespace {
                    controller->activeEditTarget() == EditorInteraction::Target::Parameters,
                "showing both panels must preserve the focused visual editor");
 
+        controller->activatePanelContext(AppGlobal::TracksEditor);
+        controller->activatePanelContext(AppGlobal::ClipEditor);
+        expect(controller->activePanel() == AppGlobal::ClipEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::Parameters,
+               "reactivating the bottom window must restore its last focused visual editor");
+
         controller->syncPanelVisibility(true, false, AppGlobal::ClipEditor);
         expect(controller->activePanel() == AppGlobal::TracksEditor &&
                    controller->activeEditTarget() == EditorInteraction::Target::Tracks &&
@@ -501,9 +507,9 @@ namespace {
 
         controller->syncPanelVisibility(false, true, AppGlobal::ClipEditor);
         expect(controller->activePanel() == AppGlobal::ClipEditor &&
-                   controller->activeEditTarget() == EditorInteraction::Target::PianoRoll &&
+                   controller->activeEditTarget() == EditorInteraction::Target::Parameters &&
                    !trackPanel.panelActive() && bottomPanel.panelActive(),
-               "hiding tracks must transfer focus and commands to the visible bottom page");
+               "hiding tracks must restore the last focused region of the visible bottom page");
 
         QCoreApplication::sendEvent(&parameterArea, &parameterPress);
         controller->syncPanelVisibility(false, true, AppGlobal::ClipEditor);

--- a/src/tests/TestEditorViewController/main.cpp
+++ b/src/tests/TestEditorViewController/main.cpp
@@ -4,6 +4,7 @@
 #include "Interface/IPanel.h"
 
 #include <QCoreApplication>
+#include <QEvent>
 #include <QTextStream>
 
 #include <cmath>
@@ -354,6 +355,92 @@ namespace {
         controller->unregisterPanel(&trackPanel);
     }
 
+    void testInteractionRouting(EditorViewController *controller) {
+        controller->setActivePanel(AppGlobal::TracksEditor);
+
+        QObject trackArea;
+        QObject trackChild(&trackArea);
+        QObject bottomArea;
+        QObject pianoRollChild(&bottomArea);
+        QObject parameterArea(&bottomArea);
+        QObject parameterChild(&parameterArea);
+
+        controller->registerInteractionArea(&trackArea, AppGlobal::TracksEditor,
+                                            EditorInteraction::Target::Tracks);
+        controller->registerInteractionArea(&bottomArea, AppGlobal::ClipEditor,
+                                            EditorInteraction::Target::PianoRoll);
+        controller->registerInteractionArea(&parameterArea, AppGlobal::ClipEditor,
+                                            EditorInteraction::Target::Parameters);
+
+        int panelSignalCount = 0;
+        int targetSignalCount = 0;
+        const auto panelConnection =
+            QObject::connect(controller, &EditorViewController::activePanelChanged,
+                             [&panelSignalCount] { ++panelSignalCount; });
+        const auto targetConnection =
+            QObject::connect(controller, &EditorViewController::activeEditTargetChanged,
+                             [&targetSignalCount] { ++targetSignalCount; });
+
+        QEvent pianoPress(QEvent::MouseButtonPress);
+        QCoreApplication::sendEvent(&pianoRollChild, &pianoPress);
+        expect(controller->activePanel() == AppGlobal::ClipEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::PianoRoll,
+               "a bottom-panel descendant must activate piano-roll editing");
+        expect(panelSignalCount == 1 && targetSignalCount == 1,
+               "a context change must emit each state transition once");
+
+        QEvent repeatedPianoPress(QEvent::MouseButtonPress);
+        QCoreApplication::sendEvent(&pianoRollChild, &repeatedPianoPress);
+        expect(panelSignalCount == 1 && targetSignalCount == 1,
+               "repeated presses in one context must not duplicate state signals");
+
+        QEvent parameterPress(QEvent::MouseButtonPress);
+        QCoreApplication::sendEvent(&parameterChild, &parameterPress);
+        expect(controller->activePanel() == AppGlobal::ClipEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::Parameters,
+               "the nearest nested interaction area must win within the bottom panel");
+        expect(panelSignalCount == 1 && targetSignalCount == 2,
+               "switching between bottom edit areas must preserve the panel border");
+
+        QEvent trackFocus(QEvent::FocusIn);
+        QCoreApplication::sendEvent(&trackChild, &trackFocus);
+        expect(controller->activePanel() == AppGlobal::TracksEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::Tracks,
+               "focus entering a registered track descendant must activate track editing");
+
+        EditorInteraction::Target commandTarget = EditorInteraction::Target::None;
+        EditorInteraction::Command requestedCommand = EditorInteraction::Command::Cut;
+        int commandCount = 0;
+        const auto commandConnection = QObject::connect(
+            controller, &EditorViewController::editCommandRequested,
+            [&commandTarget, &requestedCommand, &commandCount](
+                const EditorInteraction::Target target, const EditorInteraction::Command command) {
+                commandTarget = target;
+                requestedCommand = command;
+                ++commandCount;
+            });
+        controller->requestEditCommand(EditorInteraction::Command::SelectAll);
+        expect(commandCount == 1 && commandTarget == EditorInteraction::Target::Tracks &&
+                   requestedCommand == EditorInteraction::Command::SelectAll,
+               "edit commands must carry the current interaction target");
+
+        controller->updateInteractionArea(&bottomArea, AppGlobal::Generic,
+                                          EditorInteraction::Target::None);
+        QEvent genericPress(QEvent::MouseButtonPress);
+        QCoreApplication::sendEvent(&pianoRollChild, &genericPress);
+        expect(controller->activePanel() == AppGlobal::Generic &&
+                   controller->activeEditTarget() == EditorInteraction::Target::None,
+               "a dynamic generic bottom page must deactivate editor commands");
+
+        QObject::disconnect(commandConnection);
+        QObject::disconnect(targetConnection);
+        QObject::disconnect(panelConnection);
+        controller->unregisterInteractionArea(&parameterArea);
+        controller->unregisterInteractionArea(&bottomArea);
+        controller->unregisterInteractionArea(&trackArea);
+        controller->setActivePanel(AppGlobal::TracksEditor);
+    }
+
 } // namespace
 
 int main(int argc, char *argv[]) {
@@ -363,6 +450,7 @@ int main(int argc, char *argv[]) {
     testNoView(controller);
     testForwardingAndSnapshots(controller);
     testActivePanels(controller);
+    testInteractionRouting(controller);
 
     controller->setView(nullptr);
     if (g_failures == 0) {

--- a/src/tests/TestEditorViewController/main.cpp
+++ b/src/tests/TestEditorViewController/main.cpp
@@ -494,7 +494,22 @@ namespace {
         expect(controller->activeEditTarget() == EditorInteraction::Target::Parameters,
                "visibility sync must preserve a focused parameter editor");
 
+        controller->syncEditTargetVisibility(EditorInteraction::Target::Parameters, true,
+                                             AppGlobal::ClipEditor);
+        expect(controller->activeEditTarget() == EditorInteraction::Target::Parameters,
+               "a visible parameter editor must retain its edit target");
+        controller->syncEditTargetVisibility(EditorInteraction::Target::Parameters, false,
+                                             AppGlobal::ClipEditor);
+        expect(controller->activePanel() == AppGlobal::ClipEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::PianoRoll,
+               "collapsing the parameter editor must transfer commands to the piano roll");
+
         controller->setActivePanel(AppGlobal::TracksEditor);
+        controller->syncEditTargetVisibility(EditorInteraction::Target::Parameters, false,
+                                             AppGlobal::ClipEditor);
+        expect(controller->activePanel() == AppGlobal::TracksEditor &&
+                   controller->activeEditTarget() == EditorInteraction::Target::Tracks,
+               "collapsing an unfocused edit target must not steal focus");
         bottomPanel.setPanelType(AppGlobal::Generic);
         controller->syncPanelVisibility(false, true, AppGlobal::Generic);
         expect(controller->activePanel() == AppGlobal::Generic &&

--- a/src/tests/TestEditorViewController/main.cpp
+++ b/src/tests/TestEditorViewController/main.cpp
@@ -360,14 +360,20 @@ namespace {
 
         QObject trackArea;
         QObject trackChild(&trackArea);
-        QObject bottomArea;
-        QObject pianoRollChild(&bottomArea);
-        QObject parameterArea(&bottomArea);
+        QObject bottomContainer;
+        QObject titleBarArea(&bottomContainer);
+        QObject titleBarChild(&titleBarArea);
+        QObject pianoRollArea(&bottomContainer);
+        QObject pianoRollChild(&pianoRollArea);
+        QObject parameterArea(&bottomContainer);
         QObject parameterChild(&parameterArea);
+        QObject separator(&bottomContainer);
 
         controller->registerInteractionArea(&trackArea, AppGlobal::TracksEditor,
                                             EditorInteraction::Target::Tracks);
-        controller->registerInteractionArea(&bottomArea, AppGlobal::ClipEditor,
+        controller->registerInteractionArea(&titleBarArea, AppGlobal::ClipEditor,
+                                            EditorInteraction::Target::PianoRoll);
+        controller->registerInteractionArea(&pianoRollArea, AppGlobal::ClipEditor,
                                             EditorInteraction::Target::PianoRoll);
         controller->registerInteractionArea(&parameterArea, AppGlobal::ClipEditor,
                                             EditorInteraction::Target::Parameters);
@@ -381,26 +387,32 @@ namespace {
             QObject::connect(controller, &EditorViewController::activeEditTargetChanged,
                              [&targetSignalCount] { ++targetSignalCount; });
 
-        QEvent pianoPress(QEvent::MouseButtonPress);
-        QCoreApplication::sendEvent(&pianoRollChild, &pianoPress);
+        QEvent titleBarPress(QEvent::MouseButtonPress);
+        QCoreApplication::sendEvent(&titleBarChild, &titleBarPress);
         expect(controller->activePanel() == AppGlobal::ClipEditor &&
                    controller->activeEditTarget() == EditorInteraction::Target::PianoRoll,
-               "a bottom-panel descendant must activate piano-roll editing");
+               "the visible piano-roll toolbar must activate note editing");
         expect(panelSignalCount == 1 && targetSignalCount == 1,
                "a context change must emit each state transition once");
 
-        QEvent repeatedPianoPress(QEvent::MouseButtonPress);
-        QCoreApplication::sendEvent(&pianoRollChild, &repeatedPianoPress);
+        QEvent pianoPress(QEvent::MouseButtonPress);
+        QCoreApplication::sendEvent(&pianoRollChild, &pianoPress);
         expect(panelSignalCount == 1 && targetSignalCount == 1,
-               "repeated presses in one context must not duplicate state signals");
+               "moving within the visual note editor must not duplicate state signals");
 
         QEvent parameterPress(QEvent::MouseButtonPress);
         QCoreApplication::sendEvent(&parameterChild, &parameterPress);
         expect(controller->activePanel() == AppGlobal::ClipEditor &&
                    controller->activeEditTarget() == EditorInteraction::Target::Parameters,
-               "the nearest nested interaction area must win within the bottom panel");
+               "the visual parameter editor must activate parameter editing independently");
         expect(panelSignalCount == 1 && targetSignalCount == 2,
                "switching between bottom edit areas must preserve the panel border");
+
+        QEvent separatorPress(QEvent::MouseButtonPress);
+        QCoreApplication::sendEvent(&separator, &separatorPress);
+        expect(controller->activeEditTarget() == EditorInteraction::Target::Parameters &&
+                   targetSignalCount == 2,
+               "unassigned container space must not inherit a sibling editor target");
 
         QEvent trackFocus(QEvent::FocusIn);
         QCoreApplication::sendEvent(&trackChild, &trackFocus);
@@ -424,10 +436,10 @@ namespace {
                    requestedCommand == EditorInteraction::Command::SelectAll,
                "edit commands must carry the current interaction target");
 
-        controller->updateInteractionArea(&bottomArea, AppGlobal::Generic,
+        controller->updateInteractionArea(&titleBarArea, AppGlobal::Generic,
                                           EditorInteraction::Target::None);
         QEvent genericPress(QEvent::MouseButtonPress);
-        QCoreApplication::sendEvent(&pianoRollChild, &genericPress);
+        QCoreApplication::sendEvent(&titleBarChild, &genericPress);
         expect(controller->activePanel() == AppGlobal::Generic &&
                    controller->activeEditTarget() == EditorInteraction::Target::None,
                "a dynamic generic bottom page must deactivate editor commands");
@@ -436,7 +448,8 @@ namespace {
         QObject::disconnect(targetConnection);
         QObject::disconnect(panelConnection);
         controller->unregisterInteractionArea(&parameterArea);
-        controller->unregisterInteractionArea(&bottomArea);
+        controller->unregisterInteractionArea(&pianoRollArea);
+        controller->unregisterInteractionArea(&titleBarArea);
         controller->unregisterInteractionArea(&trackArea);
         controller->setActivePanel(AppGlobal::TracksEditor);
     }

--- a/src/tests/TestOverlaySplitter/main.cpp
+++ b/src/tests/TestOverlaySplitter/main.cpp
@@ -1,11 +1,24 @@
 #include <lite/GUI/Controls/OverlaySplitter.h>
 
 #include <QApplication>
+#include <QResizeEvent>
 #include <QTextStream>
 
 namespace {
 
     int g_failures = 0;
+
+    class ResizeProbe final : public QWidget {
+    public:
+        int zeroHeightResizeCount = 0;
+
+    protected:
+        void resizeEvent(QResizeEvent *event) override {
+            QWidget::resizeEvent(event);
+            if (event->size().height() == 0)
+                ++zeroHeightResizeCount;
+        }
+    };
 
     bool expect(const bool condition, const char *message) {
         if (condition)
@@ -40,13 +53,21 @@ int main(int argc, char *argv[]) {
     auto *splitter = new OverlaySplitter(Qt::Vertical, &firstHost);
     splitter->setGeometry(firstHost.rect());
     splitter->addWidget(new QWidget);
-    splitter->addWidget(new QWidget);
+    auto *collapsiblePane = new ResizeProbe;
+    splitter->addWidget(collapsiblePane);
     splitter->show();
     processVisibilityEvents();
 
     auto *grip = findGrip(&firstHost);
     expect(grip, "showing a two-pane splitter must create its overlay grip");
     expect(grip && grip->isVisible(), "the grip must be visible with the splitter");
+
+    splitter->setSizes({1, 0});
+    processVisibilityEvents();
+    expect(collapsiblePane->height() == 0 && collapsiblePane->zeroHeightResizeCount > 0,
+           "collapsing a pane must expose its zero-height resize transition");
+    splitter->setSizes({1, 1});
+    processVisibilityEvents();
 
     splitter->hide();
     processVisibilityEvents();


### PR DESCRIPTION
## Summary

- centralize editor focus tracking and edit-command dispatch in `EditorViewController`, including mouse/focus events from nested RHI and Legacy widgets
- route shortcuts by the three visual editor regions: track arrangement, piano notes (including its toolbar/timeline/keyboard), and parameter drawing (including its toolbar)
- synchronize Legacy clip selection presentation with `AppStatus` so model selection and rendered state cannot diverge
- keep parameter-region commands inside the parameter editor and reuse its existing deletion paths

## Root cause

The two editor views owned independent widget-scoped shortcuts, while panel highlighting and command routing were driven by different focus signals. RHI canvas events were accepted by nested rendering widgets before the parent filters saw them. Legacy clip rendering additionally relied on `QGraphicsItem` selection instead of the shared application selection state.

## Validation

- full `debug` configure + build through the project VS DevShell/CMake preset script
- `TestEditorViewController`
- `TestEditorShortcuts`
- `TestPianoRollInteractions`
- `TestTrackEditorInteractions`
- Computer Use regression on both Legacy and RHI:
  - track/piano canvas clicks switch the white panel border
  - piano toolbar, timeline, keyboard, and canvas route Ctrl+A to notes
  - parameter toolbar/canvas do not leak Ctrl+A to notes or clips
  - track Ctrl+A selects all clips with correct Legacy and RHI presentation
  - Ctrl+C/V routes independently to notes and clips
- GUI synthesis smoke with Mousse: pitch curve, phonemes, non-flat waveform, and playback-head/time advancement observed