### PR TITLE
fix(speaker-mix): sample dynamic automation in clip-local time

### DIFF
--- a/src/app/Modules/Inference/InferController.cpp
+++ b/src/app/Modules/Inference/InferController.cpp
@@ -100,7 +100,7 @@ namespace {
             const auto speakerMix = InferSpeakerMixModel::effectiveSpeakerMixFromData(
                 clip.speakerMixData(), clip.speakerId(),
                 clip.start() + piece->localStartTick(timeline),
-                clip.start() + piece->localEndTick(timeline), timeline);
+                clip.start() + piece->localEndTick(timeline), clip.start(), timeline);
             if (piece->identifier != identifier || piece->speakerMix != speakerMix)
                 return false;
         }
@@ -412,7 +412,8 @@ void InferControllerPrivate::handleTempoChanged() {
                 piece.speakerMix = InferSpeakerMixModel::effectiveSpeakerMixFromData(
                     singingClip->speakerMixData(), singingClip->speakerId(),
                     singingClip->start() + piece.localStartTick(timeline),
-                    singingClip->start() + piece.localEndTick(timeline), timeline);
+                    singingClip->start() + piece.localEndTick(timeline), singingClip->start(),
+                    timeline);
                 piece.speaker = piece.speakerMix.fallbackSpeaker;
                 pipeline->onTimelineChanged();
             }
@@ -626,7 +627,7 @@ void InferControllerPrivate::handleVoiceContextChanged(const VoiceContextChange 
         const auto speakerMix = InferSpeakerMixModel::effectiveSpeakerMixFromData(
             clip->speakerMixData(), clip->speakerId(),
             clip->start() + piece->localStartTick(timeline),
-            clip->start() + piece->localEndTick(timeline), timeline);
+            clip->start() + piece->localEndTick(timeline), clip->start(), timeline);
         piece->speakerMix = speakerMix;
         piece->speaker = speakerMix.fallbackSpeaker;
         Helper::resetPitch(*piece);

--- a/src/libs/ProjectModel/AppModel/SingingClip.cpp
+++ b/src/libs/ProjectModel/AppModel/SingingClip.cpp
@@ -148,7 +148,7 @@ ReSegmentResult SingingClip::reSegment(const Timeline &timeline, const bool bump
             newPiece->paddingEndMs = segment.paddingEndMs;
             newPiece->speakerMix = InferSpeakerMixModel::effectiveSpeakerMixFromData(
                 speakerMixData(), speakerId(), start() + newPiece->localStartTick(timeline),
-                start() + newPiece->localEndTick(timeline), timeline);
+                start() + newPiece->localEndTick(timeline), start(), timeline);
             newPiece->speaker = newPiece->speakerMix.fallbackSpeaker;
             newPieces.append(newPiece);
             result.addedPieces.append(newPiece);

