### PR TITLE
fix(anchor): remove incomplete anchor curves

### DIFF
--- a/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.cpp
+++ b/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.cpp
@@ -1,4 +1,5 @@
 #include "AnchorEditController.h"
+#include "AnchorEditUtils.h"
 
 #include <QHash>
 #include <QSet>
@@ -45,6 +46,7 @@ namespace AnchorEditor {
         if (m_mutationActive)
             discardMutation();
         clearInteractionState(true);
+        m_provisionalCurve = nullptr;
         replaceOwnedCurves(curves, m_curves);
         m_state.visibleCurves = m_curves;
         notifyCurvesChanged();
@@ -74,7 +76,7 @@ namespace AnchorEditor {
                 if (m_state.showMergePreview && node == m_state.mergeEndpointNode) {
                     if (beginMutation()) {
                         mergeCurves(m_state.mergeCandidateCurve);
-                        commitMutation();
+                        commitMutationIfReady();
                         notifyCurvesChanged();
                     }
                 } else {
@@ -88,7 +90,7 @@ namespace AnchorEditor {
                 createAnchorAt(scenePos);
                 m_state.dragStartScenePos = scenePos;
                 m_state.dragging = false;
-                commitMutation();
+                commitMutationIfReady();
                 notifyCurvesChanged();
             }
         } else if (node) {
@@ -150,12 +152,12 @@ namespace AnchorEditor {
                 removeOverlappingNodes(finalCurve, info.node);
             }
             for (auto *curve : sourcesToCleanup)
-                cleanupEmptyCurve(curve);
+                cleanupIncompleteCurve(curve);
             if (!m_state.selectedNodes.isEmpty())
                 m_state.currentCurve = findOwnerCurve(m_state.selectedNodes.first());
             m_state.dragNodeInfos.clear();
             updatePreview(scenePos);
-            commitMutation();
+            commitMutationIfReady();
             notifyChanged();
             return true;
         }
@@ -189,7 +191,7 @@ namespace AnchorEditor {
             createAnchorAt(scenePos);
             m_state.dragStartScenePos = scenePos;
             m_state.dragging = false;
-            commitMutation();
+            commitMutationIfReady();
             notifyCurvesChanged();
         }
     }
@@ -308,7 +310,7 @@ namespace AnchorEditor {
             if (!nodes.isEmpty() && nodes.last() != node)
                 node->setInterpMode(mode);
         }
-        commitMutation();
+        commitMutationIfReady();
         notifyCurvesChanged();
     }
 
@@ -321,18 +323,27 @@ namespace AnchorEditor {
             if (auto *curve = findOwnerCurve(node))
                 nodesByCurve[curve].append(node);
         }
