### PR TITLE
fix(piano-roll): adapt clip right boundary to note edits

### DIFF
--- a/src/app/Controller/Actions/AppModel/Note/NoteActions.cpp
+++ b/src/app/Controller/Actions/AppModel/Note/NoteActions.cpp
@@ -10,9 +10,15 @@
 #include "RemoveNoteAction.h"
 #include "SplitNoteAction.h"
 #include "Controller/Actions/AppModel/Clip/EditSingingClipPropertiesAction.h"
+#include <lite/ProjectModel/AppModel/AppModel.h>
 #include <lite/ProjectModel/AppModel/SingingClip.h>
+#include <lite/ProjectModel/AppModel/Track.h>
+#include <lite/ProjectModel/Utils/ClipResizeUtils.h>
+#include <lite/ProjectModel/Utils/SingingClipRangeUtils.h>
 
 #include <QCoreApplication>
+#include <QHash>
+#include <QSet>
 
 #include <limits>
 
@@ -50,20 +56,44 @@ namespace {
         return focus;
     }
 
+    template <typename EndPosition>
+    int projectedContentEnd(const SingingClip *clip, EndPosition endPosition) {
+        return ClipResizeUtils::furthestContentEnd(clip->notes().begin(), clip->notes().end(), 0,
+                                                  std::move(endPosition));
+    }
+
+    QSet<const Note *> noteSet(const QList<Note *> &notes) {
+        QSet<const Note *> result;
+        for (const auto note : notes) {
+            if (note)
+                result.insert(note);
+        }
+        return result;
+    }
+
 } // namespace
 