--- a/src/libs/ProjectModel/InferenceData/InferSpeakerMix.cpp
+++ b/src/libs/ProjectModel/InferenceData/InferSpeakerMix.cpp
@@ -176,7 +176,8 @@ namespace InferSpeakerMixModel {
 
     InferSpeakerMix dynamicSpeakerMixFromData(const SpeakerMixModel::SpeakerMixData &data,
                                               const QString &fallbackSpeaker, const int startTick,
-                                              const int endTick, const Timeline &timeline,
+                                              const int endTick, const int keyframeOriginTick,
+                                              const Timeline &timeline,
                                               const double intervalSeconds) {
         const auto normalized = SpeakerMixModel::normalizeSpeakerMixData(data);
         if (!SpeakerMixModel::isDynamicMixActive(normalized) || endTick <= startTick ||
@@ -207,7 +208,8 @@ namespace InferSpeakerMixModel {
             const int sampleTick =
                 qRound(timeline.secToTick(startSeconds + intervalSeconds * frame));
             const auto fullWeights = SpeakerMixModel::fullWeightsFromExplicitWeights(
-                interpolateExplicitWeights(normalized.dynamicKeyframes, sampleTick));
+                interpolateExplicitWeights(normalized.dynamicKeyframes,
+                                           sampleTick - keyframeOriginTick));
             if (fullWeights.size() != sources.size())
                 return fixedSpeakerMixFromData(normalized, fallbackSpeaker);
             for (int i = 0; i < sources.size(); ++i)
@@ -222,11 +224,12 @@ namespace InferSpeakerMixModel {
 
     InferSpeakerMix effectiveSpeakerMixFromData(const SpeakerMixModel::SpeakerMixData &data,
                                                 const QString &fallbackSpeaker, const int startTick,
-                                                const int endTick, const Timeline &timeline,
+                                                const int endTick, const int keyframeOriginTick,
+                                                const Timeline &timeline,
                                                 const double intervalSeconds) {
         if (SpeakerMixModel::isDynamicMixActive(data)) {
-            return dynamicSpeakerMixFromData(data, fallbackSpeaker, startTick, endTick, timeline,
-                                             intervalSeconds);
+            return dynamicSpeakerMixFromData(data, fallbackSpeaker, startTick, endTick,
+                                             keyframeOriginTick, timeline, intervalSeconds);
         }
         return fixedSpeakerMixFromData(data, fallbackSpeaker);
     }

--- a/src/libs/ProjectModel/InferenceData/InferSpeakerMix.h
+++ b/src/libs/ProjectModel/InferenceData/InferSpeakerMix.h
@@ -40,11 +40,13 @@ namespace InferSpeakerMixModel {
                                              const QString &fallbackSpeaker);
     InferSpeakerMix dynamicSpeakerMixFromData(const SpeakerMixModel::SpeakerMixData &data,
                                               const QString &fallbackSpeaker, int startTick,
-                                              int endTick, const Timeline &timeline,
+                                              int endTick, int keyframeOriginTick,
+                                              const Timeline &timeline,
                                               double intervalSeconds = 0.01);
     InferSpeakerMix effectiveSpeakerMixFromData(const SpeakerMixModel::SpeakerMixData &data,
                                                 const QString &fallbackSpeaker, int startTick,
-                                                int endTick, const Timeline &timeline,
+                                                int endTick, int keyframeOriginTick,
+                                                const Timeline &timeline,
                                                 double intervalSeconds = 0.01);
     InferSpeakerMix fitToFrames(const InferSpeakerMix &mix, int frames,
                                 double intervalSeconds = 0.01);

--- a/src/tests/TestSpeakerMix/main.cpp
+++ b/src/tests/TestSpeakerMix/main.cpp
@@ -282,7 +282,8 @@ namespace {
 
         const auto timeline = timeline120Bpm();
         const auto dynamic = dynamicMixData();
-        const auto mix = dynamicSpeakerMixFromData(dynamic, "fallback", 0, 960, timeline, 0.5);
+        const auto mix =
+            dynamicSpeakerMixFromData(dynamic, "fallback", 0, 960, 0, timeline, 0.5);
 
         ok &= expect(mix.sources.size() == 2, "dynamic inference keeps two sources");
         ok &= expect(mix.sources.at(0).speaker == "spk-a" && mix.sources.at(1).speaker == "spk-b",
@@ -296,20 +297,26 @@ namespace {
                      "dynamic inference fallback chooses highest average source");
 
         const auto fixedFallback = fixedSpeakerMixFromData(dynamic, "fallback");
-        ok &= expect(dynamicSpeakerMixFromData(dynamic, "fallback", 960, 0, timeline, 0.5) ==
+        ok &= expect(dynamicSpeakerMixFromData(dynamic, "fallback", 960, 0, 0, timeline, 0.5) ==
                          fixedFallback,
                      "dynamic inference with invalid range falls back to fixed");
-        ok &= expect(dynamicSpeakerMixFromData(dynamic, "fallback", 0, 960, timeline, 0.0) ==
+        ok &= expect(dynamicSpeakerMixFromData(dynamic, "fallback", 0, 960, 0, timeline, 0.0) ==
                          fixedFallback,
                      "dynamic inference with invalid interval falls back to fixed");
 
-        ok &= expect(effectiveSpeakerMixFromData(dynamic, "fallback", 0, 960, timeline, 0.5) == mix,
+        ok &= expect(effectiveSpeakerMixFromData(dynamic, "fallback", 0, 960, 0, timeline, 0.5) ==
+                         mix,
                      "effective inference uses dynamic mix when active");
+
+        const auto shiftedMix =
+            effectiveSpeakerMixFromData(dynamic, "fallback", 1920, 2880, 1920, timeline, 0.5);
+        ok &= expect(shiftedMix == mix,
+                     "dynamic inference samples clip-local keyframes for shifted clips");
 
         auto bypassed = dynamicMixData();
         bypassed.dynamicBypassed = true;
         bypassed.fixedWeights = {0.1};
-        ok &= expect(effectiveSpeakerMixFromData(bypassed, "fallback", 0, 960, timeline, 0.5) ==
+        ok &= expect(effectiveSpeakerMixFromData(bypassed, "fallback", 0, 960, 0, timeline, 0.5) ==
                          fixedSpeakerMixFromData(bypassed, "fallback"),
                      "effective inference uses fixed mix when dynamic is bypassed");
 


### PR DESCRIPTION
## 问题

动态混合关键帧的位置以剪辑本地 tick 存储，但推理阶段在 tempo-map 改造后直接用工程全局 tick 采样。非零起点的剪辑因此会提前越过全部关键帧，并在整段合成中错误使用最后一个混合值。

## 修改

- 将剪辑起点作为动态混合关键帧的时间原点传入推理模型
- tempo map 的秒/tick 换算继续使用全局时间，仅在关键帧插值前转换回剪辑本地时间
- 增加非零剪辑起点的回归用例，确保平移后的剪辑与零起点剪辑得到相同的动态混合帧

## 验证

- `TestSpeakerMix.exe`：通过
- `cmake --build --preset debug --target DsEditorLite`（通过项目构建脚本）：通过
- Computer Use：基线版本在用户工程中确认动态曲线位于全局第 17 小节附近但推理取到末端值；修复版重新加载同一工程与 Shisakune-Demo 后正常完成合成并生成波形