### PR TITLE
fix(speaker-mix): restore dragging for overlapping anchors

### DIFF
--- a/src/app/UI/Dialogs/SpeakerMix/SpeakerMixBar.cpp
+++ b/src/app/UI/Dialogs/SpeakerMix/SpeakerMixBar.cpp
@@ -9,7 +9,7 @@
 
 SpeakerMixBar::SpeakerMixBar(QWidget *parent)
     : QWidget(parent), m_draggingIndex(-1), m_dragOffset(0), m_isDragging(false),
-      m_readOnly(false) {
+      m_dragSplitResolved(false), m_readOnly(false) {
     setFixedHeight(m_trackHeight + 2 * m_margin);
     setMinimumWidth(300);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -62,6 +62,7 @@ void SpeakerMixBar::setReadOnly(const bool readOnly) {
     if (m_readOnly) {
         m_isDragging = false;
         m_draggingIndex = -1;
+        m_dragSplitResolved = false;
         unsetCursor();
     }
     update();
@@ -222,6 +223,7 @@ void SpeakerMixBar::mousePressEvent(QMouseEvent *event) {
             const int handleCenterX = valueToPixel(m_dividers[m_draggingIndex]);
             m_dragOffset = event->pos().x() - handleCenterX;
             m_dragStartValues = m_values;
+            m_dragSplitResolved = false;
             setCursor(Qt::SizeHorCursor);
             update();
         }
@@ -239,6 +241,19 @@ void SpeakerMixBar::mouseMoveEvent(QMouseEvent *event) {
         // where the user grabbed it rather than jumping to cursor center.
         const int adjustedX = event->pos().x() - m_dragOffset;
         const double newValue = pixelToSnappedValue(adjustedX);
+
+        if (!m_dragSplitResolved) {
+            const int initialSplitIndex = m_draggingIndex - 1;
+            const double initialValue =
+                SpeakerMixUtils::cumulativeWeightAtSplit(m_dragStartValues, initialSplitIndex);
+            if (!qFuzzyIsNull(newValue - initialValue)) {
+                m_draggingIndex = SpeakerMixUtils::resolveOverlappingSplitIndex(
+                                      m_dragStartValues, initialSplitIndex,
+                                      newValue - initialValue, 100.0) +
+                                  1;
+                m_dragSplitResolved = true;
+            }
+        }
 
         const bool proportional = event->modifiers().testFlag(Qt::AltModifier);
         const int splitIndex = m_draggingIndex - 1;
@@ -261,6 +276,7 @@ void SpeakerMixBar::mouseReleaseEvent(QMouseEvent *event) {
     if (m_isDragging) {
         m_isDragging = false;
         m_draggingIndex = -1;
+        m_dragSplitResolved = false;
         setCursor(Qt::ArrowCursor);
         update();
     }

--- a/src/app/UI/Dialogs/SpeakerMix/SpeakerMixBar.cpp
+++ b/src/app/UI/Dialogs/SpeakerMix/SpeakerMixBar.cpp
@@ -246,10 +246,10 @@ void SpeakerMixBar::mouseMoveEvent(QMouseEvent *event) {
             const int initialSplitIndex = m_draggingIndex - 1;
             const double initialValue =
                 SpeakerMixUtils::cumulativeWeightAtSplit(m_dragStartValues, initialSplitIndex);
-            if (!qFuzzyIsNull(newValue - initialValue)) {
+            const int dragDelta = adjustedX - valueToPixel(initialValue);
+            if (dragDelta != 0) {
                 m_draggingIndex = SpeakerMixUtils::resolveOverlappingSplitIndex(
-                                      m_dragStartValues, initialSplitIndex,
-                                      newValue - initialValue, 100.0) +
+                                      m_dragStartValues, initialSplitIndex, dragDelta, 100.0) +
                                   1;
                 m_dragSplitResolved = true;
             }

--- a/src/app/UI/Dialogs/SpeakerMix/SpeakerMixBar.h
+++ b/src/app/UI/Dialogs/SpeakerMix/SpeakerMixBar.h
@@ -73,6 +73,7 @@ private:
     int m_draggingIndex;
     int m_dragOffset;
     bool m_isDragging;
+    bool m_dragSplitResolved;
     bool m_readOnly;
 
     const int m_trackHeight = 40;

--- a/src/app/UI/Utils/SpeakerMixUtils.cpp
+++ b/src/app/UI/Utils/SpeakerMixUtils.cpp
@@ -150,6 +150,23 @@ namespace SpeakerMixUtils {
         return std::clamp(std::round(percent) / 100.0 * total, 0.0, total);
     }
 
+    int resolveOverlappingSplitIndex(const QVector<double> &fullWeights, const int splitIndex,
+                                     const double dragDelta, const double total) {
+        const QVector<double> normalized = normalizeFullWeights(fullWeights, total);
+        if (splitIndex < 0 || splitIndex >= normalized.size() - 1 || qFuzzyIsNull(dragDelta))
+            return splitIndex;
+
+        int firstSplit = splitIndex;
+        while (firstSplit > 0 && qFuzzyIsNull(normalized[firstSplit]))
+            --firstSplit;
+
+        int lastSplit = splitIndex;
+        while (lastSplit < normalized.size() - 2 && qFuzzyIsNull(normalized[lastSplit + 1]))
+            ++lastSplit;
+
+        return dragDelta < 0 ? firstSplit : lastSplit;
+    }
+
     QVector<double> adjacentDragWeights(const QVector<double> &dragStartFullWeights,
                                         const int splitIndex, const double newCumulative,
                                         const double total) {

--- a/src/app/UI/Utils/SpeakerMixUtils.h
+++ b/src/app/UI/Utils/SpeakerMixUtils.h
@@ -12,6 +12,8 @@ namespace SpeakerMixUtils {
 
     double cumulativeWeightAtSplit(const QVector<double> &fullWeights, int splitIndex);
     double snapCumulativeToPercent(double cumulative, double total = 1.0);
+    int resolveOverlappingSplitIndex(const QVector<double> &fullWeights, int splitIndex,
+                                     double dragDelta, double total = 1.0);
 
     QVector<double> adjacentDragWeights(const QVector<double> &dragStartFullWeights, int splitIndex,
                                         double newCumulative, double total = 1.0);

--- a/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.cpp
@@ -722,6 +722,7 @@ void SpeakerMixEditorView::endIntervalSelection() {
 void SpeakerMixEditorView::startDrag(const QPointF &scenePos) {
     m_state.dragging = false;
     m_state.dragStartScenePos = scenePos;
+    m_state.dragSplitResolved = false;
     m_state.altDrag = false;
 
     if (m_state.selectedKeyframeIndex >= 0) {
@@ -749,7 +750,16 @@ void SpeakerMixEditorView::updateDrag(const QPointF &scenePos) {
 
     const int ki = m_state.selectedKeyframeIndex;
     auto &kf = m_keyframes[ki];
-    const int si = m_state.dragSplitIndex;
+    int si = m_state.dragSplitIndex;
+
+    if (si >= 0 && !m_state.dragSplitResolved && !qFuzzyIsNull(delta.y())) {
+        const QVector<double> dragStartFullWeights = SpeakerMixUtils::storedWeightsToFull(
+            toVector(m_state.dragStartWeights.weights), m_speakers.size());
+        si = SpeakerMixUtils::resolveOverlappingSplitIndex(dragStartFullWeights, si, delta.y());
+        m_state.dragSplitIndex = si;
+        m_state.selectedSplitIndex = si;
+        m_state.dragSplitResolved = true;
+    }
 
     if (si < 0) {
         if (m_state.dragStartTick == 0)
@@ -800,6 +810,7 @@ void SpeakerMixEditorView::endDrag() {
     }
     m_state.dragging = false;
     m_state.dragSplitIndex = -1;
+    m_state.dragSplitResolved = false;
     hideSplitDragToolTip();
     if (changed)
         commit();

--- a/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.cpp
@@ -752,7 +752,7 @@ void SpeakerMixEditorView::updateDrag(const QPointF &scenePos) {
     auto &kf = m_keyframes[ki];
     int si = m_state.dragSplitIndex;
 
-    if (si >= 0 && !m_state.dragSplitResolved && !qFuzzyIsNull(delta.y())) {
+    if (si >= 0 && !m_state.dragSplitResolved && std::abs(delta.y()) > kDragThreshold) {
         const QVector<double> dragStartFullWeights = SpeakerMixUtils::storedWeightsToFull(
             toVector(m_state.dragStartWeights.weights), m_speakers.size());
         si = SpeakerMixUtils::resolveOverlappingSplitIndex(dragStartFullWeights, si, delta.y());

--- a/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.h
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/SpeakerMixEditorView.h
@@ -145,6 +145,7 @@ private:
         SpeakerMixKeyframe dragStartWeights;
         int dragStartTick = 0;
         int dragSplitIndex = -1;
+        bool dragSplitResolved = false;
         bool altDrag = false;
 
         bool selecting = false;

--- a/src/tests/TestSpeakerMix/CMakeLists.txt
+++ b/src/tests/TestSpeakerMix/CMakeLists.txt
@@ -6,6 +6,7 @@ lite_add_test(${PROJECT_NAME}
         ../../libs/ProjectModel/AppModel/SpeakerMixData.cpp
         ../../libs/ProjectModel/InferenceData/InferSpeakerMix.cpp
         ../../libs/ProjectModel/Voice/SpeakerInfo.cpp
+        ../../app/UI/Utils/SpeakerMixUtils.cpp
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE

--- a/src/tests/TestSpeakerMix/main.cpp
+++ b/src/tests/TestSpeakerMix/main.cpp
@@ -100,6 +100,24 @@ namespace {
         ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(trailingZeros, 1, 0.1) == 2,
                      "positive drag chooses last trailing overlapping split");
 
+        const QVector<double> threeLeadingZeros{0.0, 0.0, 0.0, 0.4, 0.6};
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(threeLeadingZeros, 1, -0.1) == 0,
+                     "negative drag chooses first of three leading overlapping splits");
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(threeLeadingZeros, 1, 0.1) == 2,
+                     "positive drag chooses last of three leading overlapping splits");
+
+        const QVector<double> threeTrailingZeros{0.4, 0.6, 0.0, 0.0, 0.0};
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(threeTrailingZeros, 2, -0.1) == 1,
+                     "negative drag chooses first of three trailing overlapping splits");
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(threeTrailingZeros, 2, 0.1) == 3,
+                     "positive drag chooses last of three trailing overlapping splits");
+
+        const QVector<double> interiorZeros{0.2, 0.0, 0.0, 0.0, 0.8};
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(interiorZeros, 2, -0.1) == 0,
+                     "negative drag chooses first of four interior overlapping splits");
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(interiorZeros, 2, 0.1) == 3,
+                     "positive drag chooses last of four interior overlapping splits");
+
         const QVector<double> separateSplits{0.2, 0.3, 0.5};
         ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(separateSplits, 1, -0.1) == 1,
                      "separate split keeps its index");

--- a/src/tests/TestSpeakerMix/main.cpp
+++ b/src/tests/TestSpeakerMix/main.cpp
@@ -1,6 +1,7 @@
 #include <lite/ProjectModel/AppModel/SpeakerMixData.h>
 #include <lite/MusicBase/Timeline.h>
 #include <lite/ProjectModel/InferenceData/InferSpeakerMix.h>
+#include "UI/Utils/SpeakerMixUtils.h"
 
 #include <QCoreApplication>
 #include <QTextStream>
@@ -81,6 +82,30 @@ namespace {
                                "full weights append implicit remainder");
         ok &= expectVectorNear(fullWeightsFromExplicitWeights({0.8, 0.8}), {0.5, 0.5, 0.0},
                                "overflow explicit weights normalize with zero remainder");
+        return ok;
+    }
+
+    bool testOverlappingSplitResolution() {
+        bool ok = true;
+
+        const QVector<double> leadingZeros{0.0, 0.0, 0.4, 0.6};
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(leadingZeros, 0, 0.1) == 1,
+                     "positive drag chooses last leading overlapping split");
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(leadingZeros, 1, -0.1) == 0,
+                     "negative drag chooses first leading overlapping split");
+
+        const QVector<double> trailingZeros{0.4, 0.6, 0.0, 0.0};
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(trailingZeros, 2, -0.1) == 1,
+                     "negative drag chooses first trailing overlapping split");
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(trailingZeros, 1, 0.1) == 2,
+                     "positive drag chooses last trailing overlapping split");
+
+        const QVector<double> separateSplits{0.2, 0.3, 0.5};
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(separateSplits, 1, -0.1) == 1,
+                     "separate split keeps its index");
+        ok &= expect(SpeakerMixUtils::resolveOverlappingSplitIndex(separateSplits, 1, 0.0) == 1,
+                     "stationary drag keeps its index");
+
         return ok;
     }
 
@@ -279,6 +304,7 @@ int main(int argc, char *argv[]) {
 
     bool ok = true;
     ok &= testWeightConversions();
+    ok &= testOverlappingSplitResolution();
     ok &= testNormalizeSpeakerMixData();
     ok &= testDynamicStatePredicates();
     ok &= testStaticAndFixedInferenceMix();


### PR DESCRIPTION
## 问题

静态与动态音色混合在多个分隔锚点重合时，命中顺序固定，可能选中被相邻锚点约束住的内侧分隔点，导致重叠锚点无法再次拖开。

## 修改

- 提取共享的重叠分隔点解析逻辑，支持任意数量的连续重叠锚点
- 根据首次有效拖动方向选择重叠组的外侧端点：左/上取首端，右/下取末端
- 静态混合滑块与动态混合关键帧共同复用该逻辑
- 增加头部、尾部及中间 2–4 个锚点重叠的回归测试

## 验证

- `TestSpeakerMix` 构建并通过
- Debug preset 完整增量构建通过
- Computer Use 复现旧行为，并验证修复后的静态双锚点重叠
- Computer Use 验证动态三个尾端锚点重叠后可从上端重新拖开
- GUI 冒烟：加载 0525 yelin、绘制 C4 音符、确认音素/音高/合成波形、播放走时、保存 DSPX；测试产物已清理