### PR TITLE
fix(logging): remove high-frequency UI traces

### DIFF
--- a/src/app/UI/Views/ClipEditor/CommonParamEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/CommonParamEditorView.cpp
@@ -410,15 +410,10 @@ void CommonParamEditorView::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
     m_mouseMoved = true;
     const auto scenePos = event->scenePos();
     auto tick = MathUtils::round(static_cast<int>(sceneXToTick(scenePos.x())), 5);
-    if (tick < 0) {
+    if (tick < 0)
         tick = 0;
-        qDebug() << "mouseMoveEvent: Negative tick, clipped to 0";
-    }
     const auto value = static_cast<int>(sceneYToValue(scenePos.y()));
     const auto curPos = QPoint(tick, value);
-    qDebug() << "Draw at tick:" << tick << "value:"
-             << m_properties->valueToString(value, m_properties->hasUnit(),
-                                            m_properties->displayPrecision);
 
     int startTick;
     int endTick;

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -348,7 +348,6 @@ void TimeGraphicsView::adjustScaleXToFillView() {
         auto targetSceneWidth = viewport()->width();
         auto targetScaleX = targetSceneWidth / (sceneRect().width() / scaleX());
         setScaleX(targetScaleX);
-        qDebug() << "Scene width < viewport width, adjust scaleX to" << targetScaleX;
     }
 }
 
@@ -357,7 +356,6 @@ void TimeGraphicsView::adjustScaleYToFillView() {
         auto targetSceneHeight = viewport()->height();
         auto targetScaleY = targetSceneHeight / (sceneRect().height() / scaleY());
         setScaleY(targetScaleY);
-        qDebug() << "Scene height < viewport height, adjust scaleY to" << targetScaleY;
     }
 }
 

--- a/src/app/UI/Window/MainWindow.cpp
+++ b/src/app/UI/Window/MainWindow.cpp
@@ -632,8 +632,6 @@ void MainWindow::onSplitterMoved(int pos, int index) {
     if (sizes.size() < 2)
         return;
 
-    qDebug() << "MainWindow::onSplitterMoved"
-             << "size 0:" << sizes.at(0) << "size 1:" << sizes.at(1);
     if (sizes.at(0) == 0) {
         appStatus->trackPanelCollapsed = true;
         appStatus->bottomPanelCollapsed = false;


### PR DESCRIPTION
## 变更

- 移除窗口内容自适应缩放时的逐次调试日志
- 移除主分隔条拖动时的逐次尺寸日志
- 移除参数曲线绘制期间 mouseMoveEvent 的逐事件日志与字符串格式化

## 原因

这些埋点位于连续触发的 UI 路径中。窗口缩放、分隔条拖动或参数曲线绘制会快速产生大量日志，同时为每次事件支付日志处理和格式化开销。

## 验证

- 使用 Computer Use 在修改前拖动主分隔条，并在文件日志中复现 MainWindow::onSplitterMoved
- 完整执行 debug preset 的 configure + build，DsEditorLite 链接成功
- 使用 Computer Use 启动新 Debug 构建，验证分隔条拖动、窗口最大化与还原均正常
- 扫描确认已移除的四类高频日志文本不再存在