-void NoteActions::insertNotes(const QList<Note *> &notes, SingingClip *clip) {
-    setTranslatableName("NoteActions", QT_TRANSLATE_NOOP("NoteActions", "Insert note(s)"));
-    addAction(new InsertNoteAction(notes, clip));
-    const auto focus = noteFocus(notes, clip);
-    setFocusTransition({focus, focus});
+void NoteActions::addClipExtensionToFit(const int contentEnd, SingingClip *clip, Track *track) {
+    if (!clip || !track)
+        return;
+
+    const auto oldProperties = Clip::ClipCommonProperties(*clip);
+    auto newProperties = oldProperties;
+    if (!SingingClipRangeUtils::extendRightToFit(newProperties, appModel->timeline(), contentEnd))
+        return;
+
+    addAction(EditSingingClipPropertiesAction::build(oldProperties, newProperties, clip, track));
 }
 
-void NoteActions::pasteNotes(const QList<Note *> &notes, SingingClip *clip, Track *track,
-                             const Clip::ClipCommonProperties &newClipProperties) {
+void NoteActions::insertNotes(const QList<Note *> &notes, SingingClip *clip, Track *track) {
     setTranslatableName("NoteActions", QT_TRANSLATE_NOOP("NoteActions", "Insert note(s)"));
-    addAction(EditSingingClipPropertiesAction::build(Clip::ClipCommonProperties(*clip),
-                                                     newClipProperties, clip, track));
+    auto contentEnd = projectedContentEnd(
+        clip, [](const Note *note) { return note->localStart() + note->length(); });
+    for (const auto note : notes) {
+        if (note)
+            contentEnd = std::max(contentEnd, note->localStart() + note->length());
+    }
+    addClipExtensionToFit(contentEnd, clip, track);
     addAction(new InsertNoteAction(notes, clip));
     const auto focus = noteFocus(notes, clip);
     setFocusTransition({focus, focus});
@@ -77,22 +107,42 @@ void NoteActions::removeNotes(const QList<Note *> &notes, SingingClip *clip) {
 }
 
 void NoteActions::editNotesStartAndLength(const QList<Note *> &notes, const int delta,
-                                          SingingClip *clip) {
+                                          SingingClip *clip, Track *track) {
     setTranslatableName("NoteActions",
                         QT_TRANSLATE_NOOP("NoteActions", "Edit note start and length"));
+    addClipExtensionToFit(projectedContentEnd(
+                              clip, [](const Note *note) {
+                                  return note->localStart() + note->length();
+                              }),
+                          clip, track);
     addAction(new EditNoteStartAndLengthAction(notes, delta, clip));
     setFocusTransition({noteFocus(notes, clip), noteFocus(notes, clip, delta, 0, 0, true)});
 }
 
-void NoteActions::editNotesLength(const QList<Note *> &notes, const int delta, SingingClip *clip) {
+void NoteActions::editNotesLength(const QList<Note *> &notes, const int delta, SingingClip *clip,
+                                  Track *track) {
     setTranslatableName("NoteActions", QT_TRANSLATE_NOOP("NoteActions", "Edit note length"));
+    const auto edited = noteSet(notes);
+    addClipExtensionToFit(projectedContentEnd(
+                              clip, [&](const Note *note) {
+                                  return note->localStart() + note->length() +
+                                         (edited.contains(note) ? delta : 0);
+                              }),
+                          clip, track);
     addAction(new EditNotesLengthAction(notes, delta, clip));
     setFocusTransition({noteFocus(notes, clip), noteFocus(notes, clip, 0, 0, delta)});
 }
 
 void NoteActions::editNotePosition(const QList<Note *> &notes, const int deltaTick,
-                                   const int deltaKey, SingingClip *clip) {
+                                   const int deltaKey, SingingClip *clip, Track *track) {
     setTranslatableName("NoteActions", QT_TRANSLATE_NOOP("NoteActions", "Edit note position"));
+    const auto edited = noteSet(notes);
+    addClipExtensionToFit(projectedContentEnd(
+                              clip, [&](const Note *note) {
+                                  return note->localStart() + note->length() +
+                                         (edited.contains(note) ? deltaTick : 0);
+                              }),
+                          clip, track);
     addAction(new EditNotePositionAction(notes, deltaTick, deltaKey, clip));
     setFocusTransition({noteFocus(notes, clip), noteFocus(notes, clip, deltaTick, deltaKey)});
 }
@@ -132,7 +182,7 @@ void NoteActions::splitNote(Note *originalNote, Note *newNote, int newLength, Si
 
 void NoteActions::quantizeNotes(const QList<Note *> &notes,
                                 const QList<QPair<int, int>> &newStartLengths,
-                                SingingClip *clip) {
+                                SingingClip *clip, Track *track) {
     setTranslatableName("NoteActions", QT_TRANSLATE_NOOP("NoteActions", "Quantize notes"));
     QList<QuantizeNotesAction::Change> changes;
     changes.reserve(notes.size());
@@ -148,6 +198,17 @@ void NoteActions::quantizeNotes(const QList<Note *> &notes,
         change.newLength = newStartLengths.at(i).second;
         changes.append(change);
     }
+    QHash<const Note *, QPair<int, int>> projectedGeometry;
+    for (const auto &change : changes)
+        projectedGeometry.insert(change.note, {change.newStart, change.newLength});
+    addClipExtensionToFit(projectedContentEnd(
+                              clip, [&](const Note *note) {
+                                  const auto geometry = projectedGeometry.constFind(note);
+                                  return geometry == projectedGeometry.cend()
+                                             ? note->localStart() + note->length()
+                                             : geometry->first + geometry->second;
+                              }),
+                          clip, track);
     addAction(new QuantizeNotesAction(std::move(changes), clip));
 
     const auto before = noteFocus(notes, clip);

--- a/src/app/Controller/Actions/AppModel/Note/NoteActions.cpp
+++ b/src/app/Controller/Actions/AppModel/Note/NoteActions.cpp
@@ -79,7 +79,7 @@ void NoteActions::addClipExtensionToFit(const int contentEnd, SingingClip *clip,
 
     const auto oldProperties = Clip::ClipCommonProperties(*clip);
     auto newProperties = oldProperties;
-    if (!SingingClipRangeUtils::extendRightToFit(newProperties, appModel->timeline(), contentEnd))
+    if (!SingingClipRangeUtils::extendRightToFit(newProperties, contentEnd))
         return;
 
     addAction(EditSingingClipPropertiesAction::build(oldProperties, newProperties, clip, track));

--- a/src/app/Controller/Actions/AppModel/Note/NoteActions.h
+++ b/src/app/Controller/Actions/AppModel/Note/NoteActions.h
@@ -16,20 +16,19 @@ class NoteActions : public ActionSequence {
     Q_OBJECT
 
 public:
-    void insertNotes(const QList<Note *> &notes, SingingClip *clip);
-    void pasteNotes(const QList<Note *> &notes, SingingClip *clip, Track *track,
-                    const Clip::ClipCommonProperties &newClipProperties);
+    void insertNotes(const QList<Note *> &notes, SingingClip *clip, Track *track);
     void removeNotes(const QList<Note *> &notes, SingingClip *clip);
 
     // Resize from left
-    void editNotesStartAndLength(const QList<Note *> &notes, int delta, SingingClip *clip);
+    void editNotesStartAndLength(const QList<Note *> &notes, int delta, SingingClip *clip,
+                                 Track *track);
 
     // Resize from right
-    void editNotesLength(const QList<Note *> &notes, int delta, SingingClip *clip);
+    void editNotesLength(const QList<Note *> &notes, int delta, SingingClip *clip, Track *track);
 
     // Move notes
     void editNotePosition(const QList<Note *> &notes, int deltaTick, int deltaKey,
-                          SingingClip *clip);
+                          SingingClip *clip, Track *track);
 
     // Edit lyrics, pronunciations and phonemes
     void editNotesWordProperties(const QList<Note *> &notes,
@@ -42,7 +41,11 @@ public:
 
     // Quantize: set absolute start/length values (per-note, not a uniform delta)
     void quantizeNotes(const QList<Note *> &notes,
-                       const QList<QPair<int, int>> &newStartLengths, SingingClip *clip);
+                       const QList<QPair<int, int>> &newStartLengths, SingingClip *clip,
+                       Track *track);
+
+private:
+    void addClipExtensionToFit(int contentEnd, SingingClip *clip, Track *track);
 };
 
 

--- a/src/app/Controller/ClipController.cpp
+++ b/src/app/Controller/ClipController.cpp
@@ -28,6 +28,13 @@
 #include <algorithm>
 #include <limits>
 
+namespace {
+    Track *owningTrack(SingingClip *clip) {
+        Track *track = nullptr;
+        return clip && appModel->findClipById(clip->id(), track) == clip ? track : nullptr;
+    }
+}
+
 ClipController::ClipController(QObject *parent)
     : QObject(parent), d_ptr(new ClipControllerPrivate(this)) {
 }
@@ -117,12 +124,8 @@ void ClipController::pasteNotesWithParams(const NotesParamsInfo &info, int tick)
         newNotes.append(note);
     }
 
-    const auto extendsClip = NotePasteUtils::extendClipToFit(clipProperties, pastePlan.pastedEnd);
     const auto a = new NoteActions;
-    if (extendsClip)
-        a->pasteNotes(newNotes, singingClip, targetTrack, clipProperties);
-    else
-        a->insertNotes(newNotes, singingClip);
+    a->insertNotes(newNotes, singingClip, targetTrack);
     const auto focus = a->focusTransition();
     a->execute();
     historyManager->record(a);
@@ -177,7 +180,7 @@ void ClipController::onInsertNote(Note *note) {
     const auto a = new NoteActions;
     QList<Note *> notes;
     notes.append(note);
-    a->insertNotes(notes, singingClip);
+    a->insertNotes(notes, singingClip, owningTrack(singingClip));
     a->execute();
     historyManager->record(a);
     emit hasSelectedNotesChanged(hasSelectedNotes());
@@ -214,7 +217,8 @@ void ClipController::onMoveNotes(const QList<int> &notesId, const int deltaTick,
     // Do not allow any note to be moved to the left of clip start (tick 0 inside the clip)
     const auto safeDeltaTick = NoteResizeUtils::clampLeftMoveDelta(deltaTick, minLocalStart);
     const auto a = new NoteActions;
-    a->editNotePosition(notesToEdit, safeDeltaTick, deltaKey, singingClip);
+    a->editNotePosition(notesToEdit, safeDeltaTick, deltaKey, singingClip,
+                        owningTrack(singingClip));
     a->execute();
     historyManager->record(a);
 }
@@ -240,7 +244,8 @@ void ClipController::onResizeNotesLeft(const QList<int> &notesId, const int delt
     // Do not resize the left edge past clip start (tick 0 inside the clip)
     safeDeltaTick = NoteResizeUtils::clampLeftMoveDelta(safeDeltaTick, minLocalStart);
     const auto a = new NoteActions;
-    a->editNotesStartAndLength(notesToEdit, safeDeltaTick, singingClip);
+    a->editNotesStartAndLength(notesToEdit, safeDeltaTick, singingClip,
+                               owningTrack(singingClip));
     a->execute();
     historyManager->record(a);
 }
@@ -262,7 +267,7 @@ void ClipController::onResizeNotesRight(const QList<int> &notesId, const int del
         return;
 
     const auto a = new NoteActions;
-    a->editNotesLength(notesToEdit, safeDeltaTick, singingClip);
+    a->editNotesLength(notesToEdit, safeDeltaTick, singingClip, owningTrack(singingClip));
     a->execute();
     historyManager->record(a);
 }
@@ -358,7 +363,7 @@ void ClipController::onQuantizeNotes(const int quantize, const bool quantizeStar
         return;
 
     const auto a = new NoteActions;
-    a->quantizeNotes(notes, newStartLengths, singingClip);
+    a->quantizeNotes(notes, newStartLengths, singingClip, owningTrack(singingClip));
     a->execute();
     historyManager->record(a);
 }

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -187,6 +187,7 @@ PianoRollGraphicsView::~PianoRollGraphicsView() {
 void PianoRollGraphicsView::setDataContext(SingingClip *clip) {
     Q_D(PianoRollGraphicsView);
     d->hideLyricToolTip();
+    setSceneLengthExtension(0);
     // 切换 clip 时清空编辑预览，避免残留到新 clip
     appStatus->pianoRollNoteEditPreview = {};
     appStatus->pianoRollNoteErasePreview = {};
@@ -568,6 +569,18 @@ void PianoRollGraphicsView::onEdgeAutoScrollFrame(const QPoint &clampedViewportP
     if (cancelRequested)
         return;
 
+    const auto behavior = d->m_interactionController->mouseMoveBehavior();
+    const auto noteCanExtendRight =
+        behavior == NoteInteractionController::Move ||
+        behavior == NoteInteractionController::ResizeRight ||
+        dynamic_cast<DrawNoteHandler *>(d->m_currentHandler);
+    const auto hBar = horizontalScrollBar();
+    if (noteCanExtendRight && clampedViewportPos.x() >= viewport()->rect().right() - 1 &&
+        hBar->value() >= hBar->maximum()) {
+        const auto visibleTickSpan = std::max(1, qRound(endTick() - startTick()));
+        setSceneLengthExtension(sceneLengthExtension() + visibleTickSpan);
+    }
+
     if (d->m_interactionController->mouseMoveBehavior() != NoteInteractionController::None &&
         d->m_interactionController->isMouseDown()) {
         updateNoteDragAt(clampedViewportPos, modifiers);
@@ -613,6 +626,7 @@ void PianoRollGraphicsView::mouseReleaseEvent(QMouseEvent *event) {
         if (!cancelRequested) {
             if (d->m_currentHandler->mouseReleaseEvent(event)) {
                 cancelRequested = false;
+                setSceneLengthExtension(0);
                 TimeGraphicsView::mouseReleaseEvent(event);
                 return;
             }
@@ -984,6 +998,7 @@ void PianoRollGraphicsView::discardAction() {
     d->m_pitchEditor->discardAction();
     cancelRequested = true;
     disarmEdgeAutoScroll();
+    setSceneLengthExtension(0);
     if (d->m_currentHandler) {
         d->m_currentHandler->discard();
     }
@@ -1047,6 +1062,7 @@ void PianoRollGraphicsView::commitAction() {
     // model 写入完成后才清空预览，避免轨道先画旧几何再跳变
     appStatus->pianoRollNoteEditPreview = {};
     appStatus->pianoRollNoteErasePreview = {};
+    setSceneLengthExtension(0);
     d->m_interactionController->setMouseMoveBehavior(NoteInteractionController::None);
     d->m_interactionController->setDeltaTick(0);
     d->m_interactionController->setDeltaKey(0);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -273,6 +273,18 @@ public:
                                       std::max(1.0, noteHeight * verticalScale())));
     }
 
+    int effectiveSceneLength() const {
+        return (clip ? clip->length() : 0) + sceneLengthExtension;
+    }
+
+    void setSceneLengthExtension(const int ticks) {
+        const auto extension = std::max(0, ticks);
+        if (sceneLengthExtension == extension)
+            return;
+        sceneLengthExtension = extension;
+        viewport.setContentTickRange(0.0, effectiveSceneLength());
+    }
+
     void setDataContext(SingingClip *newClip) {
         hideLyricToolTip();
         wheel.stop();
@@ -293,7 +305,8 @@ public:
             QObject::disconnect(clip, nullptr, q, nullptr);
 
         clip = newClip;
-        viewport.setContentTickRange(0.0, clip ? clip->length() : 0.0);
+        sceneLengthExtension = 0;
+        viewport.setContentTickRange(0.0, effectiveSceneLength());
         if (clip) {
             QObject::connect(clip, &SingingClip::noteChanged, q, [this] {
                 hideLyricToolTip();
@@ -309,7 +322,7 @@ public:
                                  }
                              });
             QObject::connect(clip, &SingingClip::propertyChanged, q, [this] {
-                viewport.setContentTickRange(0.0, clip->length());
+                viewport.setContentTickRange(0.0, effectiveSceneLength());
                 q->notifyViewportChanged();
                 scheduleSnapshot();
             });
@@ -614,6 +627,16 @@ public:
         const QPointF pointerPosition(q->mapFromGlobal(QCursor::pos()));
         const QRectF viewportRect(QPointF(), q->size());
         const auto step = edgeAutoScroller.computeDragStep(pointerPosition, viewportRect, dtMs);
+        if (step.x() > 0 && (interaction == Interaction::Move ||
+                             interaction == Interaction::ResizeRight ||
+                             interaction == Interaction::Draw)) {
+            const auto maximumOffset =
+                std::max(0.0, viewport.tickToSceneX(effectiveSceneLength()) - q->width());
+            if (viewport.horizontalOffset() >= maximumOffset - 1.0) {
+                const auto visibleTicks = std::max(1, qRound(endTick() - startTick()));
+                setSceneLengthExtension(sceneLengthExtension + visibleTicks);
+            }
+        }
         if (!step.isNull())
             viewport.scrollBy(step);
         continueEdgeDragAt(EdgeAutoScroller::clampToRect(pointerPosition, viewportRect),
@@ -1720,6 +1743,7 @@ public:
     }
 
     void resetNoteInteraction() {
+        setSceneLengthExtension(0);
         interaction = Interaction::None;
         interactionNoteId = -1;
         interactionDeltaTick = 0;
@@ -2111,7 +2135,7 @@ private:
     }
 
     double sceneWidth() const {
-        return clip ? viewport.tickToSceneX(clip->length()) : q->width();
+        return clip ? viewport.tickToSceneX(effectiveSceneLength()) : q->width();
     }
 
     double sceneHeight() const {
@@ -2896,6 +2920,7 @@ public:
     int drawStart = 0;
     int drawEnd = 0;
     int drawKey = 60;
+    int sceneLengthExtension = 0;
     int hoveredKey = -1;
     int splitPreviewNoteId = -1;
     int splitPreviewTick = 0;

--- a/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicer.cpp
+++ b/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicer.cpp
@@ -62,7 +62,7 @@ SliceResult SingingClipSlicer::slice(const Timeline &timeline, const NoteList &s
     auto getTailLength = [=](const Note &note) -> double {
         if (isRestNote(note))
             return 0.0;
-        return SingingClipSlicerGlobal::tailPaddingLengthMax;
+        return padBaseLength;
     };
 
     // Filter out overlapped notes before processing

--- a/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicer.cpp
+++ b/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicer.cpp
@@ -62,7 +62,7 @@ SliceResult SingingClipSlicer::slice(const Timeline &timeline, const NoteList &s
     auto getTailLength = [=](const Note &note) -> double {
         if (isRestNote(note))
             return 0.0;
-        return padBaseLength;
+        return SingingClipSlicerGlobal::tailPaddingLengthMax;
     };
 
     // Filter out overlapped notes before processing

--- a/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicerGlobal.h
+++ b/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicerGlobal.h
@@ -9,6 +9,9 @@ namespace SingingClipSlicerGlobal {
     // 头部填充SP长度基础量(ms)
     constexpr double padBaseLength = 100;
 
+    // 末尾填充SP的最大长度(ms)
+    constexpr double tailPaddingLengthMax = padBaseLength;
+
     // 头部填充SP长度增量基数(ms)
     constexpr double padUnitAdditionalLength = 100;
 }

--- a/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicerGlobal.h
+++ b/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicerGlobal.h
@@ -9,9 +9,6 @@ namespace SingingClipSlicerGlobal {
     // 头部填充SP长度基础量(ms)
     constexpr double padBaseLength = 100;
 
-    // 末尾填充SP的最大长度(ms)
-    constexpr double tailPaddingLengthMax = padBaseLength;
-
     // 头部填充SP长度增量基数(ms)
     constexpr double padUnitAdditionalLength = 100;
 }

--- a/src/libs/ProjectModel/Utils/NotePasteUtils.h
+++ b/src/libs/ProjectModel/Utils/NotePasteUtils.h
@@ -1,7 +1,7 @@
 #ifndef NOTEPASTEUTILS_H
 #define NOTEPASTEUTILS_H
 
-#include <lite/ProjectModel/Utils/ClipResizeUtils.h>
+#include <lite/ProjectModel/AppModel/Clip.h>
 
 #include <algorithm>
 
@@ -35,12 +35,6 @@ namespace NotePasteUtils {
         return {localAnchor, offset, source.end + offset};
     }
 
-    inline bool extendClipToFit(Clip::ClipCommonProperties &target, const int pastedEnd) {
-        if (pastedEnd <= target.clipStart + target.clipLen)
-            return false;
-        return ClipResizeUtils::updateRightEdge(target, pastedEnd - target.clipStart, 1, true,
-                                                std::max(target.length, pastedEnd));
-    }
 }
 
 #endif // NOTEPASTEUTILS_H

--- a/src/libs/ProjectModel/Utils/SingingClipRangeUtils.h
+++ b/src/libs/ProjectModel/Utils/SingingClipRangeUtils.h
@@ -1,0 +1,34 @@
+#ifndef SINGINGCLIPRANGEUTILS_H
+#define SINGINGCLIPRANGEUTILS_H
+
+#include <lite/MusicBase/Timeline.h>
+#include <lite/ProjectModel/AppModel/Clip.h>
+#include <lite/ProjectModel/SingingClipSlicer/SingingClipSlicerGlobal.h>
+#include <lite/ProjectModel/Utils/ClipResizeUtils.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace SingingClipRangeUtils {
+    inline int paddedContentEnd(const Clip::ClipCommonProperties &properties,
+                                const Timeline &timeline, const int contentEnd) {
+        const auto globalContentEnd = properties.start + contentEnd;
+        const auto paddedGlobalEnd = timeline.msToTick(
+            timeline.tickToMs(globalContentEnd) + SingingClipSlicerGlobal::tailPaddingLengthMax);
+        return std::max(contentEnd,
+                        static_cast<int>(std::ceil(paddedGlobalEnd - properties.start)));
+    }
+
+    inline bool extendRightToFit(Clip::ClipCommonProperties &properties,
+                                 const Timeline &timeline, const int contentEnd) {
+        const auto requiredEnd = paddedContentEnd(properties, timeline, contentEnd);
+        if (requiredEnd <= properties.clipStart + properties.clipLen)
+            return false;
+
+        return ClipResizeUtils::updateRightEdge(
+            properties, requiredEnd - properties.clipStart, 1, true,
+            std::max(properties.length, requiredEnd));
+    }
+}
+
+#endif // SINGINGCLIPRANGEUTILS_H

--- a/src/libs/ProjectModel/Utils/SingingClipRangeUtils.h
+++ b/src/libs/ProjectModel/Utils/SingingClipRangeUtils.h
@@ -1,27 +1,19 @@
 #ifndef SINGINGCLIPRANGEUTILS_H
 #define SINGINGCLIPRANGEUTILS_H
 
-#include <lite/MusicBase/Timeline.h>
 #include <lite/ProjectModel/AppModel/Clip.h>
-#include <lite/ProjectModel/SingingClipSlicer/SingingClipSlicerGlobal.h>
 #include <lite/ProjectModel/Utils/ClipResizeUtils.h>
 
-#include <algorithm>
-#include <cmath>
-
 namespace SingingClipRangeUtils {
-    inline int paddedContentEnd(const Clip::ClipCommonProperties &properties,
-                                const Timeline &timeline, const int contentEnd) {
-        const auto globalContentEnd = properties.start + contentEnd;
-        const auto paddedGlobalEnd = timeline.msToTick(
-            timeline.tickToMs(globalContentEnd) + SingingClipSlicerGlobal::tailPaddingLengthMax);
-        return std::max(contentEnd,
-                        static_cast<int>(std::ceil(paddedGlobalEnd - properties.start)));
+    // 剪辑右侧为音符编辑保留的固定安全余量（tick）。
+    constexpr int tailPaddingTicks = 120;
+
+    inline int paddedContentEnd(const int contentEnd) {
+        return contentEnd + tailPaddingTicks;
     }
 
-    inline bool extendRightToFit(Clip::ClipCommonProperties &properties,
-                                 const Timeline &timeline, const int contentEnd) {
-        const auto requiredEnd = paddedContentEnd(properties, timeline, contentEnd);
+    inline bool extendRightToFit(Clip::ClipCommonProperties &properties, const int contentEnd) {
+        const auto requiredEnd = paddedContentEnd(contentEnd);
         if (requiredEnd <= properties.clipStart + properties.clipLen)
             return false;
 

--- a/src/tests/TestTrackEditorInteractions/main.cpp
+++ b/src/tests/TestTrackEditorInteractions/main.cpp
@@ -1,6 +1,7 @@
 #include "UI/Views/TrackEditor/AudioClipDragState.h"
 #include <lite/ProjectModel/Utils/ClipResizeUtils.h>
 #include <lite/ProjectModel/Utils/NotePasteUtils.h>
+#include <lite/ProjectModel/Utils/SingingClipRangeUtils.h>
 #include "UI/Views/TrackEditor/SingingClipPreviewLayout.h"
 #include "UI/Views/Common/EditorResizeUtils.h"
 #include "UI/Views/Common/EditorSelectionUtils.h"
@@ -49,6 +50,12 @@ int main(int argc, char *argv[]) {
                EditorSelectionUtils::selectionForPress({1}, 1, true).isEmpty(),
            "toggle presses must add or remove the target clip");
 
+    const Timeline timeline({
+        {0,    120.0},
+        {4800, 60.0 },
+        {9600, 150.0},
+    });
+
     Clip::ClipCommonProperties singing;
     singing.length = 1920;
     singing.clipStart = 120;
@@ -77,10 +84,39 @@ int main(int argc, char *argv[]) {
            "pasting inside the visible range must use the snapped playback position");
     const auto overrunsVisibleRange =
         NotePasteUtils::plan(pasteTarget, 2020, 2040, copiedBounds);
+    const auto paddedPasteEnd =
+        SingingClipRangeUtils::paddedContentEnd(pasteTarget, timeline,
+                                                overrunsVisibleRange.pastedEnd);
     expect(overrunsVisibleRange.pastedEnd == 1560 &&
-               NotePasteUtils::extendClipToFit(pasteTarget, overrunsVisibleRange.pastedEnd) &&
-               pasteTarget.clipLen == 1320 && pasteTarget.length == 1560,
-           "pasting beyond the visible right edge must extend both clip ranges to the note end");
+               SingingClipRangeUtils::extendRightToFit(pasteTarget, timeline,
+                                                       overrunsVisibleRange.pastedEnd) &&
+               pasteTarget.clipStart + pasteTarget.clipLen == paddedPasteEnd &&
+               pasteTarget.length == paddedPasteEnd,
+           "inserting beyond the visible right edge must extend both clip ranges with tail room");
+    const auto extendedPasteTarget = pasteTarget;
+    expect(!SingingClipRangeUtils::extendRightToFit(pasteTarget, timeline,
+                                                    overrunsVisibleRange.pastedEnd) &&
+               pasteTarget.clipLen == extendedPasteTarget.clipLen &&
+               pasteTarget.length == extendedPasteTarget.length,
+           "an existing tail margin must not grow again for unchanged note geometry");
+
+    Clip::ClipCommonProperties manuallyTrimmed;
+    manuallyTrimmed.start = 4000;
+    manuallyTrimmed.clipStart = 200;
+    manuallyTrimmed.clipLen = 600;
+    manuallyTrimmed.length = 1200;
+    constexpr int touchingContentEnd = 800;
+    const auto paddedTouchingEnd =
+        SingingClipRangeUtils::paddedContentEnd(manuallyTrimmed, timeline, touchingContentEnd);
+    expect(SingingClipRangeUtils::extendRightToFit(manuallyTrimmed, timeline,
+                                                   touchingContentEnd) &&
+               manuallyTrimmed.clipStart + manuallyTrimmed.clipLen == paddedTouchingEnd &&
+               manuallyTrimmed.length == 1200,
+           "editing a note touching a manually trimmed edge must restore the tail margin");
+    const auto contentEndMs = timeline.tickToMs(4000 + touchingContentEnd);
+    const auto paddedEndMs = timeline.tickToMs(4000 + paddedTouchingEnd);
+    expect(paddedEndMs - contentEndMs >= SingingClipSlicerGlobal::tailPaddingLengthMax,
+           "adaptive clip room must cover the slicer's maximum tail padding in realtime");
 
     Clip::ClipCommonProperties leftResize;
     leftResize.start = 100;
@@ -189,11 +225,6 @@ int main(int argc, char *argv[]) {
     expect(SingingClipPreview::projectNotes(modelNotes, false, editedNotes, {3}) == modelNotes,
            "piano-roll edits must not leak into inactive clip previews");
 
-    const Timeline timeline({
-        {0,    120.0},
-        {4800, 60.0 },
-        {9600, 150.0},
-    });
     constexpr double trimStartMs = 500.0;
     constexpr double playLengthMs = 2500.0;
     constexpr double materialLengthMs = 5000.0;

--- a/src/tests/TestTrackEditorInteractions/main.cpp
+++ b/src/tests/TestTrackEditorInteractions/main.cpp
@@ -85,16 +85,15 @@ int main(int argc, char *argv[]) {
     const auto overrunsVisibleRange =
         NotePasteUtils::plan(pasteTarget, 2020, 2040, copiedBounds);
     const auto paddedPasteEnd =
-        SingingClipRangeUtils::paddedContentEnd(pasteTarget, timeline,
-                                                overrunsVisibleRange.pastedEnd);
+        SingingClipRangeUtils::paddedContentEnd(overrunsVisibleRange.pastedEnd);
     expect(overrunsVisibleRange.pastedEnd == 1560 &&
-               SingingClipRangeUtils::extendRightToFit(pasteTarget, timeline,
+               SingingClipRangeUtils::extendRightToFit(pasteTarget,
                                                        overrunsVisibleRange.pastedEnd) &&
                pasteTarget.clipStart + pasteTarget.clipLen == paddedPasteEnd &&
                pasteTarget.length == paddedPasteEnd,
            "inserting beyond the visible right edge must extend both clip ranges with tail room");
     const auto extendedPasteTarget = pasteTarget;
-    expect(!SingingClipRangeUtils::extendRightToFit(pasteTarget, timeline,
+    expect(!SingingClipRangeUtils::extendRightToFit(pasteTarget,
                                                     overrunsVisibleRange.pastedEnd) &&
                pasteTarget.clipLen == extendedPasteTarget.clipLen &&
                pasteTarget.length == extendedPasteTarget.length,
@@ -106,17 +105,13 @@ int main(int argc, char *argv[]) {
     manuallyTrimmed.clipLen = 600;
     manuallyTrimmed.length = 1200;
     constexpr int touchingContentEnd = 800;
-    const auto paddedTouchingEnd =
-        SingingClipRangeUtils::paddedContentEnd(manuallyTrimmed, timeline, touchingContentEnd);
-    expect(SingingClipRangeUtils::extendRightToFit(manuallyTrimmed, timeline,
-                                                   touchingContentEnd) &&
+    const auto paddedTouchingEnd = SingingClipRangeUtils::paddedContentEnd(touchingContentEnd);
+    expect(SingingClipRangeUtils::extendRightToFit(manuallyTrimmed, touchingContentEnd) &&
                manuallyTrimmed.clipStart + manuallyTrimmed.clipLen == paddedTouchingEnd &&
                manuallyTrimmed.length == 1200,
            "editing a note touching a manually trimmed edge must restore the tail margin");
-    const auto contentEndMs = timeline.tickToMs(4000 + touchingContentEnd);
-    const auto paddedEndMs = timeline.tickToMs(4000 + paddedTouchingEnd);
-    expect(paddedEndMs - contentEndMs >= SingingClipSlicerGlobal::tailPaddingLengthMax,
-           "adaptive clip room must cover the slicer's maximum tail padding in realtime");
+    expect(paddedTouchingEnd - touchingContentEnd == SingingClipRangeUtils::tailPaddingTicks,
+           "adaptive clip room must use the fixed tick padding");
 
     Clip::ClipCommonProperties leftResize;
     leftResize.start = 100;


### PR DESCRIPTION
## What
- extend singing clip right edges when notes are drawn, pasted, moved, resized, or quantized near the boundary
- preserve a fixed 120-tick safety margin after the furthest note
- keep right-edge drag interactions scrolling naturally in both classic and RHI piano rolls
- restore the margin on the next note move/resize after a legacy project or manual trim leaves notes touching or crossing the boundary

## Why
The clip right edge acted as a hard obstacle during note editing. Besides blocking direct manipulation, one-off paste growth did not cover drawing, movement, resizing, quantization, or manually trimmed/legacy projects.

## Impact
The left boundary remains hard, preventing negative note coordinates. Right-edge expansion is atomic with the note edit and undoable; manual clip shrinking is still allowed until the next affected note edit. The safety margin is fixed in tick space, so tempo changes or clip relocation do not alter its geometric size.

## Checks
- `TestTrackEditorInteractions.exe`
- debug `DsEditorLite` target built with the project CMake preset script
- Computer Use GUI smoke test with Charlie: draw, resize, move, manual right-edge trim, recovery move, synthesis waveform/pitch/phoneme, save, and playback
- follow-up Computer Use fixed-padding regression: resize through the prior right edge and inspect the saved DSPX (`clipEnd=7920`, furthest note end `7800`, padding `120` ticks)