+        const bool discardingOnlyProvisional =
+            m_provisionalCurve && nodesByCurve.size() == 1 &&
+            nodesByCurve.contains(m_provisionalCurve);
         clearSelection();
         for (auto it = nodesByCurve.begin(); it != nodesByCurve.end(); ++it) {
             auto *curve = it.key();
             for (auto *node : it.value()) {
                 curve->removeNode(node);
+                if (m_state.hoveredNode == node)
+                    m_state.hoveredNode = nullptr;
                 delete node;
             }
             const auto remaining = curve->nodes().toList();
-            if (remaining.isEmpty()) {
+            if (remaining.size() < 2) {
                 m_curves.removeOne(curve);
                 if (m_state.currentCurve == curve)
                     m_state.currentCurve = nullptr;
+                if (m_state.hoveredNode && remaining.contains(m_state.hoveredNode))
+                    m_state.hoveredNode = nullptr;
+                if (m_provisionalCurve == curve)
+                    m_provisionalCurve = nullptr;
                 delete curve;
             } else {
                 remaining.last()->setInterpMode(AnchorNode::None);
@@ -340,7 +351,12 @@ namespace AnchorEditor {
         }
         if (!m_state.currentCurve)
             exitEditingState();
-        commitMutation();
+        if (discardingOnlyProvisional) {
+            discardMutation();
+            notifyChanged();
+            return;
+        }
+        commitMutationIfReady();
         notifyCurvesChanged();
     }
 
@@ -432,12 +448,19 @@ namespace AnchorEditor {
         }
     }
 
-    void AnchorEditController::cleanupEmptyCurve(AnchorCurve *curve) {
-        if (!curve || !curve->nodes().toList().isEmpty())
+    void AnchorEditController::cleanupIncompleteCurve(AnchorCurve *curve) {
+        if (!curve || AnchorEditor::isCompleteAnchorCurve(curve))
             return;
         m_curves.removeOne(curve);
         if (m_state.currentCurve == curve)
             m_state.currentCurve = nullptr;
+        for (auto *node : curve->nodes().toList()) {
+            m_state.selectedNodes.removeOne(node);
+            if (m_state.hoveredNode == node)
+                m_state.hoveredNode = nullptr;
+        }
+        if (m_provisionalCurve == curve)
+            m_provisionalCurve = nullptr;
         delete curve;
         if (!m_state.currentCurve)
             exitEditingState();
@@ -485,7 +508,8 @@ namespace AnchorEditor {
         } else {
             curve = anchorCurveAt(tick);
         }
-        if (!curve) {
+        const bool createdCurve = !curve;
+        if (createdCurve) {
             curve = new AnchorCurve;
             m_curves.append(curve);
         }
@@ -522,6 +546,10 @@ namespace AnchorEditor {
             node->setInterpMode(mode);
         }
         curve->insertNode(node);
+        if (createdCurve)
+            m_provisionalCurve = curve;
+        if (m_provisionalCurve == curve && AnchorEditor::isCompleteAnchorCurve(curve))
+            m_provisionalCurve = nullptr;
         enterEditingState(curve, node);
         m_state.hoveredNode = node;
         m_state.showPreview = false;
@@ -644,9 +672,20 @@ namespace AnchorEditor {
         return true;
     }
 
+    void AnchorEditController::commitMutationIfReady() {
+        if (m_provisionalCurve) {
+            if (!AnchorEditor::isCompleteAnchorCurve(m_provisionalCurve))
+                return;
+            m_provisionalCurve = nullptr;
+        }
+        commitMutation();
+    }
+
     void AnchorEditController::commitMutation() {
         if (!m_mutationActive)
             return;
+        removeIncompleteCurves();
+        m_provisionalCurve = nullptr;
         m_state.visibleCurves = m_curves;
         m_publishing = true;
         if (m_callbacks.publish)
@@ -666,10 +705,17 @@ namespace AnchorEditor {
         m_curves = m_backupCurves;
         m_backupCurves.clear();
         m_mutationActive = false;
+        m_provisionalCurve = nullptr;
         m_state.visibleCurves = m_curves;
         ++m_curveRevision;
         if (m_callbacks.finishEdit)
             m_callbacks.finishEdit(EditFinishReason::Discard);
+    }
+
+    void AnchorEditController::removeIncompleteCurves() {
+        const auto curves = m_curves;
+        for (auto *curve : curves)
+            cleanupIncompleteCurve(curve);
     }
 
     void AnchorEditController::clearInteractionState(const bool leaveEditing) {
@@ -704,7 +750,7 @@ namespace AnchorEditor {
         destination.clear();
         destination.reserve(source.size());
         for (const auto *curve : source) {
-            if (curve)
+            if (AnchorEditor::isCompleteAnchorCurve(curve))
                 destination.append(new AnchorCurve(*curve));
         }
     }

--- a/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.cpp
+++ b/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.cpp
@@ -489,6 +489,7 @@ namespace AnchorEditor {
         m_state.mergeCandidateCurve = nullptr;
         m_state.mergeEndpointNode = nullptr;
         delete curve;
+        ++m_curveRevision;
     }
 
     void AnchorEditController::enterEditingState(AnchorCurve *curve, AnchorNode *node) {

--- a/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.cpp
+++ b/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.cpp
@@ -451,6 +451,12 @@ namespace AnchorEditor {
     void AnchorEditController::cleanupIncompleteCurve(AnchorCurve *curve) {
         if (!curve || AnchorEditor::isCompleteAnchorCurve(curve))
             return;
+        if (curve == m_provisionalCurve) {
+            discardProvisionalCurve();
+            if (!m_state.currentCurve)
+                exitEditingState();
+            return;
+        }
         m_curves.removeOne(curve);
         if (m_state.currentCurve == curve)
             m_state.currentCurve = nullptr;
@@ -459,11 +465,30 @@ namespace AnchorEditor {
             if (m_state.hoveredNode == node)
                 m_state.hoveredNode = nullptr;
         }
-        if (m_provisionalCurve == curve)
-            m_provisionalCurve = nullptr;
         delete curve;
         if (!m_state.currentCurve)
             exitEditingState();
+    }
+
+    void AnchorEditController::discardProvisionalCurve() {
+        auto *curve = m_provisionalCurve;
+        if (!curve)
+            return;
+        m_provisionalCurve = nullptr;
+        m_curves.removeOne(curve);
+        if (m_state.currentCurve == curve)
+            m_state.currentCurve = nullptr;
+        for (auto *node : curve->nodes().toList()) {
+            m_state.selectedNodes.removeOne(node);
+            if (m_state.hoveredNode == node)
+                m_state.hoveredNode = nullptr;
+        }
+        m_state.showPreview = false;
+        m_state.previewCurve = nullptr;
+        m_state.showMergePreview = false;
+        m_state.mergeCandidateCurve = nullptr;
+        m_state.mergeEndpointNode = nullptr;
+        delete curve;
     }
 
     void AnchorEditController::enterEditingState(AnchorCurve *curve, AnchorNode *node) {
@@ -485,8 +510,11 @@ namespace AnchorEditor {
     }
 
     void AnchorEditController::selectNode(AnchorNode *node) {
+        auto *owner = findOwnerCurve(node);
+        if (m_provisionalCurve && owner != m_provisionalCurve)
+            discardProvisionalCurve();
         m_state.selectedNodes = {node};
-        m_state.currentCurve = findOwnerCurve(node);
+        m_state.currentCurve = owner;
     }
 
     void AnchorEditController::clearSelection() {
@@ -508,6 +536,8 @@ namespace AnchorEditor {
         } else {
             curve = anchorCurveAt(tick);
         }
+        if (m_provisionalCurve && curve != m_provisionalCurve)
+            discardProvisionalCurve();
         const bool createdCurve = !curve;
         if (createdCurve) {
             curve = new AnchorCurve;

--- a/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.h
+++ b/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.h
@@ -114,6 +114,7 @@ namespace AnchorEditor {
                                                         AnchorNode *exclude = nullptr);
         void removeOverlappingNodes(AnchorCurve *curve, AnchorNode *keep);
         void cleanupIncompleteCurve(AnchorCurve *curve);
+        void discardProvisionalCurve();
 
         void enterEditingState(AnchorCurve *curve, AnchorNode *node = nullptr);
         void exitEditingState();

--- a/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.h
+++ b/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditController.h
@@ -113,7 +113,7 @@ namespace AnchorEditor {
         [[nodiscard]] static AnchorNode *findNodeAtTick(AnchorCurve *curve, int tick,
                                                         AnchorNode *exclude = nullptr);
         void removeOverlappingNodes(AnchorCurve *curve, AnchorNode *keep);
-        void cleanupEmptyCurve(AnchorCurve *curve);
+        void cleanupIncompleteCurve(AnchorCurve *curve);
 
         void enterEditingState(AnchorCurve *curve, AnchorNode *node = nullptr);
         void exitEditingState();
@@ -127,8 +127,10 @@ namespace AnchorEditor {
         void updateSelectionRectAt(const QPointF &scenePos);
 
         bool beginMutation();
+        void commitMutationIfReady();
         void commitMutation();
         void discardMutation();
+        void removeIncompleteCurves();
         void clearInteractionState(bool leaveEditing);
         void notifyChanged();
         void notifyCurvesChanged();
@@ -140,6 +142,7 @@ namespace AnchorEditor {
         AnchorOverlayState m_state;
         QList<AnchorCurve *> m_curves;
         QList<AnchorCurve *> m_backupCurves;
+        AnchorCurve *m_provisionalCurve = nullptr;
         bool m_mutationActive = false;
         bool m_publishing = false;
         quint64 m_curveRevision = 0;

--- a/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.cpp
+++ b/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.cpp
@@ -4,6 +4,10 @@
 #include <lite/ProjectModel/AppModel/Curve.h>
 #include <lite/ProjectModel/AppModel/DrawCurve.h>
 
+bool AnchorEditor::isCompleteAnchorCurve(const AnchorCurve *curve) {
+    return curve && curve->nodes().toList().size() >= 2;
+}
+
 QList<Curve *> AnchorEditor::replaceAnchors(const QList<Curve *> &existing,
                                             const QList<AnchorCurve *> &replacementAnchors) {
     QList<Curve *> result;
@@ -12,7 +16,7 @@ QList<Curve *> AnchorEditor::replaceAnchors(const QList<Curve *> &existing,
             result.append(new DrawCurve(*static_cast<const DrawCurve *>(curve)));
     }
     for (const auto *curve : replacementAnchors) {
-        if (curve)
+        if (isCompleteAnchorCurve(curve))
             result.append(new AnchorCurve(*curve));
     }
     return result;
@@ -26,8 +30,11 @@ QList<Curve *> AnchorEditor::replaceDrawCurves(const QList<Curve *> &existing,
             result.append(new DrawCurve(*curve));
     }
     for (const auto *curve : existing) {
-        if (curve && curve->type() == Curve::Anchor)
-            result.append(new AnchorCurve(*static_cast<const AnchorCurve *>(curve)));
+        if (curve && curve->type() == Curve::Anchor) {
+            const auto *anchor = static_cast<const AnchorCurve *>(curve);
+            if (isCompleteAnchorCurve(anchor))
+                result.append(new AnchorCurve(*anchor));
+        }
     }
     return result;
 }

--- a/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.h
+++ b/src/app/UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.h
@@ -8,6 +8,7 @@ class Curve;
 class DrawCurve;
 
 namespace AnchorEditor {
+    [[nodiscard]] bool isCompleteAnchorCurve(const AnchorCurve *curve);
     [[nodiscard]] QList<Curve *> replaceAnchors(const QList<Curve *> &existing,
                                                 const QList<AnchorCurve *> &replacementAnchors);
     [[nodiscard]] QList<Curve *> replaceDrawCurves(const QList<Curve *> &existing,

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -15,6 +15,7 @@
 #include "UI/Utils/AppColorPalette.h"
 #include "UI/Utils/ITimelinePainter.h"
 #include "UI/Views/ClipEditor/AnchorEditor/AnchorEditController.h"
+#include "UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.h"
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
 #include "UI/Views/ClipEditor/CurveRenderUtils.h"
 #include "UI/Views/Common/AutoPageTurnUtils.h"
@@ -1195,6 +1196,7 @@ public:
         anchorSelecting = false;
         anchorCursorInView = true;
         currentAnchorCurve = nullptr;
+        provisionalAnchorCurve = nullptr;
         selectedAnchorNodes.clear();
         hoveredAnchorNode = nullptr;
         anchorDragInfos.clear();
@@ -1217,8 +1219,11 @@ public:
         if (!pitch)
             return;
         for (const auto *curve : pitch->curves(Param::Edited)) {
-            if (curve->type() == Curve::Anchor)
-                anchorCurves.append(new AnchorCurve(*static_cast<const AnchorCurve *>(curve)));
+            if (curve->type() == Curve::Anchor) {
+                const auto *anchor = static_cast<const AnchorCurve *>(curve);
+                if (AnchorEditor::isCompleteAnchorCurve(anchor))
+                    anchorCurves.append(new AnchorCurve(*anchor));
+            }
         }
     }
 
@@ -1319,15 +1324,32 @@ public:
         clearAnchorSelection();
     }
 
-    void cleanupEmptyAnchorCurve(AnchorCurve *curve) {
-        if (!curve || !curve->nodes().toList().isEmpty())
+    void cleanupIncompleteAnchorCurve(AnchorCurve *curve) {
+        if (!curve || AnchorEditor::isCompleteAnchorCurve(curve))
             return;
         anchorCurves.removeOne(curve);
         if (currentAnchorCurve == curve)
             currentAnchorCurve = nullptr;
+        for (auto *node : curve->nodes().toList()) {
+            selectedAnchorNodes.removeOne(node);
+            if (hoveredAnchorNode == node)
+                hoveredAnchorNode = nullptr;
+        }
+        if (anchorPreviewCurve == curve)
+            anchorPreviewCurve = nullptr;
+        if (anchorMergeCandidateCurve == curve)
+            anchorMergeCandidateCurve = nullptr;
+        if (provisionalAnchorCurve == curve)
+            provisionalAnchorCurve = nullptr;
         delete curve;
         if (!currentAnchorCurve)
             exitAnchorEditing();
+    }
+
+    void cleanupIncompleteAnchorCurves() {
+        const auto curves = anchorCurves;
+        for (auto *curve : curves)
+            cleanupIncompleteAnchorCurve(curve);
     }
 
     void removeOverlappingAnchorNodes(AnchorCurve *curve, AnchorNode *keep) {
@@ -1350,6 +1372,14 @@ public:
     void commitAnchorEdit() {
         if (!clip)
             return;
+        if (provisionalAnchorCurve) {
+            if (!AnchorEditor::isCompleteAnchorCurve(provisionalAnchorCurve)) {
+                scheduleSnapshot();
+                return;
+            }
+            provisionalAnchorCurve = nullptr;
+        }
+        cleanupIncompleteAnchorCurves();
         beginAnchorEditSession();
 
         QList<Curve *> combined;
@@ -1384,7 +1414,8 @@ public:
         } else {
             curve = anchorCurveAt(point.x());
         }
-        if (!curve) {
+        const bool createdCurve = !curve;
+        if (createdCurve) {
             curve = new AnchorCurve;
             anchorCurves.append(curve);
         }
@@ -1418,6 +1449,10 @@ public:
             node->setInterpMode(mode);
         }
         curve->insertNode(node);
+        if (createdCurve)
+            provisionalAnchorCurve = curve;
+        if (provisionalAnchorCurve == curve && AnchorEditor::isCompleteAnchorCurve(curve))
+            provisionalAnchorCurve = nullptr;
         enterAnchorEditing(curve, node);
         commitAnchorEdit();
     }
@@ -1430,22 +1465,28 @@ public:
             if (auto *curve = findAnchorOwner(node))
                 byCurve[curve].append(node);
         }
+        const bool discardingOnlyProvisional =
+            provisionalAnchorCurve && byCurve.size() == 1 &&
+            byCurve.contains(provisionalAnchorCurve);
+        if (discardingOnlyProvisional) {
+            loadAnchorCurvesFromModel();
+            scheduleSnapshot();
+            return;
+        }
         clearAnchorSelection();
         for (auto it = byCurve.begin(); it != byCurve.end(); ++it) {
             auto *curve = it.key();
             for (auto *node : it.value()) {
                 curve->removeNode(node);
+                if (hoveredAnchorNode == node)
+                    hoveredAnchorNode = nullptr;
                 delete node;
             }
             const auto remaining = curve->nodes().toList();
-            if (remaining.isEmpty()) {
-                anchorCurves.removeOne(curve);
-                if (currentAnchorCurve == curve)
-                    currentAnchorCurve = nullptr;
-                delete curve;
-            } else {
+            if (remaining.size() < 2)
+                cleanupIncompleteAnchorCurve(curve);
+            else
                 remaining.last()->setInterpMode(AnchorNode::None);
-            }
         }
         if (!currentAnchorCurve)
             exitAnchorEditing();
@@ -1631,7 +1672,7 @@ public:
                 removeOverlappingAnchorNodes(finalCurve, info.node);
             }
             for (auto *curve : sourcesToCleanup)
-                cleanupEmptyAnchorCurve(curve);
+                cleanupIncompleteAnchorCurve(curve);
             if (!selectedAnchorNodes.isEmpty())
                 currentAnchorCurve = findAnchorOwner(selectedAnchorNodes.first());
             anchorDragInfos.clear();
@@ -1652,12 +1693,18 @@ public:
             }
             anchorSelectionRect = {};
         }
-        finishAnchorEditSession(EditSessionEndReason::Discard);
+        if (!provisionalAnchorCurve)
+            finishAnchorEditSession(EditSessionEndReason::Discard);
         scheduleSnapshot();
     }
 
     bool keyPressAnchor(QKeyEvent *event) {
         if (event->key() == Qt::Key_Escape && anchorEditing) {
+            if (provisionalAnchorCurve) {
+                loadAnchorCurvesFromModel();
+                scheduleSnapshot();
+                return true;
+            }
             if (anchorDragging)
                 loadAnchorCurvesFromModel();
             else
@@ -2920,6 +2967,7 @@ public:
     QList<AnchorCurve *> anchorCurves;
     quint64 anchorEditSessionId = 0;
     bool anchorCommitting = false;
+    AnchorCurve *provisionalAnchorCurve = nullptr;
     bool anchorEditing = false;
     bool anchorDragging = false;
     bool anchorSelecting = false;
@@ -3289,7 +3337,10 @@ void PianoRollRhiWidget::contextMenuEvent(QContextMenuEvent *event) {
         auto *node = d->anchorNodeAt(event->pos());
         if (!node) {
             if (d->anchorEditing) {
-                d->exitAnchorEditing();
+                if (d->provisionalAnchorCurve)
+                    d->loadAnchorCurvesFromModel();
+                else
+                    d->exitAnchorEditing();
                 d->scheduleSnapshot();
             }
             event->accept();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -1305,8 +1305,11 @@ public:
     }
 
     void selectAnchorNode(AnchorNode *node) {
+        auto *owner = findAnchorOwner(node);
+        if (provisionalAnchorCurve && owner != provisionalAnchorCurve)
+            discardProvisionalAnchorCurve();
         selectedAnchorNodes = {node};
-        currentAnchorCurve = findAnchorOwner(node);
+        currentAnchorCurve = owner;
     }
 
     void enterAnchorEditing(AnchorCurve *curve, AnchorNode *node = nullptr) {
@@ -1327,6 +1330,12 @@ public:
     void cleanupIncompleteAnchorCurve(AnchorCurve *curve) {
         if (!curve || AnchorEditor::isCompleteAnchorCurve(curve))
             return;
+        if (curve == provisionalAnchorCurve) {
+            discardProvisionalAnchorCurve();
+            if (!currentAnchorCurve)
+                exitAnchorEditing();
+            return;
+        }
         anchorCurves.removeOne(curve);
         if (currentAnchorCurve == curve)
             currentAnchorCurve = nullptr;
@@ -1339,11 +1348,30 @@ public:
             anchorPreviewCurve = nullptr;
         if (anchorMergeCandidateCurve == curve)
             anchorMergeCandidateCurve = nullptr;
-        if (provisionalAnchorCurve == curve)
-            provisionalAnchorCurve = nullptr;
         delete curve;
         if (!currentAnchorCurve)
             exitAnchorEditing();
+    }
+
+    void discardProvisionalAnchorCurve() {
+        auto *curve = provisionalAnchorCurve;
+        if (!curve)
+            return;
+        provisionalAnchorCurve = nullptr;
+        anchorCurves.removeOne(curve);
+        if (currentAnchorCurve == curve)
+            currentAnchorCurve = nullptr;
+        for (auto *node : curve->nodes().toList()) {
+            selectedAnchorNodes.removeOne(node);
+            if (hoveredAnchorNode == node)
+                hoveredAnchorNode = nullptr;
+        }
+        showAnchorPreview = false;
+        anchorPreviewCurve = nullptr;
+        showAnchorMergePreview = false;
+        anchorMergeCandidateCurve = nullptr;
+        anchorMergeEndpointNode = nullptr;
+        delete curve;
     }
 
     void cleanupIncompleteAnchorCurves() {
@@ -1414,6 +1442,8 @@ public:
         } else {
             curve = anchorCurveAt(point.x());
         }
+        if (provisionalAnchorCurve && curve != provisionalAnchorCurve)
+            discardProvisionalAnchorCurve();
         const bool createdCurve = !curve;
         if (createdCurve) {
             curve = new AnchorCurve;

--- a/src/tests/TestAnchorEditController/main.cpp
+++ b/src/tests/TestAnchorEditController/main.cpp
@@ -239,7 +239,10 @@ namespace {
         selectionController.loadFromModel({source});
         selectionController.setEditActive(true);
         selectionController.doubleClickAt({100, 800}, Qt::LeftButton);
+        const auto provisionalRevision = selectionController.curveRevision();
         selectionController.pressAt({300, 800}, Qt::LeftButton);
+        expect(selectionController.curveRevision() > provisionalRevision,
+               "discarding a provisional curve must invalidate rendered curve state");
         selectionController.setSelectedInterpolation(AnchorNode::Linear);
         expect(selectionController.curves().size() == 1 && selectionPublishes == 1,
                "switching to an existing curve must discard the provisional curve and commit");

--- a/src/tests/TestAnchorEditController/main.cpp
+++ b/src/tests/TestAnchorEditController/main.cpp
@@ -73,12 +73,55 @@ namespace {
         });
         controller.setEditActive(true);
         controller.doubleClickAt({100, 800}, Qt::LeftButton);
-        expect(begins == 1 && commits == 1, "create must be one transaction");
+        expect(begins == 1 && commits == 0,
+               "the first anchor must stay provisional until it forms a curve");
+        controller.doubleClickAt({200, 600}, Qt::LeftButton);
+        expect(begins == 1 && commits == 1,
+               "the second anchor must commit the provisional transaction");
         expect(controller.curves().size() == 1, "reentrant load must be ignored while publishing");
         if (controller.curves().isEmpty())
             return;
         expect(controller.curves().first()->nodes().toList().first()->pos() == 10,
                "created anchor tick must use mapper");
+        expect(controller.curves().first()->nodes().toList().size() == 2,
+               "the committed anchor curve must contain both nodes");
+    }
+
+    void testProvisionalAnchorExitDiscardsWithoutPublishing() {
+        AnchorEditor::AnchorEditController controller;
+        controller.setCoordinateMapper(mapper());
+        int begins = 0;
+        int publishes = 0;
+        int discards = 0;
+        controller.setHostCallbacks({
+            [&] {
+                ++begins;
+                return true;
+            },
+            [&](const QList<AnchorCurve *> &) { ++publishes; },
+            [&](const AnchorEditor::EditFinishReason reason) {
+                if (reason == AnchorEditor::EditFinishReason::Discard)
+                    ++discards;
+            },
+            [] {},
+        });
+        controller.setEditActive(true);
+
+        controller.doubleClickAt({100, 800}, Qt::LeftButton);
+        expect(controller.curves().size() == 1, "the provisional anchor must remain visible");
+        controller.exitEditing();
+        expect(controller.curves().isEmpty(), "Escape-style exit must remove the provisional anchor");
+        expect(begins == 1 && publishes == 0 && discards == 1,
+               "discarding a provisional anchor must not publish history");
+
+        controller.doubleClickAt({100, 800}, Qt::LeftButton);
+        AnchorEditor::MenuInfo info;
+        expect(!controller.prepareMenu({500, 500}, info),
+               "a background context action must not open an anchor menu");
+        expect(controller.curves().isEmpty(),
+               "background right-click-style exit must remove the provisional anchor");
+        expect(begins == 2 && publishes == 0 && discards == 2,
+               "both provisional exit paths must discard without publishing");
     }
 
     void testCreateClearsOverlappingPreview() {
@@ -178,6 +221,40 @@ namespace {
         delete source;
     }
 
+    void testDeleteToOneRemovesWholeCurve() {
+        AnchorEditor::AnchorEditController controller;
+        controller.setCoordinateMapper(mapper());
+        auto *source = makeCurve({
+            {10, 20},
+            {20, 40}
+        });
+        int publishes = 0;
+        int publishedCurveCount = -1;
+        int commits = 0;
+        controller.setHostCallbacks({
+            [] { return true; },
+            [&](const QList<AnchorCurve *> &curves) {
+                ++publishes;
+                publishedCurveCount = curves.size();
+            },
+            [&](const AnchorEditor::EditFinishReason reason) {
+                if (reason == AnchorEditor::EditFinishReason::Commit)
+                    ++commits;
+            },
+            [] {},
+        });
+        controller.loadFromModel({source});
+        controller.setEditActive(true);
+        controller.pressAt({200, 600}, Qt::LeftButton);
+        controller.deleteSelectedNodes();
+
+        expect(controller.curves().isEmpty(),
+               "deleting a two-node curve down to one must remove the remaining node");
+        expect(publishes == 1 && publishedCurveCount == 0 && commits == 1,
+               "removing the whole curve must be committed as one history entry");
+        delete source;
+    }
+
     void testCompositionPreservesOtherCurveKind() {
         auto *draw = new DrawCurve;
         draw->setLocalStart(0);
@@ -232,6 +309,30 @@ namespace {
         delete draw;
         delete singlePoint;
         delete anchor;
+    }
+
+    void testCompositionRejectsIncompleteAnchorCurves() {
+        auto *single = makeCurve({
+            {10, 20}
+        });
+        auto *complete = makeCurve({
+            {20, 40},
+            {30, 60}
+        });
+
+        auto anchorResult = AnchorEditor::replaceAnchors({}, {single, complete});
+        expect(anchorResult.size() == 1 && anchorResult.first()->type() == Curve::Anchor,
+               "anchor replacement must reject incomplete curves");
+
+        QList<Curve *> existing{single, complete};
+        auto drawResult = AnchorEditor::replaceDrawCurves(existing, {});
+        expect(drawResult.size() == 1 && drawResult.first()->type() == Curve::Anchor,
+               "draw replacement must not preserve incomplete anchor curves");
+
+        qDeleteAll(anchorResult);
+        qDeleteAll(drawResult);
+        delete complete;
+        delete single;
     }
 
     void testSelectionAndLastNodeMenu() {
@@ -311,18 +412,28 @@ namespace {
         controller.pressAt({200, 600}, Qt::LeftButton);
         controller.moveAt({450, 400}, Qt::LeftButton);
         controller.releaseAt({450, 400}, Qt::LeftButton);
-        expect(controller.curves().size() == 2, "cross-curve transfer must retain both curves");
-        expect(controller.curves().at(0)->nodes().toList().size() == 1,
-               "cross-curve transfer must remove the source node");
-        expect(controller.curves().at(1)->nodes().toList().size() == 3,
+        expect(controller.curves().size() == 1,
+               "cross-curve transfer must remove an incomplete source curve");
+        expect(controller.curves().first()->nodes().toList().size() == 3,
                "cross-curve transfer must insert the target node");
 
-        controller.exitEditing();
-        controller.pressAt({100, 800}, Qt::LeftButton);
-        controller.hoverMoveAt({400, 400});
-        expect(controller.state().showMergePreview, "adjacent endpoint must offer merge preview");
-        controller.pressAt({400, 400}, Qt::LeftButton);
-        expect(controller.curves().size() == 1, "endpoint merge must combine adjacent curves");
+        AnchorEditor::AnchorEditController mergeController;
+        mergeController.setCoordinateMapper(mapper());
+        mergeController.setHostCallbacks({
+            [] { return true; },
+            [](const QList<AnchorCurve *> &) {},
+            [](AnchorEditor::EditFinishReason) {},
+            [] {},
+        });
+        mergeController.loadFromModel({left, right});
+        mergeController.setEditActive(true);
+        mergeController.pressAt({100, 800}, Qt::LeftButton);
+        mergeController.hoverMoveAt({400, 400});
+        expect(mergeController.state().showMergePreview,
+               "adjacent endpoint must offer merge preview");
+        mergeController.pressAt({400, 400}, Qt::LeftButton);
+        expect(mergeController.curves().size() == 1,
+               "endpoint merge must combine adjacent curves");
         delete left;
         delete right;
     }
@@ -343,8 +454,9 @@ namespace {
         controller.setEditActive(true);
         events.clear();
         controller.doubleClickAt({100, 800}, Qt::LeftButton);
-        expect(events == QStringList({"begin", "publish", "finish", "state"}),
-               "mutation callbacks must follow begin-publish-finish-state order");
+        controller.doubleClickAt({200, 600}, Qt::LeftButton);
+        expect(events == QStringList({"begin", "state", "publish", "finish", "state"}),
+               "provisional creation must publish only after the second anchor");
     }
 
     void testAnchorSamplesOverrideDrawOnlyInTheirInterval() {
@@ -398,11 +510,14 @@ int main(int argc, char *argv[]) {
     QCoreApplication application(argc, argv);
     testLoadOwnsCopies();
     testCreateAndPublishingReentry();
+    testProvisionalAnchorExitDiscardsWithoutPublishing();
     testCreateClearsOverlappingPreview();
     testDragCancelRestoresSnapshot();
     testSelectionDeleteAndInterpolation();
+    testDeleteToOneRemovesWholeCurve();
     testCompositionPreservesOtherCurveKind();
     testCompositionRejectsSinglePointDrawCurves();
+    testCompositionRejectsIncompleteAnchorCurves();
     testSelectionAndLastNodeMenu();
     testBoundaryClippingAndRejectedMutation();
     testTransferAndMerge();

--- a/src/tests/TestAnchorEditController/main.cpp
+++ b/src/tests/TestAnchorEditController/main.cpp
@@ -221,6 +221,54 @@ namespace {
         delete source;
     }
 
+    void testSwitchingAwayFromProvisionalAllowsCommit() {
+        auto *source = makeCurve({
+            {30, 20},
+            {40, 40}
+        });
+
+        AnchorEditor::AnchorEditController selectionController;
+        selectionController.setCoordinateMapper(mapper());
+        int selectionPublishes = 0;
+        selectionController.setHostCallbacks({
+            [] { return true; },
+            [&](const QList<AnchorCurve *> &) { ++selectionPublishes; },
+            [](AnchorEditor::EditFinishReason) {},
+            [] {},
+        });
+        selectionController.loadFromModel({source});
+        selectionController.setEditActive(true);
+        selectionController.doubleClickAt({100, 800}, Qt::LeftButton);
+        selectionController.pressAt({300, 800}, Qt::LeftButton);
+        selectionController.setSelectedInterpolation(AnchorNode::Linear);
+        expect(selectionController.curves().size() == 1 && selectionPublishes == 1,
+               "switching to an existing curve must discard the provisional curve and commit");
+        if (!selectionController.curves().isEmpty()) {
+            expect(selectionController.curves().first()->nodes().toList().first()->interpMode() ==
+                       AnchorNode::Linear,
+                   "the selected existing curve must remain editable after a provisional curve");
+        }
+
+        AnchorEditor::AnchorEditController insertionController;
+        insertionController.setCoordinateMapper(mapper());
+        int insertionPublishes = 0;
+        insertionController.setHostCallbacks({
+            [] { return true; },
+            [&](const QList<AnchorCurve *> &) { ++insertionPublishes; },
+            [](AnchorEditor::EditFinishReason) {},
+            [] {},
+        });
+        insertionController.loadFromModel({source});
+        insertionController.setEditActive(true);
+        insertionController.doubleClickAt({100, 800}, Qt::LeftButton);
+        insertionController.doubleClickAt({350, 700}, Qt::LeftButton);
+        expect(insertionController.curves().size() == 1 &&
+                   insertionController.curves().first()->nodes().toList().size() == 3 &&
+                   insertionPublishes == 1,
+               "adding to an existing curve must replace and commit the provisional curve");
+        delete source;
+    }
+
     void testDeleteToOneRemovesWholeCurve() {
         AnchorEditor::AnchorEditController controller;
         controller.setCoordinateMapper(mapper());
@@ -512,6 +560,7 @@ int main(int argc, char *argv[]) {
     testCreateAndPublishingReentry();
     testProvisionalAnchorExitDiscardsWithoutPublishing();
     testCreateClearsOverlappingPreview();
+    testSwitchingAwayFromProvisionalAllowsCommit();
     testDragCancelRestoresSnapshot();
     testSelectionDeleteAndInterpolation();
     testDeleteToOneRemovesWholeCurve();


### PR DESCRIPTION
## Summary

- keep the first anchor point provisional until a second point completes the curve
- discard a provisional curve on Esc or background right-click without publishing history
- remove an entire anchor curve when edits leave fewer than two points, while preserving undo history
- apply the same invariant to the shared parameter controller, pitch RHI path, and curve composition helpers

## Validation

- `cmake --build --preset debug`
- `ctest --test-dir build/Debug --output-on-failure -R '^TestAnchorEditController$'`
- Computer Use smoke checks for pitch and parameter panels:
  - first point + Esc
  - first point + background right-click
  - two-point curve + Delete + Undo
