### PR TITLE
fix(speaker-mix): preserve inherited mix presentation

### DIFF
--- a/src/app/UI/Views/ClipEditor/ToolBar/ClipEditorToolBarView.cpp
+++ b/src/app/UI/Views/ClipEditor/ToolBar/ClipEditorToolBarView.cpp
@@ -504,18 +504,17 @@ void ClipEditorToolBarViewPrivate::refreshPitchBakeAvailability() const {
 }
 
 void ClipEditorToolBarViewPrivate::onSingerEdited() const {
-    if (m_singingClip) {
-        if (m_cbSinger->isInheritSelected()) {
-            m_singingClip->useTrackSingerAndSpeaker();
-            m_cbSinger->setCurrentData(m_singingClip->singerInfo(), m_singingClip->speakerInfo(),
-                                       true);
-        } else {
-            const auto singerInfo = m_cbSinger->currentSinger();
-            const auto speakerInfo = m_cbSinger->currentSpeaker();
-            m_singingClip->setOwnSingerAndSpeaker(singerInfo, speakerInfo);
-        }
-        m_cbSinger->setToolTip(m_cbSinger->currentText());
+    if (!m_singingClip)
+        return;
+
+    if (m_cbSinger->isInheritSelected()) {
+        m_singingClip->useTrackSingerAndSpeaker();
+    } else {
+        const auto singerInfo = m_cbSinger->currentSinger();
+        const auto speakerInfo = m_cbSinger->currentSpeaker();
+        m_singingClip->setOwnSingerAndSpeaker(singerInfo, speakerInfo);
     }
+    refreshSingerComboPresentation();
 }
 
 void ClipEditorToolBarViewPrivate::refreshSingerComboPresentation() const {

--- a/src/tests/TestTwoLevelComboBox/main.cpp
+++ b/src/tests/TestTwoLevelComboBox/main.cpp
@@ -32,6 +32,11 @@ int main(int argc, char *argv[]) {
     bool success = true;
     comboBox.setCurrentData(singer, speaker, true);
     success &= expect(comboBox.isInheritSelected(), "inherit item should be selected explicitly");
+    const auto inheritedMixText = QStringLiteral("Singer / Custom Mix");
+    comboBox.setDisplayTextOverride(inheritedMixText);
+    success &= expect(comboBox.currentText() ==
+                          QStringLiteral("Follow Track (%1)").arg(inheritedMixText),
+                      "inherited mix text should retain the Follow Track prefix");
 
     comboBox.setCurrentData(singer, speaker, false);
     const auto dynamicMixText = QStringLiteral("Singer / Dynamic Mix");


### PR DESCRIPTION
## Problem

After a clip uses dynamic speaker mixing and then switches back to **Follow Track**, the model correctly resumes the track's custom mix. However, the edit callback writes to the singer combo box again after the canonical presentation refresh, clearing the mix-specific display override.

The track settings and inference input remain unchanged, but the clip header incorrectly falls back to a base speaker name such as `ice`, conflicting with the actual state shown in the speaker-mix editor.

## Fix

- Route the post-edit presentation update through the existing `refreshSingerComboPresentation()` path so the singer, mix label, tooltip, preset menus, and language display are derived from the effective voice context.
- Remove the redundant UI write in the **Follow Track** branch that overwrote the `Custom Mix` / `Dynamic Mix` label.
- Add regression coverage for the `Follow Track` + `Custom Mix` display contract in `TwoLevelComboBox`.

## Validation

- Debug builds: `DsEditorLite`, `TestVoiceContext`, `TestTwoLevelComboBox`, and `TestSingerMenuDisplay`
- Relevant tests: 3/3 passed
- Computer Use reproduction: track `Custom Mix` → clip `Dynamic Mix` → `Follow Track`; both the track and clip continued to use and display `Custom Mix`
- GUI smoke test: drew a C4 note, verified phonemes, pitch curve, and synthesized waveform, confirmed playback advanced, saved a DSPX project successfully, and removed the temporary artifacts