### PR TITLE
fix(inference): release switched voicebank sessions

### DIFF
--- a/src/app/Modules/Inference/InferController.cpp
+++ b/src/app/Modules/Inference/InferController.cpp
@@ -1,4 +1,5 @@
 #include "InferController.h"
+#include "InferEngine.h"
 #include "Model/AppStatus/AppStatus.h"
 #include "InferController_p.h"
 
@@ -150,6 +151,7 @@ InferController::InferController(QObject *parent)
             &InferControllerPrivate::onPlaybackStatusChanged);
     connect(playbackController, &PlaybackController::positionChanged, d,
             &InferControllerPrivate::onPlaybackPositionChanged);
+    d->syncSingerSessions();
 }
 
 InferController::~InferController() = default;
@@ -354,6 +356,7 @@ void InferControllerPrivate::suspendPendingAcousticPipelines() {
 
 void InferControllerPrivate::handleModelChanged() {
     qInfo() << "Reset inference state for model change";
+    syncSingerSessions();
     editSessionManager->clear();
     appStatus->currentEditObject = AppStatus::EditObjectType::None;
     clearAllPendingApplies("pending-cleared-model-changed");
@@ -420,8 +423,22 @@ void InferControllerPrivate::handleTempoChanged() {
     }
 }
 
+void InferControllerPrivate::handleTrackInserted(Track *track) {
+    ModelChangeHandler::handleTrackInserted(track);
+    connect(track, &Track::voiceContextChanged, this,
+            [this] { syncSingerSessions(); });
+    syncSingerSessions();
+}
+
+void InferControllerPrivate::handleTrackRemoved(Track *track) {
+    disconnect(track, &Track::voiceContextChanged, this, nullptr);
+    ModelChangeHandler::handleTrackRemoved(track);
+    syncSingerSessions();
+}
+
 void InferControllerPrivate::handleSingingClipInserted(SingingClip *clip) {
     ModelChangeHandler::handleSingingClipInserted(clip);
+    syncSingerSessions();
 
     if (!clip->pieces().isEmpty()) {
         // Cross-track move: keep existing pipelines only when their singer/speaker context is
@@ -443,6 +460,7 @@ void InferControllerPrivate::handleSingingClipInserted(SingingClip *clip) {
 
 void InferControllerPrivate::handleSingingClipRemoved(SingingClip *clip) {
     ModelChangeHandler::handleSingingClipRemoved(clip);
+    syncSingerSessions();
 
     if (appModel->findClipById(clip->id())) {
         // Cross-track move: inference pipelines continue running,
@@ -586,6 +604,7 @@ void InferControllerPrivate::handleVoiceContextChanged(const VoiceContextChange 
     if (!clip)
         return;
 
+    syncSingerSessions();
     const bool singerChanged = change.before.singer != change.after.singer;
     const bool speakerChanged = change.before.speaker != change.after.speaker;
     if (singerChanged || speakerChanged) {
@@ -629,6 +648,26 @@ void InferControllerPrivate::handleVoiceContextChanged(const VoiceContextChange 
         for (const auto pipeline : pipelines)
             pipeline->onExpressivenessChanged();
     }
+}
+
+void InferControllerPrivate::syncSingerSessions() {
+    QSet<SingerIdentifier> identifiers;
+    for (const auto track : appModel->tracks()) {
+        const auto trackIdentifier = track->singerIdentifier();
+        if (!trackIdentifier.isEmpty()) {
+            identifiers.insert(trackIdentifier);
+        }
+        for (const auto clip : track->clips()) {
+            if (clip->clipType() != IClip::Singing) {
+                continue;
+            }
+            const auto identifier = static_cast<SingingClip *>(clip)->singerIdentifier();
+            if (!identifier.isEmpty()) {
+                identifiers.insert(identifier);
+            }
+        }
+    }
+    inferEngine->retainSingerSessions(identifiers);
 }
 
 void InferControllerPrivate::handleLanguageModuleStatusChanged(

--- a/src/app/Modules/Inference/InferController_p.h
+++ b/src/app/Modules/Inference/InferController_p.h
@@ -44,6 +44,8 @@ public slots:
 protected:
     void handleModelChanged() override;
     void handleTempoChanged() override;
+    void handleTrackInserted(Track *track) override;
+    void handleTrackRemoved(Track *track) override;
     void handleSingingClipInserted(SingingClip *clip) override;
     void handleSingingClipRemoved(SingingClip *clip) override;
     void handlePiecesChanged(const PieceList &newPieces, const PieceList &discardedPieces,
@@ -55,6 +57,7 @@ protected:
 
 public:
     void handleLanguageModuleStatusChanged(AppStatus::ModuleStatus status);
+    void syncSingerSessions();
     void handleGetPronTaskFinished(GetPronunciationTask &task);
     void handleGetPhoneTaskFinished(GetPhonemeNameTask &task);
 

--- a/src/app/Modules/Inference/InferEngine.cpp
+++ b/src/app/Modules/Inference/InferEngine.cpp
@@ -23,6 +23,8 @@
 #include <QStandardPaths>
 #include <QString>
 
+#include <algorithm>
+
 #include "Tasks/InferTaskCommon.h"
 #include "Utils/CudaGpuUtils.h"
 
@@ -48,6 +50,19 @@ static void log_report_callback(const int level, const srt::core::LogContext &ct
             Log::d(ctx.category, message_qstr);
             break;
     }
+}
+
+static bool packageIsSelected(const ds::session::LoadedVoicebankInfo &package,
+                              const QSet<SingerIdentifier> &identifiers) {
+    const auto packageId = QString::fromStdString(package.packageId);
+    const auto packageVersion =
+        QVersionNumber::fromString(QString::fromStdString(package.version.toString()));
+    return std::any_of(identifiers.cbegin(), identifiers.cend(),
+                       [&packageId, &packageVersion](const SingerIdentifier &identifier) {
+                           return identifier.packageId == packageId &&
+                                  QVersionNumber::compare(identifier.packageVersion,
+                                                          packageVersion) == 0;
+                       });
 }
 
 InferEngine::InferEngine(QObject *parent) : QObject(parent) {
@@ -238,6 +253,30 @@ std::shared_ptr<ds::session::ModelSetHandle>
         }
         return *exp;
     });
+}
+
+void InferEngine::retainSingerSessions(const QSet<SingerIdentifier> &identifiers) {
+    QReadLocker lock(&m_engineRwLock);
+    m_singerSessions.retainOnly(identifiers);
+    if (!m_initialized || m_disposed) {
+        return;
+    }
+
+    auto &session = SynthrtEngine::instance().session();
+    for (const auto &package : session.loadedVoicebanks()) {
+        if (packageIsSelected(package, identifiers)) {
+            continue;
+        }
+
+        auto result = session.unloadVoicebank(package.packageId, package.version);
+        if (!result && result.error().code() != srt::core::ErrorCode::PackageInUse &&
+            result.error().code() != srt::core::ErrorCode::RuntimePackageNotLoaded) {
+            qWarning().noquote().nospace()
+                << "retainSingerSessions: failed to unload package "
+                << QString::fromStdString(package.packageId) << ": "
+                << QString::fromUtf8(result.error().messageWithLocation());
+        }
+    }
 }
 
 void InferEngine::dispose() {

--- a/src/app/Modules/Inference/InferEngine.h
+++ b/src/app/Modules/Inference/InferEngine.h
@@ -10,6 +10,7 @@
 
 #include <QReadWriteLock>
 #include <QObject>
+#include <QSet>
 
 #include <synthrt/Core/Core/Runtime.h>
 #include <diffsinger/Session/ModelSetHandle.h>
@@ -55,6 +56,7 @@ public:
     // shape the 4 DiffSinger tasks consume.
     std::shared_ptr<ds::session::ModelSetHandle>
         acquireSingerSession(const SingerIdentifier &identifier) const;
+    void retainSingerSessions(const QSet<SingerIdentifier> &identifiers);
 
     // Kicks off asynchronous initialization; called by the owner after
     // construction.

--- a/src/app/Modules/Inference/SingerSessionCache.h
+++ b/src/app/Modules/Inference/SingerSessionCache.h
@@ -8,6 +8,7 @@
 #include <lite/ProjectModel/AppModel/SingerIdentifier.h>
 
 #include <QHash>
+#include <QSet>
 
 template <typename Handle>
 class SingerSessionCache final {
@@ -27,23 +28,41 @@ public:
             }
 
             result = std::forward<Factory>(factory)();
-            if (result) {
+            if (result && m_retainedIdentifiers.contains(identifier)) {
                 m_handles.insert(identifier, result);
             }
         }
         return result;
     }
 
+    void retainOnly(const QSet<SingerIdentifier> &identifiers) {
+        QHash<SingerIdentifier, std::shared_ptr<Handle>> released;
+        {
+            std::lock_guard lock(m_mutex);
+            m_retainedIdentifiers = identifiers;
+            for (auto it = m_handles.begin(); it != m_handles.end();) {
+                if (identifiers.contains(it.key())) {
+                    ++it;
+                    continue;
+                }
+                released.insert(it.key(), std::move(it.value()));
+                it = m_handles.erase(it);
+            }
+        }
+    }
+
     void clear() {
         QHash<SingerIdentifier, std::shared_ptr<Handle>> released;
         {
             std::lock_guard lock(m_mutex);
+            m_retainedIdentifiers.clear();
             m_handles.swap(released);
         }
     }
 
 private:
     std::mutex m_mutex;
+    QSet<SingerIdentifier> m_retainedIdentifiers;
     QHash<SingerIdentifier, std::shared_ptr<Handle>> m_handles;
 };
 

--- a/src/tests/TestSingerSessionCache/main.cpp
+++ b/src/tests/TestSingerSessionCache/main.cpp
@@ -29,15 +29,22 @@ namespace {
         bool stale = false;
     };
 
-    bool testOwningLifetimeAndStaleReplacement() {
+    SingerIdentifier makeIdentifier(const QString &singerId) {
+        SingerIdentifier identifier;
+        identifier.packageId = QStringLiteral("package");
+        identifier.singerId = singerId;
+        identifier.packageVersion = QVersionNumber(1, 0, 0);
+        return identifier;
+    }
+
+    bool testRetainsOnlySelectedSingers() {
         bool ok = true;
         int creationCount = 0;
         int destroyedCount = 0;
         SingerSessionCache<FakeHandle> cache;
-        SingerIdentifier identifier;
-        identifier.packageId = QStringLiteral("package");
-        identifier.singerId = QStringLiteral("singer");
-        identifier.packageVersion = QVersionNumber(1, 0, 0);
+        const auto firstIdentifier = makeIdentifier(QStringLiteral("first"));
+        const auto secondIdentifier = makeIdentifier(QStringLiteral("second"));
+        cache.retainOnly({firstIdentifier, secondIdentifier});
 
         const auto createHandle = [&] {
             ++creationCount;
@@ -46,34 +53,69 @@ namespace {
 
         std::weak_ptr<FakeHandle> firstWeak;
         {
-            const auto first = cache.acquire(identifier, createHandle);
+            const auto first = cache.acquire(firstIdentifier, createHandle);
             firstWeak = first;
         }
         ok &= expect(!firstWeak.expired(), "cache retains the handle after the caller releases it");
 
-        auto reused = cache.acquire(identifier, createHandle);
+        auto reused = cache.acquire(firstIdentifier, createHandle);
         ok &= expect(reused == firstWeak.lock(), "a non-stale handle is reused");
         ok &= expect(creationCount == 1, "reuse does not create another handle");
-
-        reused->stale = true;
-        const auto staleWeak = std::weak_ptr<FakeHandle>(reused);
-        auto replacement = cache.acquire(identifier, createHandle);
-        ok &= expect(replacement != reused, "a stale handle is replaced");
-        ok &= expect(creationCount == 2, "stale replacement creates exactly one handle");
         reused.reset();
+
+        auto second = cache.acquire(secondIdentifier, createHandle);
+        const auto secondWeak = std::weak_ptr<FakeHandle>(second);
+        second.reset();
+
+        cache.retainOnly({secondIdentifier});
+        ok &= expect(firstWeak.expired(), "a deselected singer handle is released");
+        ok &= expect(!secondWeak.expired(), "a selected singer handle remains cached");
+
+        auto uncached = cache.acquire(firstIdentifier, createHandle);
+        const auto uncachedWeak = std::weak_ptr<FakeHandle>(uncached);
+        uncached.reset();
+        ok &= expect(uncachedWeak.expired(), "a deselected singer cannot re-enter the cache");
+
+        cache.clear();
+        ok &= expect(secondWeak.expired(), "clearing releases the remaining cached handle");
+        ok &= expect(creationCount == 3, "only the expected handles are created");
+        ok &= expect(destroyedCount == 3, "all selected and uncached handles are destroyed once");
+        return ok;
+    }
+
+    bool testActiveCallerAndStaleReplacement() {
+        bool ok = true;
+        int creationCount = 0;
+        int destroyedCount = 0;
+        SingerSessionCache<FakeHandle> cache;
+        const auto identifier = makeIdentifier(QStringLiteral("singer"));
+        cache.retainOnly({identifier});
+
+        const auto createHandle = [&] {
+            ++creationCount;
+            return std::make_shared<FakeHandle>(destroyedCount);
+        };
+
+        auto active = cache.acquire(identifier, createHandle);
+        active->stale = true;
+        const auto staleWeak = std::weak_ptr<FakeHandle>(active);
+        auto replacement = cache.acquire(identifier, createHandle);
+        ok &= expect(replacement != active, "a stale handle is replaced");
+        ok &= expect(creationCount == 2, "stale replacement creates exactly one handle");
+        active.reset();
         ok &= expect(staleWeak.expired(), "the displaced stale handle is released");
 
         const auto replacementWeak = std::weak_ptr<FakeHandle>(replacement);
-        cache.clear();
-        ok &= expect(!replacementWeak.expired(), "an active caller survives cache clearing");
+        cache.retainOnly({});
+        ok &= expect(!replacementWeak.expired(), "an active caller survives cache eviction");
         replacement.reset();
         ok &= expect(replacementWeak.expired(),
-                     "the final handle is released after its caller exits");
+                     "an evicted handle releases after its caller exits");
         ok &= expect(destroyedCount == 2, "all handles are destroyed exactly once");
         return ok;
     }
 }
 
 int main() {
-    return testOwningLifetimeAndStaleReplacement() ? 0 : 1;
+    return testRetainsOnlySelectedSingers() && testActiveCallerAndStaleReplacement() ? 0 : 1;
 }


### PR DESCRIPTION
## 问题

声库切换后，`SingerSessionCache` 会持续强引用所有曾用过的 `ModelSetHandle`，对应的 ONNX Runtime session 只能在应用退出时统一释放，反复切换声库会累积显存占用。

## 修改

- 将 session 缓存约束到当前工程中已选中的歌手集合；切走歌手后立即移除缓存强引用
- 同步 track 歌手与 singing clip 覆盖歌手，支持多轨/片段级多声库同时选中
- 对已不在选中范围内的 voicebank 请求卸载；仍被运行中任务引用时沿用 synthrt 的延迟卸载语义
- 防止已取消的旧任务在切换完成后把旧歌手 session 重新放回缓存
- 扩充缓存生命周期单元测试，覆盖复用、切走释放、活动调用者、stale 替换和清空

## 验证

- `TestSingerSessionCache`：通过
- Debug preset 完整 configure + build：通过
- 全量 CTest 中相关测试通过；现有 `TestPitchDisplayStrategy` 断言失败，且若干未构建测试目标被 CTest 报为 Not Run，与本 PR 无关
