### PR TITLE
fix(logging): stop RHI resize initialization traces

### DIFF
--- a/src/app/UI/Views/Common/EditorRhiWidget.cpp
+++ b/src/app/UI/Views/Common/EditorRhiWidget.cpp
@@ -153,10 +153,6 @@ public:
             return;
 
         resourcesReady = true;
-        qInfo().noquote() << QStringLiteral(
-                                 "[%1] initialized backend=%2 sampleCount=1 depthStencil=none "
-                                 "sceneCache=enabled")
-                                 .arg(diagnosticsTag, QString::fromUtf8(rhi->backendName()));
         q->onRhiReady();
     }
 


### PR DESCRIPTION
## Summary

- remove the unconditional RHI initialization info log missed by #144
- prevent splitter drags and window resize/maximize operations from repeatedly printing backend initialization lines
- preserve the explicit opt-in developer diagnostics

## Verification

- Debug `DsEditorLite` build passes
- exercised the main splitter repeatedly and maximized/restored the window through the GUI
- confirmed the post-fix capture contains no `initialized backend`, `[Stats]`, or `[Diag]` entries during those operations