### PR TITLE
fix(editor): prevent RHI lyric overflow on short notes

### DIFF
--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteLyricPresentation.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteLyricPresentation.h
@@ -42,7 +42,9 @@ namespace NoteLyricPresentation {
             result.textRect.height() <= 0.0) {
             return result;
         }
-        if (result.textRect.width() <= 0.0) {
+        const auto availableWidth =
+            static_cast<int>(std::floor(std::max(0.0, result.textRect.width())));
+        if (availableWidth <= 0) {
             result.elided = true;
             return result;
         }
@@ -51,8 +53,6 @@ namespace NoteLyricPresentation {
         if (metrics.height() >= result.textRect.height())
             return result;
 
-        const auto availableWidth =
-            static_cast<int>(std::floor(std::max(0.0, result.textRect.width())));
         result.displayText = metrics.elidedText(lyric, Qt::ElideRight, availableWidth);
         result.elided = result.displayText != lyric;
         return result;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteLyricPresentation.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteLyricPresentation.h
@@ -42,6 +42,10 @@ namespace NoteLyricPresentation {
             result.textRect.height() <= 0.0) {
             return result;
         }
+        if (result.textRect.width() <= 0.0) {
+            result.elided = true;
+            return result;
+        }
 
         const QFontMetricsF metrics(font);
         if (metrics.height() >= result.textRect.height())

--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteLyricToolTipController.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteLyricToolTipController.cpp
@@ -1,0 +1,34 @@
+#include "NoteLyricToolTipController.h"
+
+#include <lite/GUI/Controls/ToolTip.h>
+
+#include <QTextDocument>
+
+NoteLyricToolTipController::NoteLyricToolTipController(QWidget *parent)
+    : m_toolTip(std::make_unique<ToolTip>(QString(), parent)) {
+    m_toolTip->setAnimationEnabled(false);
+}
+
+NoteLyricToolTipController::~NoteLyricToolTipController() = default;
+
+void NoteLyricToolTipController::showFor(
+    const int noteId, const QString &lyric, const QRect &screenAnchor) {
+    if (lyric.isEmpty() || screenAnchor.isEmpty()) {
+        hide();
+        return;
+    }
+    if (m_noteId == noteId && m_lyric == lyric && m_toolTip->isVisible())
+        return;
+
+    m_noteId = noteId;
+    m_lyric = lyric;
+    m_toolTip->setTitle(Qt::convertFromPlainText(lyric));
+    m_toolTip->showAbove(screenAnchor);
+}
+
+void NoteLyricToolTipController::hide() {
+    m_noteId = -1;
+    m_lyric.clear();
+    if (m_toolTip->isVisible())
+        m_toolTip->hideWithAnimation();
+}

--- a/src/app/UI/Views/ClipEditor/PianoRoll/NoteLyricToolTipController.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/NoteLyricToolTipController.h
@@ -1,0 +1,26 @@
+#ifndef NOTELYRICTOOLTIPCONTROLLER_H
+#define NOTELYRICTOOLTIPCONTROLLER_H
+
+#include <QRect>
+#include <QString>
+
+#include <memory>
+
+class ToolTip;
+class QWidget;
+
+class NoteLyricToolTipController final {
+public:
+    explicit NoteLyricToolTipController(QWidget *parent);
+    ~NoteLyricToolTipController();
+
+    void showFor(int noteId, const QString &lyric, const QRect &screenAnchor);
+    void hide();
+
+private:
+    std::unique_ptr<ToolTip> m_toolTip;
+    int m_noteId = -1;
+    QString m_lyric;
+};
+
+#endif // NOTELYRICTOOLTIPCONTROLLER_H

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -2,6 +2,7 @@
 
 #include "ClipRangeOverlay.h"
 #include "NoteEditUtils.h"
+#include "NoteLyricToolTipController.h"
 #include "NoteView.h"
 #include "PianoRollBackground.h"
 #include "PianoRollGraphicsScene.h"
@@ -36,7 +37,6 @@
 #include "Model/AppStatus/AppStatus.h"
 #include "Modules/Inference/EditSessionManager.h"
 #include <lite/GUI/Controls/InlineTextEditOverlay.h>
-#include <lite/GUI/Controls/ToolTip.h>
 #include <lite/Support/Linq.h>
 #include <lite/Support/MathUtils.h>
 #include <lite/MusicBase/TimelineSnapUtils.h>
@@ -45,7 +45,6 @@
 #include <limits>
 
 #include <QDebug>
-#include <QCursor>
 #include <QGraphicsLineItem>
 #include <QGraphicsPathItem>
 #include <QHideEvent>
@@ -54,7 +53,6 @@
 #include <QKeyEvent>
 #include <QScrollBar>
 #include <QShowEvent>
-#include <QTextDocument>
 
 namespace Helper = PianoRollGraphicsViewHelper;
 
@@ -83,8 +81,7 @@ PianoRollGraphicsView::PianoRollGraphicsView(PianoRollGraphicsScene *scene, QWid
             &PianoRollGraphicsViewPrivate::onInlineNavigationRequested);
     connect(d->m_inlineEditor, &InlineTextEditOverlay::editCancelled, d,
             &PianoRollGraphicsViewPrivate::onInlineEditCancelled);
-    d->m_lyricToolTip = new ToolTip(QString(), viewport());
-    d->m_lyricToolTip->setAnimationEnabled(false);
+    d->m_lyricToolTip = std::make_unique<NoteLyricToolTipController>(viewport());
 
     d->m_selectionModel =
         new PianoRollSelectionModel(this, d->noteViews, d->noteViewIndex, d->m_notes, this);
@@ -1595,26 +1592,16 @@ void PianoRollGraphicsViewPrivate::updateLyricToolTip(const QPoint &position) {
         return;
     }
 
-    const auto lyric = noteView->lyric();
-    if (m_lyricToolTipNoteId == noteView->id() && m_lyricToolTipText == lyric &&
-        m_lyricToolTip->isVisible()) {
-        return;
-    }
-
-    m_lyricToolTipNoteId = noteView->id();
-    m_lyricToolTipText = lyric;
-    m_lyricToolTip->setTitle(Qt::convertFromPlainText(lyric));
     const auto noteRect = q->mapFromScene(noteView->sceneBoundingRect())
                               .boundingRect()
                               .intersected(q->viewport()->rect());
-    m_lyricToolTip->showAbove({q->viewport()->mapToGlobal(noteRect.topLeft()), noteRect.size()});
+    m_lyricToolTip->showFor(noteView->id(), noteView->lyric(),
+                            {q->viewport()->mapToGlobal(noteRect.topLeft()), noteRect.size()});
 }
 
 void PianoRollGraphicsViewPrivate::hideLyricToolTip() {
-    m_lyricToolTipNoteId = -1;
-    m_lyricToolTipText.clear();
-    if (m_lyricToolTip && m_lyricToolTip->isVisible())
-        m_lyricToolTip->hideWithAnimation();
+    if (m_lyricToolTip)
+        m_lyricToolTip->hide();
 }
 
 void PianoRollGraphicsViewPrivate::onClipPropertyChanged() {

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView_p.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView_p.h
@@ -1,6 +1,8 @@
 #ifndef PIANOROLLGRAPHICSVIEW_P_H
 #define PIANOROLLGRAPHICSVIEW_P_H
 
+#include "NoteLyricToolTipController.h"
+
 #include <lite/ProjectModel/AppModel/Params.h>
 #include <lite/ProjectModel/AppModel/SingingClip.h>
 
@@ -27,7 +29,6 @@ class PianoRollEditHandler;
 class PianoRollSelectionModel;
 class NoteInteractionController;
 class InlineTextEditOverlay;
-class ToolTip;
 enum class EditSessionEndReason;
 
 using namespace ClipEditorGlobal;
@@ -61,9 +62,7 @@ public:
     PianoRollSelectionModel *m_selectionModel = nullptr;
     NoteInteractionController *m_interactionController = nullptr;
     InlineTextEditOverlay *m_inlineEditor = nullptr;
-    ToolTip *m_lyricToolTip = nullptr;
-    int m_lyricToolTipNoteId = -1;
-    QString m_lyricToolTipText;
+    std::unique_ptr<NoteLyricToolTipController> m_lyricToolTip;
     InlineEditField m_inlineEditField = InlineEditField::None;
     int m_inlineEditingNoteId = -1;
     void restoreHandler();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -3,6 +3,7 @@
 #include "NoteView.h"
 #include "NoteEditUtils.h"
 #include "NoteLyricPresentation.h"
+#include "NoteLyricToolTipController.h"
 #include "PianoPaintUtils.h"
 #include "PianoRollCoord.h"
 #include "PitchDisplayStrategy.h"
@@ -32,7 +33,6 @@
 #include "Modules/Inference/EditSessionManager.h"
 
 #include <lite/GUI/Controls/InlineTextEditOverlay.h>
-#include <lite/GUI/Controls/ToolTip.h>
 #include <lite/ProjectModel/AppModel/AnchorCurve.h>
 #include <lite/ProjectModel/AppModel/DrawCurve.h>
 #include <lite/ProjectModel/AppModel/AppModel.h>
@@ -57,7 +57,6 @@
 #include <QResizeEvent>
 #include <QSet>
 #include <QShowEvent>
-#include <QTextDocument>
 #include <QTimer>
 #include <QWheelEvent>
 
@@ -266,8 +265,7 @@ public:
     }
 
     void initializeLyricToolTip() {
-        lyricToolTip = new ToolTip(QString(), q);
-        lyricToolTip->setAnimationEnabled(false);
+        lyricToolTip = std::make_unique<NoteLyricToolTipController>(q);
     }
 
     void initializeScrollBars() {
@@ -762,25 +760,14 @@ public:
             return;
         }
 
-        const auto lyric = note->lyric();
-        if (lyricToolTipNoteId == note->id() && lyricToolTipText == lyric &&
-            lyricToolTip->isVisible()) {
-            return;
-        }
-
-        lyricToolTipNoteId = note->id();
-        lyricToolTipText = lyric;
-        lyricToolTip->setTitle(Qt::convertFromPlainText(lyric));
         const auto visibleNoteRect = noteRect.intersected(visibleRect).toAlignedRect();
-        lyricToolTip->showAbove(
-            {q->mapToGlobal(visibleNoteRect.topLeft()), visibleNoteRect.size()});
+        lyricToolTip->showFor(note->id(), note->lyric(),
+                              {q->mapToGlobal(visibleNoteRect.topLeft()), visibleNoteRect.size()});
     }
 
     void hideLyricToolTip() {
-        lyricToolTipNoteId = -1;
-        lyricToolTipText.clear();
-        if (lyricToolTip && lyricToolTip->isVisible())
-            lyricToolTip->hideWithAnimation();
+        if (lyricToolTip)
+            lyricToolTip->hide();
     }
 
     void eraseNoteAt(const QPointF &viewportPosition) {
@@ -2487,9 +2474,7 @@ public:
     QColor rubberBandBorderColor{155, 186, 255, 200};
     QColor rubberBandFillColor{155, 186, 255, 64};
     InlineTextEditOverlay *inlineEditor = nullptr;
-    ToolTip *lyricToolTip = nullptr;
-    int lyricToolTipNoteId = -1;
-    QString lyricToolTipText;
+    std::unique_ptr<NoteLyricToolTipController> lyricToolTip;
     EditorRhiScrollBarController *scrollBars = nullptr;
     InlineEditField inlineEditField = InlineEditField::None;
     int inlineEditingNoteId = -1;

--- a/src/tests/TestPianoRollInteractions/main.cpp
+++ b/src/tests/TestPianoRollInteractions/main.cpp
@@ -117,6 +117,11 @@ int main(int argc, char *argv[]) {
         QRectF(0.0, 0.0, 7.0, noteTextHeight), longLyric, lyricFont, 1.0);
     expect(!ultraShortLayout.isVisible() && ultraShortLayout.elided,
            "a lyric with no drawable width must remain eligible for its tooltip");
+    const auto negativeWidthLayout = NoteLyricPresentation::layout(
+        QRectF(0.0, 0.0, 6.0, noteTextHeight), QStringLiteral("啦"), lyricFont, 1.0);
+    expect(negativeWidthLayout.textRect.width() < 0.0 && !negativeWidthLayout.isVisible() &&
+               negativeWidthLayout.elided,
+           "an ultra-short note must not draw a one-character lyric outside its bounds");
     const auto compactLayout = NoteLyricPresentation::layout(
         narrowNoteRect, longLyric, lyricFont, NoteLyricPresentation::compactScaleThreshold - 0.01);
     expect(!compactLayout.isVisible() && !compactLayout.elided,

--- a/src/tests/TestPianoRollInteractions/main.cpp
+++ b/src/tests/TestPianoRollInteractions/main.cpp
@@ -117,6 +117,12 @@ int main(int argc, char *argv[]) {
         QRectF(0.0, 0.0, 7.0, noteTextHeight), longLyric, lyricFont, 1.0);
     expect(!ultraShortLayout.isVisible() && ultraShortLayout.elided,
            "a lyric with no drawable width must remain eligible for its tooltip");
+    const auto subpixelWidthLayout = NoteLyricPresentation::layout(
+        QRectF(0.0, 0.0, 7.2, noteTextHeight), QStringLiteral("啦"), lyricFont, 1.0);
+    expect(subpixelWidthLayout.textRect.width() > 0.0 &&
+               subpixelWidthLayout.textRect.width() < 1.0 && !subpixelWidthLayout.isVisible() &&
+               subpixelWidthLayout.elided,
+           "a subpixel lyric area must stay tooltip-eligible across editor backends");
     const auto negativeWidthLayout = NoteLyricPresentation::layout(
         QRectF(0.0, 0.0, 6.0, noteTextHeight), QStringLiteral("啦"), lyricFont, 1.0);
     expect(negativeWidthLayout.textRect.width() < 0.0 && !negativeWidthLayout.isVisible() &&


### PR DESCRIPTION
## Summary

- stop lyric layout when the note's drawable text width is non-positive
- preserve the elided state so ultra-short notes remain eligible for lyric tooltips
- add regression coverage for a one-character lyric in a 6 px note

## Validation

- `ConfigureAndBuild -Preset debug`
- `TestPianoRollInteractions.exe` with Qt offscreen platform
- Computer Use: confirmed `PianoRollRhiWidget`, opened `overflow.dspx`, and verified the 31-tick note no longer renders `啦` outside its bounds

The aggregate `test` target was also attempted. This regression test passed; the aggregate remained red because 14 other test executables were not built by that target and the unrelated `TestPitchDisplayStrategy` test failed.