### PR TITLE
fix(playback): hide start marker while stationary

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
@@ -289,7 +289,7 @@ void PhonemeView::paintEvent(QPaintEvent *event) {
         }
     }
 
-    if (playbackController->playbackStatus() == PlaybackGlobal::Playing) {
+    if (playbackController->playbackStatus() != PlaybackGlobal::Stopped) {
         // Draw last playback position (dashed)
         painter.setRenderHint(QPainter::Antialiasing);
         pen.setStyle(Qt::DashLine);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PhonemeView.cpp
@@ -43,6 +43,8 @@ PhonemeView::PhonemeView(QWidget *parent) : QWidget(parent) {
             &PhonemeView::setPosition);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &PhonemeView::setLastPosition);
+    connect(playbackController, &PlaybackController::playbackStatusChanged, this,
+            [this] { update(); });
 
     m_lastPosition = playbackController->lastPosition();
 }
@@ -287,14 +289,16 @@ void PhonemeView::paintEvent(QPaintEvent *event) {
         }
     }
 
-    // Draw last playback position (dashed)
-    painter.setRenderHint(QPainter::Antialiasing);
-    pen.setStyle(Qt::DashLine);
-    pen.setWidthF(1.0);
-    pen.setColor(m_lastPositionLineColor);
-    painter.setPen(pen);
-    auto lastX = tickToX(m_lastPosition);
-    painter.drawLine(QLineF(lastX, 0, lastX, rect().height()));
+    if (playbackController->playbackStatus() == PlaybackGlobal::Playing) {
+        // Draw last playback position (dashed)
+        painter.setRenderHint(QPainter::Antialiasing);
+        pen.setStyle(Qt::DashLine);
+        pen.setWidthF(1.0);
+        pen.setColor(m_lastPositionLineColor);
+        painter.setPen(pen);
+        auto lastX = tickToX(m_lastPosition);
+        painter.drawLine(QLineF(lastX, 0, lastX, rect().height()));
+    }
 
     // Draw playback indicator
     painter.setRenderHint(QPainter::Antialiasing);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -2334,7 +2334,7 @@ private:
     }
 
     void appendLastPlaybackIndicator(const double sceneTop, const double sceneBottom) {
-        if (playbackController->playbackStatus() != PlaybackGlobal::Playing)
+        if (playbackController->playbackStatus() == PlaybackGlobal::Stopped)
             return;
         const auto lastX = (lastPlaybackPosition - clip->start()) * pixelsPerTick();
         for (auto top = sceneTop; top < sceneBottom; top += 6.0) {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -9,6 +9,7 @@
 #include "PianoRollGraphicsViewHelper.h"
 #include "PronunciationView.h"
 #include "Controller/ClipController.h"
+#include "Controller/PlaybackController.h"
 #include "Global/AppGlobal.h"
 #include "Model/AppOptions/AppOptions.h"
 #include "Model/AppStatus/AppStatus.h"
@@ -2333,6 +2334,8 @@ private:
     }
 
     void appendLastPlaybackIndicator(const double sceneTop, const double sceneBottom) {
+        if (playbackController->playbackStatus() != PlaybackGlobal::Playing)
+            return;
         const auto lastX = (lastPlaybackPosition - clip->start()) * pixelsPerTick();
         for (auto top = sceneTop; top < sceneBottom; top += 6.0) {
             appendPixelAlignedVerticalLine(lastX, top, std::min(top + 4.0, sceneBottom),
@@ -2503,6 +2506,8 @@ PianoRollRhiWidget::PianoRollRhiWidget(QWidget *parent)
     connect(this, &EditorRhiWidget::backendFailed, this,
             [this](const QString &) { d->requestFallback(); });
     connect(appStatus, &AppStatus::pianoRollQuantizeChanged, this,
+            [this] { d->scheduleSnapshot(); });
+    connect(playbackController, &PlaybackController::playbackStatusChanged, this,
             [this] { d->scheduleSnapshot(); });
     connect(appStatus, &AppStatus::noteSelectionChanged, this, [this](const QList<int> &selection) {
         d->noteSelection.synchronize(selection);

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -144,11 +144,11 @@ TimeGraphicsView::TimeGraphicsView(TimeGraphicsScene *scene, bool showLastPlayba
     m_sceneLastPlayPosIndicator->setPen(lastPlayPosPen);
     if (showLastPlaybackPosition) {
         m_scene->addTimeIndicator(m_sceneLastPlayPosIndicator);
-        m_sceneLastPlayPosIndicator->setVisible(playbackController->playbackStatus() ==
-                                                PlaybackGlobal::Playing);
+        m_sceneLastPlayPosIndicator->setVisible(playbackController->playbackStatus() !=
+                                                PlaybackGlobal::Stopped);
         connect(playbackController, &PlaybackController::playbackStatusChanged, this,
                 [this](const PlaybackGlobal::PlaybackStatus status) {
-                    m_sceneLastPlayPosIndicator->setVisible(status == PlaybackGlobal::Playing);
+                    m_sceneLastPlayPosIndicator->setVisible(status != PlaybackGlobal::Stopped);
                 });
     }
 

--- a/src/app/UI/Views/Common/TimeGraphicsView.cpp
+++ b/src/app/UI/Views/Common/TimeGraphicsView.cpp
@@ -142,8 +142,15 @@ TimeGraphicsView::TimeGraphicsView(TimeGraphicsScene *scene, bool showLastPlayba
     lastPlayPosPen.setColor(m_lastPlayPosIndicatorColor);
     lastPlayPosPen.setStyle(Qt::DashLine);
     m_sceneLastPlayPosIndicator->setPen(lastPlayPosPen);
-    if (showLastPlaybackPosition)
+    if (showLastPlaybackPosition) {
         m_scene->addTimeIndicator(m_sceneLastPlayPosIndicator);
+        m_sceneLastPlayPosIndicator->setVisible(playbackController->playbackStatus() ==
+                                                PlaybackGlobal::Playing);
+        connect(playbackController, &PlaybackController::playbackStatusChanged, this,
+                [this](const PlaybackGlobal::PlaybackStatus status) {
+                    m_sceneLastPlayPosIndicator->setVisible(status == PlaybackGlobal::Playing);
+                });
+    }
 
     setScene(m_scene);
     setEnsureSceneFillViewX(true);

--- a/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
+++ b/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
@@ -44,6 +44,8 @@ InfoLaneView::InfoLaneView(QWidget *parent) : QWidget(parent) {
             &InfoLaneView::setPosition);
     connect(playbackController, &PlaybackController::lastPositionChanged, this,
             &InfoLaneView::setLastPosition);
+    connect(playbackController, &PlaybackController::playbackStatusChanged, this,
+            [this] { update(); });
 }
 
 void InfoLaneView::setTimeRange(const double startTick, const double endTick) {
@@ -191,7 +193,8 @@ void InfoLaneView::paintEvent(QPaintEvent *event) {
         painter.setPen(pen);
         painter.drawLine(QLineF(x, 0, x, height()));
     };
-    drawPlayheadLine(m_lastPosition, m_lastPlayheadColor, Qt::DashLine);
+    if (playbackController->playbackStatus() == PlaybackGlobal::Playing)
+        drawPlayheadLine(m_lastPosition, m_lastPlayheadColor, Qt::DashLine);
     drawPlayheadLine(m_position, m_playheadColor, Qt::SolidLine);
 }
 

--- a/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
+++ b/src/app/UI/Views/TrackEditor/InfoLane/InfoLaneView.cpp
@@ -193,7 +193,7 @@ void InfoLaneView::paintEvent(QPaintEvent *event) {
         painter.setPen(pen);
         painter.drawLine(QLineF(x, 0, x, height()));
     };
-    if (playbackController->playbackStatus() == PlaybackGlobal::Playing)
+    if (playbackController->playbackStatus() != PlaybackGlobal::Stopped)
         drawPlayheadLine(m_lastPosition, m_lastPlayheadColor, Qt::DashLine);
     drawPlayheadLine(m_position, m_playheadColor, Qt::SolidLine);
 }

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -1201,7 +1201,7 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
 
 void TracksRhiWidget::appendLastPlaybackIndicator(EditorRhiFrameData &frame,
                                                   const double dpr) const {
-    if (playbackController->playbackStatus() != PlaybackGlobal::Playing)
+    if (playbackController->playbackStatus() == PlaybackGlobal::Stopped)
         return;
     const auto visible = m_viewport.visibleSceneRect();
     const auto top = visible.top() * dpr;

--- a/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
+++ b/src/app/UI/Views/TrackEditor/TracksRhiWidget.cpp
@@ -216,6 +216,8 @@ TracksRhiWidget::TracksRhiWidget(QWidget *parent)
             &TracksRhiWidget::scheduleSnapshot);
     connect(appStatus, &AppStatus::projectEditableLengthChanged, this,
             &TracksRhiWidget::setSceneLength);
+    connect(playbackController, &PlaybackController::playbackStatusChanged, this,
+            [this] { scheduleSnapshot(); });
     connect(appOptions, &AppOptions::optionsChanged, this,
             [this](const AppOptionsGlobal::Option option) {
                 if (option == AppOptionsGlobal::DeveloperOptions ||
@@ -1199,6 +1201,8 @@ void TracksRhiWidget::appendClip(EditorRhiFrameData &frame, const ClipSnapshot &
 
 void TracksRhiWidget::appendLastPlaybackIndicator(EditorRhiFrameData &frame,
                                                   const double dpr) const {
+    if (playbackController->playbackStatus() != PlaybackGlobal::Playing)
+        return;
     const auto visible = m_viewport.visibleSceneRect();
     const auto top = visible.top() * dpr;
     const auto bottom = visible.bottom() * dpr;


### PR DESCRIPTION
## Summary

- keep the dashed playback-start indicator visible while playing or paused
- hide the dashed indicator only after playback enters the stopped state
- refresh RHI and legacy editor paths from the existing playback status signal

## Validation

- Debug preset configure and build completed successfully
- Computer Use: verified playback shows both the dashed start marker and solid current marker
- Computer Use: verified pause keeps both markers visible
- Computer Use: verified stop hides the dashed marker and leaves only the solid current marker