### PR TITLE
fix(inference): route tone shift across model stages

### DIFF
--- a/src/app/Modules/Inference/InferController.cpp
+++ b/src/app/Modules/Inference/InferController.cpp
@@ -539,6 +539,7 @@ void InferControllerPrivate::handleParamChanged(const ParamInfo::Name name, cons
             }
             break;
         case ParamInfo::Pitch:
+        case ParamInfo::ToneShift:
             for (const auto &piece : dirtyPieces) {
                 auto pred = L_PRED(t, t->pieceId() == piece->id());
                 m_inferVarianceTasks.cancelIf(pred);
@@ -559,7 +560,6 @@ void InferControllerPrivate::handleParamChanged(const ParamInfo::Name name, cons
         case ParamInfo::MouthOpening:
         case ParamInfo::Gender:
         case ParamInfo::Velocity:
-        case ParamInfo::ToneShift:
             for (const auto &piece : dirtyPieces) {
                 auto pred = L_PRED(t, t->pieceId() == piece->id());
                 m_inferAcousticTasks.cancelIf(pred);

--- a/src/app/Modules/Inference/InferControllerHelper.cpp
+++ b/src/app/Modules/Inference/InferControllerHelper.cpp
@@ -139,6 +139,7 @@ namespace InferControllerHelper {
         VarianceInput input;
         populateBaseInput(input, piece, identifier);
         input.pitch = curveSnapshot(piece.inputPitch, 100.0);
+        input.toneShift = curveSnapshot(piece.inputToneShift, 1.0);
         return input;
     }
 

--- a/src/app/Modules/Inference/InferControllerHelper.cpp
+++ b/src/app/Modules/Inference/InferControllerHelper.cpp
@@ -87,6 +87,12 @@ namespace InferControllerHelper {
             return result;
         }
 
+        InferParamCurve toneShiftSnapshot(const InferPiece &piece) {
+            if (!paramUtils->isSupportedBySinger(ParamInfo::ToneShift, piece.clip->singerInfo()))
+                return {};
+            return curveSnapshot(piece.inputToneShift, 1.0);
+        }
+
         template <typename F>
         InferParamCurve curveTransformedSnapshot(const DrawCurve &curve, const double scale,
                                                  F unaryOp) {
@@ -139,7 +145,7 @@ namespace InferControllerHelper {
         VarianceInput input;
         populateBaseInput(input, piece, identifier);
         input.pitch = curveSnapshot(piece.inputPitch, 100.0);
-        input.toneShift = curveSnapshot(piece.inputToneShift, 1.0);
+        input.toneShift = toneShiftSnapshot(piece);
         return input;
     }
 
@@ -156,7 +162,7 @@ namespace InferControllerHelper {
         input.gender = curveSnapshot(piece.inputGender, 1000.0);
         input.velocity = curveTransformedSnapshot(piece.inputVelocity, 1000.0,
                                                   [](double x) { return std::exp2(x); });
-        input.toneShift = curveSnapshot(piece.inputToneShift, 1.0);
+        input.toneShift = toneShiftSnapshot(piece);
         input.depth = appOptions->inference()->depth;
         return input;
     }

--- a/src/app/Modules/Inference/Tasks/InferAcousticTask.cpp
+++ b/src/app/Modules/Inference/Tasks/InferAcousticTask.cpp
@@ -285,25 +285,6 @@ bool InferAcousticTask::runInference(const GenericInferModel &model, const QStri
             return false;
         }
 
-        const auto vocoderSpec = inferenceVocoder->spec();
-        const auto vocoderConfig =
-            vocoderSpec ? vocoderSpec->configuration().as<Vo::VocoderConfiguration>() : nullptr;
-        if (!vocoderConfig) {
-            error = tr("Vocoder configuration is unavailable");
-            qCritical() << "inferAcoustic:" << error;
-            return false;
-        }
-
-        bool pitchDiffers = acousticPitch->values.size() != vocoderPitch->values.size();
-        for (qsizetype i = 0; !pitchDiffers && i < acousticPitch->values.size(); ++i) {
-            pitchDiffers = !qFuzzyCompare(acousticPitch->values.at(i), vocoderPitch->values.at(i));
-        }
-        if (pitchDiffers && !vocoderConfig->pitchControllable) {
-            error = tr("Tone shift requires a pitch-controllable vocoder");
-            qCritical() << "inferAcoustic:" << error;
-            return false;
-        }
-
         const auto originalF0Values = PitchRouting::midiPitchToF0(
             vocoderPitch->values, vocoderPitch->interval,
             static_cast<qsizetype>(acousticF0->elementCount()), acousticFrameWidth);

--- a/src/app/Modules/Inference/Tasks/InferAcousticTask.cpp
+++ b/src/app/Modules/Inference/Tasks/InferAcousticTask.cpp
@@ -4,12 +4,15 @@
 
 #include <diffsinger/Infer/dsinfer/Api/Inferences/Acoustic/1/AcousticApiL1.h>
 #include <diffsinger/Infer/dsinfer/Api/Inferences/Vocoder/1/VocoderApiL1.h>
+#include <synthrt/Core/Tensor/Tensor.h>
+#include <synthrt/SVS/InferenceContrib.h>
 
 #include "Model/AppOptions/AppOptions.h"
 #include "Modules/Inference/Models/InferInputNote.h"
 #include "Modules/Inference/InferEngine.h"
 #include "Modules/Inference/Models/GenericInferModel.h"
 #include "Modules/Inference/Utils/InferTaskHelper.h"
+#include "Modules/Inference/Utils/PitchRouting.h"
 #include <lite/Support/JsonUtils.h>
 #include <lite/Support/StringUtils.h>
 
@@ -19,6 +22,8 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
+
+#include <algorithm>
 
 namespace Ac = srt::svs::Api::Acoustic::L1;
 namespace Vo = srt::svs::Api::Vocoder::L1;
@@ -143,6 +148,19 @@ bool InferAcousticTask::runInference(const GenericInferModel &model, const QStri
     }
 
     const auto &identifier = model.identifier;
+    const auto paramWithTag = [&model](const QString &tag) -> const InferParam * {
+        const auto it = std::find_if(model.params.cbegin(), model.params.cend(),
+                                     [&tag](const auto &param) { return param.tag == tag; });
+        return it == model.params.cend() ? nullptr : &*it;
+    };
+    const auto vocoderPitch = paramWithTag(QString::fromLatin1(PitchRouting::VocoderPitchTag));
+    const auto acousticPitch = paramWithTag(QStringLiteral("pitch"));
+    if (!vocoderPitch || vocoderPitch->values.isEmpty() || !acousticPitch) {
+        error = tr("Pitch routing data is missing");
+        qCritical() << "inferAcoustic:" << error;
+        return false;
+    }
+
     std::string speakerName = model.speaker.toStdString();
     const auto input = srt::core::NO<Ac::AcousticStartInput>::create();
     input->parameters = convertInputParams(model.params);
@@ -156,7 +174,8 @@ bool InferAcousticTask::runInference(const GenericInferModel &model, const QStri
     }
     // Infer acoustic
     srt::core::NO<srt::core::ITensor> mel;
-    srt::core::NO<srt::core::ITensor> f0;
+    srt::core::NO<srt::core::ITensor> acousticF0;
+    double acousticFrameWidth = 0;
     {
         auto acousticExp = m_activeInference.acquire(handle, ds::infer::StageKind::Acoustic);
         if (!acousticExp) {
@@ -172,6 +191,17 @@ bool InferAcousticTask::runInference(const GenericInferModel &model, const QStri
             qCritical() << "inferAcoustic: Acoustic inference not found for" << identifier;
             return false;
         }
+
+        const auto acousticSpec = inferenceAcoustic->spec();
+        const auto acousticConfig =
+            acousticSpec ? acousticSpec->configuration().as<Ac::AcousticConfiguration>() : nullptr;
+        if (!acousticConfig || acousticConfig->sampleRate <= 0 || acousticConfig->hopSize <= 0) {
+            error = tr("Acoustic model frame configuration is invalid");
+            qCritical() << "inferAcoustic:" << error;
+            return false;
+        }
+        acousticFrameWidth = static_cast<double>(acousticConfig->hopSize) /
+                             static_cast<double>(acousticConfig->sampleRate);
 
         if (!acousticModel.importOptions) {
             qCritical() << "inferAcoustic: Import options not found";
@@ -231,7 +261,13 @@ bool InferAcousticTask::runInference(const GenericInferModel &model, const QStri
             return false;
         }
         mel = result->mel;
-        f0 = result->f0;
+        acousticF0 = result->f0;
+        if (!acousticF0 || acousticF0->dataType() != srt::core::ITensor::Float ||
+            acousticF0->elementCount() == 0) {
+            error = tr("Acoustic model returned invalid f0 data");
+            qCritical() << "inferAcoustic:" << error;
+            return false;
+        }
     }
     // Run vocoder
     {
@@ -248,9 +284,49 @@ bool InferAcousticTask::runInference(const GenericInferModel &model, const QStri
             qCritical() << "inferAcoustic: Vocoder inference not found for" << identifier;
             return false;
         }
+
+        const auto vocoderSpec = inferenceVocoder->spec();
+        const auto vocoderConfig =
+            vocoderSpec ? vocoderSpec->configuration().as<Vo::VocoderConfiguration>() : nullptr;
+        if (!vocoderConfig) {
+            error = tr("Vocoder configuration is unavailable");
+            qCritical() << "inferAcoustic:" << error;
+            return false;
+        }
+
+        bool pitchDiffers = acousticPitch->values.size() != vocoderPitch->values.size();
+        for (qsizetype i = 0; !pitchDiffers && i < acousticPitch->values.size(); ++i) {
+            pitchDiffers = !qFuzzyCompare(acousticPitch->values.at(i), vocoderPitch->values.at(i));
+        }
+        if (pitchDiffers && !vocoderConfig->pitchControllable) {
+            error = tr("Tone shift requires a pitch-controllable vocoder");
+            qCritical() << "inferAcoustic:" << error;
+            return false;
+        }
+
+        const auto originalF0Values = PitchRouting::midiPitchToF0(
+            vocoderPitch->values, vocoderPitch->interval,
+            static_cast<qsizetype>(acousticF0->elementCount()), acousticFrameWidth);
+        if (originalF0Values.size() != static_cast<qsizetype>(acousticF0->elementCount())) {
+            error = tr("Failed to align the original pitch for the vocoder");
+            qCritical() << "inferAcoustic:" << error;
+            return false;
+        }
+        auto originalF0Exp =
+            srt::core::Tensor::create(srt::core::ITensor::Float, acousticF0->shape());
+        if (!originalF0Exp) {
+            error = tr("Failed to create the vocoder f0 tensor");
+            qCritical().noquote().nospace()
+                << "inferAcoustic: " << error << ": " << originalF0Exp.error().message();
+            return false;
+        }
+        auto originalF0 = originalF0Exp.take();
+        std::copy(originalF0Values.cbegin(), originalF0Values.cend(),
+                  originalF0->mutableData<float>());
+
         const auto vocoderInput = srt::core::NO<Vo::VocoderStartInput>::create();
         vocoderInput->mel = mel;
-        vocoderInput->f0 = f0;
+        vocoderInput->f0 = originalF0;
 
         srt::core::NO<Vo::VocoderResult> result;
         // Start inference
@@ -363,7 +439,13 @@ GenericInferModel InferAcousticTask::InferAcousticInput::toEngineModel() const {
 
     InferParam pitch = param;
     pitch.tag = "pitch";
-    pitch.values = resampleCurveToFrames(this->pitch, frames, interval);
+    const auto originalPitch = resampleCurveToFrames(this->pitch, frames, interval);
+    pitch.values = PitchRouting::applyToneShift(
+        originalPitch, resampleCurveToFrames(this->toneShift, frames, interval));
+
+    InferParam vocoderPitch = param;
+    vocoderPitch.tag = QString::fromLatin1(PitchRouting::VocoderPitchTag);
+    vocoderPitch.values = originalPitch;
 
     InferParam breathiness = param;
     breathiness.tag = "breathiness";
@@ -393,18 +475,14 @@ GenericInferModel InferAcousticTask::InferAcousticInput::toEngineModel() const {
     velocity.tag = "velocity";
     velocity.values = resampleCurveToFrames(this->velocity, frames, interval);
 
-    InferParam toneShift = param;
-    toneShift.tag = "tone_shift";
-    toneShift.values = resampleCurveToFrames(this->toneShift, frames, interval);
-
     GenericInferModel model;
     model.speaker = speaker;
     const auto effectiveMix =
         speakerMix.isEmpty() ? InferSpeakerMixModel::staticSpeakerMix(speaker) : speakerMix;
     model.speakerMix = InferSpeakerMixModel::fitToFrames(effectiveMix, frames, interval);
     model.words = words;
-    model.params = {pitch,        breathiness, tension,  voicing,  energy,
-                    mouthOpening, gender,      velocity, toneShift};
+    model.params = {pitch,  vocoderPitch, breathiness, tension, voicing,
+                    energy, mouthOpening, gender,      velocity};
     model.steps = steps;
     model.depth = static_cast<float>(depth);
     model.identifier = identifier;

--- a/src/app/Modules/Inference/Tasks/InferVarianceTask.cpp
+++ b/src/app/Modules/Inference/Tasks/InferVarianceTask.cpp
@@ -7,6 +7,7 @@
 #include "Modules/Inference/Models/GenericInferModel.h"
 #include "Modules/Inference/Models/InferInputNote.h"
 #include "Modules/Inference/Utils/InferTaskHelper.h"
+#include "Modules/Inference/Utils/PitchRouting.h"
 #include <lite/Support/JsonUtils.h>
 #include "InferTaskCommon.h"
 
@@ -253,7 +254,8 @@ void InferVarianceTask::buildPreviewText() {
 QString InferVarianceTask::InferVarianceInput::semanticSignature() const {
     return InferInputBase::semanticSignature(
         "variance", QJsonObject{
-                        {"pitch", InferInputBase::paramCurveObject(pitch)}
+                        {"pitch",     InferInputBase::paramCurveObject(pitch)    },
+                        {"toneShift", InferInputBase::paramCurveObject(toneShift)},
     });
 }
 
@@ -274,7 +276,9 @@ GenericInferModel InferVarianceTask::InferVarianceInput::toEngineModel() const {
 
     InferParam pitch = param;
     pitch.tag = "pitch";
-    pitch.values = resampleCurveToFrames(this->pitch, frames, interval);
+    pitch.values =
+        PitchRouting::applyToneShift(resampleCurveToFrames(this->pitch, frames, interval),
+                                     resampleCurveToFrames(this->toneShift, frames, interval));
 
     InferParam breathiness = param;
     breathiness.tag = "breathiness";

--- a/src/app/Modules/Inference/Tasks/InferVarianceTask.h
+++ b/src/app/Modules/Inference/Tasks/InferVarianceTask.h
@@ -21,6 +21,7 @@ public:
     class InferVarianceInput : public InferInputBase {
     public:
         InferParamCurve pitch;
+        InferParamCurve toneShift;
 
         bool operator==(const InferVarianceInput &other) const;
         [[nodiscard]] QString semanticSignature() const;

--- a/src/app/Modules/Inference/Utils/InferenceApplyGate.cpp
+++ b/src/app/Modules/Inference/Utils/InferenceApplyGate.cpp
@@ -83,10 +83,10 @@ namespace {
             case ParamInfo::Voicing:
             case ParamInfo::Tension:
             case ParamInfo::MouthOpening:
+            case ParamInfo::ToneShift:
                 return isVariance || isAcoustic;
             case ParamInfo::Gender:
             case ParamInfo::Velocity:
-            case ParamInfo::ToneShift:
                 return isAcoustic;
             case ParamInfo::SpeakerMix:
             case ParamInfo::Unknown:
@@ -203,7 +203,8 @@ namespace InferenceApplyGate {
                 return drop("piece-singer-speaker-mismatch", currentRevision);
             }
             if (options.checkSingerSpeaker && shouldCheckSpeakerMixSignature(context) &&
-                InferSpeakerMixModel::effectiveSpeakerMixForPiece(*piece).signature() != context.speakerMixSignature) {
+                InferSpeakerMixModel::effectiveSpeakerMixForPiece(*piece).signature() !=
+                    context.speakerMixSignature) {
                 return drop("piece-speaker-mix-mismatch", currentRevision);
             }
         }

--- a/src/app/Modules/Inference/Utils/PitchRouting.cpp
+++ b/src/app/Modules/Inference/Utils/PitchRouting.cpp
@@ -2,6 +2,7 @@
 
 #include <lite/Support/MathUtils.h>
 
+#include <algorithm>
 #include <cmath>
 
 QList<double> PitchRouting::applyToneShift(QList<double> pitch,
@@ -9,8 +10,10 @@ QList<double> PitchRouting::applyToneShift(QList<double> pitch,
     if (pitch.size() != toneShiftCents.size())
         return {};
 
-    for (qsizetype i = 0; i < pitch.size(); ++i)
-        pitch[i] += toneShiftCents.at(i) / 100.0;
+    for (qsizetype i = 0; i < pitch.size(); ++i) {
+        if (pitch.at(i) > 0)
+            pitch[i] += toneShiftCents.at(i) / 100.0;
+    }
     return pitch;
 }
 
@@ -39,7 +42,16 @@ QList<float> PitchRouting::midiPitchToF0(const QList<double> &pitch,
 
     QList<float> result;
     result.reserve(resampled.size());
-    for (const auto midiPitch : resampled)
+    for (qsizetype i = 0; i < resampled.size(); ++i) {
+        const auto sourceIndex = std::clamp<qsizetype>(
+            static_cast<qsizetype>(std::llround(targetPositions.at(i) / sourceIntervalSeconds)), 0,
+            pitch.size() - 1);
+        const auto midiPitch = resampled.at(i);
+        if (pitch.at(sourceIndex) <= 0 || midiPitch <= 0) {
+            result.append(0);
+            continue;
+        }
         result.append(static_cast<float>(440.0 * std::exp2((midiPitch - 69.0) / 12.0)));
+    }
     return result;
 }

--- a/src/app/Modules/Inference/Utils/PitchRouting.cpp
+++ b/src/app/Modules/Inference/Utils/PitchRouting.cpp
@@ -1,0 +1,45 @@
+#include "PitchRouting.h"
+
+#include <lite/Support/MathUtils.h>
+
+#include <cmath>
+
+QList<double> PitchRouting::applyToneShift(QList<double> pitch,
+                                           const QList<double> &toneShiftCents) {
+    if (pitch.size() != toneShiftCents.size())
+        return {};
+
+    for (qsizetype i = 0; i < pitch.size(); ++i)
+        pitch[i] += toneShiftCents.at(i) / 100.0;
+    return pitch;
+}
+
+QList<float> PitchRouting::midiPitchToF0(const QList<double> &pitch,
+                                         const double sourceIntervalSeconds,
+                                         const qsizetype targetFrames,
+                                         const double targetIntervalSeconds) {
+    if (pitch.isEmpty() || sourceIntervalSeconds <= 0 || targetFrames <= 0 ||
+        targetIntervalSeconds <= 0) {
+        return {};
+    }
+
+    QList<double> sourcePositions;
+    sourcePositions.reserve(pitch.size());
+    for (qsizetype i = 0; i < pitch.size(); ++i)
+        sourcePositions.append(static_cast<double>(i) * sourceIntervalSeconds);
+
+    QList<double> targetPositions;
+    targetPositions.reserve(targetFrames);
+    for (qsizetype i = 0; i < targetFrames; ++i)
+        targetPositions.append(static_cast<double>(i) * targetIntervalSeconds);
+
+    const auto resampled = MathUtils::resample(pitch, sourcePositions, targetPositions);
+    if (resampled.size() != targetFrames)
+        return {};
+
+    QList<float> result;
+    result.reserve(resampled.size());
+    for (const auto midiPitch : resampled)
+        result.append(static_cast<float>(440.0 * std::exp2((midiPitch - 69.0) / 12.0)));
+    return result;
+}

--- a/src/app/Modules/Inference/Utils/PitchRouting.h
+++ b/src/app/Modules/Inference/Utils/PitchRouting.h
@@ -1,0 +1,16 @@
+#ifndef PITCHROUTING_H
+#define PITCHROUTING_H
+
+#include <QList>
+
+namespace PitchRouting {
+    inline constexpr char VocoderPitchTag[] = "vocoder_pitch";
+
+    [[nodiscard]] QList<double> applyToneShift(QList<double> pitch,
+                                               const QList<double> &toneShiftCents);
+    [[nodiscard]] QList<float> midiPitchToF0(const QList<double> &pitch,
+                                             double sourceIntervalSeconds, qsizetype targetFrames,
+                                             double targetIntervalSeconds);
+}
+
+#endif // PITCHROUTING_H

--- a/src/tests/TestInputConversion/main.cpp
+++ b/src/tests/TestInputConversion/main.cpp
@@ -7,6 +7,7 @@
 #include "Modules/Inference/Models/GenericInferModel.h"
 #include <lite/ProjectModel/InferenceData/InferSpeakerMix.h>
 #include "Modules/Inference/Tasks/InferTaskCommon.h"
+#include "Modules/Inference/Utils/PitchRouting.h"
 
 #include <QCoreApplication>
 #include <QTextStream>
@@ -110,7 +111,9 @@ namespace {
     bool testConvertInputWordsSpeakerNotFound() {
         bool ok = true;
         const auto words = makeSingleWord(0);
-        const std::map<std::string, std::string> mapping{{"S1", "M1"}};
+        const std::map<std::string, std::string> mapping{
+            {"S1", "M1"}
+        };
 
         QString error;
         const auto result = convertInputWords(words, "S2", {}, mapping, error);
@@ -139,7 +142,9 @@ namespace {
     bool testConvertInputSpeakersNotFound() {
         bool ok = true;
         const auto mix = buildMix("S1", 0.6, "S2", 0.4);
-        const std::map<std::string, std::string> mapping{{"S1", "M1"}};
+        const std::map<std::string, std::string> mapping{
+            {"S1", "M1"}
+        };
 
         QString error;
         const auto result = convertInputSpeakers(mix, mapping, error);
@@ -199,6 +204,33 @@ namespace {
         return ok;
     }
 
+    bool testVocoderPitchStaysHostOnlyAndAffectsCacheKey() {
+        bool ok = true;
+        InferParam acousticPitch;
+        acousticPitch.tag = "pitch";
+        acousticPitch.values = {72.0};
+
+        InferParam vocoderPitch;
+        vocoderPitch.tag = QString::fromLatin1(PitchRouting::VocoderPitchTag);
+        vocoderPitch.values = {60.0};
+
+        const auto converted = convertInputParams({acousticPitch, vocoderPitch});
+        ok &= expect(converted.size() == 1,
+                     "host-only vocoder pitch must not reach the acoustic model");
+        ok &= expect(converted.at(0).tag == Co::Tags::Pitch,
+                     "acoustic model must receive the shifted pitch");
+        ok &= expect(converted.at(0).values == std::vector<double>{72.0},
+                     "acoustic pitch value must stay shifted");
+
+        GenericInferModel first;
+        first.params = {acousticPitch, vocoderPitch};
+        auto second = first;
+        second.params[1].values = {61.0};
+        ok &= expect(first.hashData() != second.hashData(),
+                     "original vocoder pitch must participate in the acoustic cache key");
+        return ok;
+    }
+
     // B-12: tone passthrough - tone=60 and tone=0
     bool testConvertInputWordsTonePassthrough() {
         bool ok = true;
@@ -255,6 +287,7 @@ int main(int argc, char *argv[]) {
     ok &= testConvertInputSpeakersEmptyMapping();
     ok &= testConvertInputParamsRetakeSet();
     ok &= testConvertInputParamsRetakeEmpty();
+    ok &= testVocoderPitchStaysHostOnlyAndAffectsCacheKey();
     ok &= testConvertInputWordsTonePassthrough();
     ok &= testConvertInputWordsSpeakerMix();
 

--- a/src/tests/TestParamResample/CMakeLists.txt
+++ b/src/tests/TestParamResample/CMakeLists.txt
@@ -3,6 +3,11 @@ project(TestParamResample)
 lite_add_test(${PROJECT_NAME}
         SOURCES
         main.cpp
+        ../../app/Modules/Inference/Utils/PitchRouting.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+        ../../app
 )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE NOMINMAX QT_MESSAGELOGCONTEXT)

--- a/src/tests/TestParamResample/main.cpp
+++ b/src/tests/TestParamResample/main.cpp
@@ -1,5 +1,6 @@
 #include <lite/MusicBase/Timeline.h>
 #include <lite/Support/MathUtils.h>
+#include "Modules/Inference/Utils/PitchRouting.h"
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -80,5 +81,19 @@ int main(int argc, char *argv[]) {
     const auto boundaryValues =
         MathUtils::resample(values, curveSeconds(stepped, startTick, pointCount), boundaryTargets);
     expect(boundaryValues.size() == 2, "tempo-boundary targets must not be truncated");
+
+    expect(PitchRouting::applyToneShift({60.0, 61.0}, {1200.0, -50.0}) ==
+               QList<double>({72.0, 60.5}),
+           "tone shift must be added to MIDI pitch in cents");
+    expect(PitchRouting::applyToneShift({60.0}, {100.0, 200.0}).isEmpty(),
+           "mismatched pitch and tone-shift samples must fail");
+
+    const auto f0 = PitchRouting::midiPitchToF0({69.0, 81.0}, 1.0, 4, 0.5);
+    expect(f0.size() == 4, "vocoder f0 must use the requested frame count");
+    expect(std::abs(f0.at(0) - 440.0f) < 0.01f, "MIDI 69 must map to 440 Hz");
+    expect(std::abs(f0.at(1) - 622.25397f) < 0.01f,
+           "vocoder f0 must interpolate the original pitch timeline");
+    expect(std::abs(f0.at(2) - 880.0f) < 0.01f && std::abs(f0.at(3) - 880.0f) < 0.01f,
+           "vocoder f0 must clamp the original pitch at the tail");
     return 0;
 }

--- a/src/tests/TestParamResample/main.cpp
+++ b/src/tests/TestParamResample/main.cpp
@@ -87,6 +87,9 @@ int main(int argc, char *argv[]) {
            "tone shift must be added to MIDI pitch in cents");
     expect(PitchRouting::applyToneShift({60.0}, {100.0, 200.0}).isEmpty(),
            "mismatched pitch and tone-shift samples must fail");
+    expect(PitchRouting::applyToneShift({0.0, -1.0, 60.0}, {1200.0, 1200.0, 1200.0}) ==
+               QList<double>({0.0, -1.0, 72.0}),
+           "tone shift must preserve non-positive unvoiced pitch samples");
 
     const auto f0 = PitchRouting::midiPitchToF0({69.0, 81.0}, 1.0, 4, 0.5);
     expect(f0.size() == 4, "vocoder f0 must use the requested frame count");
@@ -95,5 +98,8 @@ int main(int argc, char *argv[]) {
            "vocoder f0 must interpolate the original pitch timeline");
     expect(std::abs(f0.at(2) - 880.0f) < 0.01f && std::abs(f0.at(3) - 880.0f) < 0.01f,
            "vocoder f0 must clamp the original pitch at the tail");
+    expect(PitchRouting::midiPitchToF0({0.0, -1.0, 69.0}, 1.0, 3, 1.0) ==
+               QList<float>({0.0f, 0.0f, 440.0f}),
+           "vocoder f0 must preserve non-positive unvoiced pitch samples");
     return 0;
 }


### PR DESCRIPTION
## Summary

- move tone-shift orchestration into the editor after synthrt removed its acoustic-stage awareness
- send shifted pitch to variance/acoustic while preserving original pitch for pitch-controllable vocoders
- include host-only vocoder pitch in acoustic cache identity and invalidate variance/acoustic stages on tone-shift edits
- reject shifted synthesis explicitly when the configured vocoder cannot accept pitch control

## Validation

- root `update-vcpkg-win.bat` completed successfully against the updated synthrt port
- debug CMake configure and full build passed
- `TestParamResample`, `TestInputConversion`, and `TestParamSupport` passed
- Computer Use GUI smoke with Thea passed: singer load, note synthesis, phonemes/pitch/waveform, playback, and DSPX save
- GUI cache comparison showed variance/acoustic pitch increased by 9.91 semitones, `vocoder_pitch` stayed at the original pitch, duration/pitch caches were reused, and no `tone_shift` reached synthrt
- baseline and shifted acoustic outputs both measured 260.12 Hz median F0 (0 cent difference)