### PR TITLE
fix(project): accept legacy DSPX clip ranges

### DIFF
--- a/src/app/Automation/OperationIds.h
+++ b/src/app/Automation/OperationIds.h
@@ -70,10 +70,10 @@ namespace Automation::OperationIds {
     X(notes, move, "notes.move")                                                                   \
     X(notes, quantize, "notes.quantize")                                                           \
     X(notes, remove, "notes.remove")                                                               \
+    X(notes, reset_phoneme_offsets, "notes.reset_phoneme_offsets")                                 \
     X(notes, resize_left, "notes.resize_left")                                                     \
     X(notes, resize_right, "notes.resize_right")                                                   \
     X(notes, set_phoneme_offsets, "notes.set_phoneme_offsets")                                     \
-    X(notes, reset_phoneme_offsets, "notes.reset_phoneme_offsets")                                 \
     X(notes, set_word_properties, "notes.set_word_properties")                                     \
     X(notes, split, "notes.split")                                                                 \
     X(operations, cancel, "operations.cancel")                                                     \

--- a/src/app/Automation/OperationIds.h
+++ b/src/app/Automation/OperationIds.h
@@ -143,8 +143,12 @@ namespace Automation::OperationIds {
 
     inline const QStringList &all() {
 #define AUTOMATION_REFERENCE_OPERATION_ID(scope, name, value) scope::name,
-        static const QStringList ids = {
-            AUTOMATION_OPERATION_ID_LIST(AUTOMATION_REFERENCE_OPERATION_ID)};
+        static const QStringList ids = [] {
+            QStringList result = {
+                AUTOMATION_OPERATION_ID_LIST(AUTOMATION_REFERENCE_OPERATION_ID)};
+            result.sort();
+            return result;
+        }();
 #undef AUTOMATION_REFERENCE_OPERATION_ID
         return ids;
     }

--- a/src/app/Automation/OperationIds.h
+++ b/src/app/Automation/OperationIds.h
@@ -70,10 +70,10 @@ namespace Automation::OperationIds {
     X(notes, move, "notes.move")                                                                   \
     X(notes, quantize, "notes.quantize")                                                           \
     X(notes, remove, "notes.remove")                                                               \
-    X(notes, reset_phoneme_offsets, "notes.reset_phoneme_offsets")                                 \
     X(notes, resize_left, "notes.resize_left")                                                     \
     X(notes, resize_right, "notes.resize_right")                                                   \
     X(notes, set_phoneme_offsets, "notes.set_phoneme_offsets")                                     \
+    X(notes, reset_phoneme_offsets, "notes.reset_phoneme_offsets")                                 \
     X(notes, set_word_properties, "notes.set_word_properties")                                     \
     X(notes, split, "notes.split")                                                                 \
     X(operations, cancel, "operations.cancel")                                                     \

--- a/src/app/Automation/ProjectAutomationDtos.cpp
+++ b/src/app/Automation/ProjectAutomationDtos.cpp
@@ -546,7 +546,10 @@ namespace Automation {
             auto *audio = static_cast<AudioClip *>(result.get());
             if (audio->hasRealTimeAnchor()) {
                 audio->updateTicksFromTruth(timeline);
-                if (audio->start() == draft.properties.start &&
+                const auto submittedLocalEnd =
+                    static_cast<qint64>(draft.properties.clipStart) + draft.properties.clipLen;
+                if (draft.properties.length < submittedLocalEnd &&
+                    audio->start() == draft.properties.start &&
                     audio->clipStart() == draft.properties.clipStart &&
                     audio->clipLen() == draft.properties.clipLen) {
                     audio->setLength(draft.properties.length);

--- a/src/app/Automation/ProjectAutomationDtos.cpp
+++ b/src/app/Automation/ProjectAutomationDtos.cpp
@@ -544,8 +544,16 @@ namespace Automation {
         result->workspace() = draft.workspace;
         if (result->clipType() == Clip::Audio) {
             auto *audio = static_cast<AudioClip *>(result.get());
-            if (!audio->hasRealTimeAnchor())
+            if (audio->hasRealTimeAnchor()) {
+                audio->updateTicksFromTruth(timeline);
+                if (audio->start() == draft.properties.start &&
+                    audio->clipStart() == draft.properties.clipStart &&
+                    audio->clipLen() == draft.properties.clipLen) {
+                    audio->setLength(draft.properties.length);
+                }
+            } else {
                 audio->syncTruthFromTicks(timeline);
+            }
         }
         return result;
     }

--- a/src/app/Automation/ProjectAutomationDtos.cpp
+++ b/src/app/Automation/ProjectAutomationDtos.cpp
@@ -698,12 +698,13 @@ namespace Automation {
 
     AutomationResult<AutomationUnit> validate(const ClipDraftDto &draft) {
         const auto &properties = draft.properties;
+        const auto localEnd = static_cast<qint64>(properties.clipStart) + properties.clipLen;
         const auto visibleStart = static_cast<qint64>(properties.start) + properties.clipStart;
         const auto visibleEnd = visibleStart + properties.clipLen;
-        if (visibleStart < 0 || visibleEnd > std::numeric_limits<int>::max() ||
-            properties.length < 0 || properties.clipStart < 0 || properties.clipLen < 0 ||
-            !std::isfinite(properties.gain) || !std::isfinite(properties.trimStartMs) ||
-            !std::isfinite(properties.playLengthMs) ||
+        if (localEnd > std::numeric_limits<int>::max() || visibleStart < 0 ||
+            visibleEnd > std::numeric_limits<int>::max() || properties.length < 0 ||
+            properties.clipStart < 0 || properties.clipLen < 0 || !std::isfinite(properties.gain) ||
+            !std::isfinite(properties.trimStartMs) || !std::isfinite(properties.playLengthMs) ||
             !std::isfinite(properties.materialLengthMs)) {
             return AutomationError::invalidArgument(
                 QStringLiteral("clip.properties"),

--- a/src/app/Automation/ProjectAutomationDtos.cpp
+++ b/src/app/Automation/ProjectAutomationDtos.cpp
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <cmath>
+#include <limits>
 
 namespace Automation {
     namespace {
@@ -697,7 +698,9 @@ namespace Automation {
 
     AutomationResult<AutomationUnit> validate(const ClipDraftDto &draft) {
         const auto &properties = draft.properties;
-        if (static_cast<qint64>(properties.start) + properties.clipStart < 0 ||
+        const auto visibleStart = static_cast<qint64>(properties.start) + properties.clipStart;
+        const auto visibleEnd = visibleStart + properties.clipLen;
+        if (visibleStart < 0 || visibleEnd > std::numeric_limits<int>::max() ||
             properties.length < 0 || properties.clipStart < 0 || properties.clipLen < 0 ||
             !std::isfinite(properties.gain) || !std::isfinite(properties.trimStartMs) ||
             !std::isfinite(properties.playLengthMs) ||

--- a/src/app/Automation/ProjectAutomationDtos.cpp
+++ b/src/app/Automation/ProjectAutomationDtos.cpp
@@ -544,9 +544,7 @@ namespace Automation {
         result->workspace() = draft.workspace;
         if (result->clipType() == Clip::Audio) {
             auto *audio = static_cast<AudioClip *>(result.get());
-            if (audio->hasRealTimeAnchor())
-                audio->updateTicksFromTruth(timeline);
-            else
+            if (!audio->hasRealTimeAnchor())
                 audio->syncTruthFromTicks(timeline);
         }
         return result;

--- a/src/app/Automation/ProjectAutomationDtos.cpp
+++ b/src/app/Automation/ProjectAutomationDtos.cpp
@@ -697,9 +697,8 @@ namespace Automation {
 
     AutomationResult<AutomationUnit> validate(const ClipDraftDto &draft) {
         const auto &properties = draft.properties;
-        if (properties.start + properties.clipStart < 0 || properties.length < 0 ||
-            properties.clipStart < 0 || properties.clipLen < 0 ||
-            properties.clipStart + properties.clipLen > properties.length ||
+        if (static_cast<qint64>(properties.start) + properties.clipStart < 0 ||
+            properties.length < 0 || properties.clipStart < 0 || properties.clipLen < 0 ||
             !std::isfinite(properties.gain) || !std::isfinite(properties.trimStartMs) ||
             !std::isfinite(properties.playLengthMs) ||
             !std::isfinite(properties.materialLengthMs)) {

--- a/src/app/Automation/ProjectAutomationFacade.cpp
+++ b/src/app/Automation/ProjectAutomationFacade.cpp
@@ -125,8 +125,6 @@ namespace Automation {
         bool validClipProperties(const ClipPropertiesDto &properties) {
             return static_cast<qint64>(properties.start) + properties.clipStart >= 0 &&
                    properties.length >= 0 && properties.clipStart >= 0 && properties.clipLen >= 0 &&
-                   static_cast<qint64>(properties.clipStart) + properties.clipLen <=
-                       properties.length &&
                    std::isfinite(properties.gain) && std::isfinite(properties.trimStartMs) &&
                    std::isfinite(properties.playLengthMs) &&
                    std::isfinite(properties.materialLengthMs);

--- a/src/app/Automation/ProjectAutomationFacade.cpp
+++ b/src/app/Automation/ProjectAutomationFacade.cpp
@@ -124,10 +124,12 @@ namespace Automation {
         }
 
         bool validClipProperties(const ClipPropertiesDto &properties) {
+            const auto localEnd = static_cast<qint64>(properties.clipStart) + properties.clipLen;
             const auto visibleStart = static_cast<qint64>(properties.start) + properties.clipStart;
             const auto visibleEnd = visibleStart + properties.clipLen;
-            return visibleStart >= 0 && visibleEnd <= std::numeric_limits<int>::max() &&
-                   properties.length >= 0 && properties.clipStart >= 0 && properties.clipLen >= 0 &&
+            return localEnd <= std::numeric_limits<int>::max() && visibleStart >= 0 &&
+                   visibleEnd <= std::numeric_limits<int>::max() && properties.length >= 0 &&
+                   properties.clipStart >= 0 && properties.clipLen >= 0 &&
                    std::isfinite(properties.gain) && std::isfinite(properties.trimStartMs) &&
                    std::isfinite(properties.playLengthMs) &&
                    std::isfinite(properties.materialLengthMs);

--- a/src/app/Automation/ProjectAutomationFacade.cpp
+++ b/src/app/Automation/ProjectAutomationFacade.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -123,7 +124,9 @@ namespace Automation {
         }
 
         bool validClipProperties(const ClipPropertiesDto &properties) {
-            return static_cast<qint64>(properties.start) + properties.clipStart >= 0 &&
+            const auto visibleStart = static_cast<qint64>(properties.start) + properties.clipStart;
+            const auto visibleEnd = visibleStart + properties.clipLen;
+            return visibleStart >= 0 && visibleEnd <= std::numeric_limits<int>::max() &&
                    properties.length >= 0 && properties.clipStart >= 0 && properties.clipLen >= 0 &&
                    std::isfinite(properties.gain) && std::isfinite(properties.trimStartMs) &&
                    std::isfinite(properties.playLengthMs) &&

--- a/src/app/Controller/Actions/AppModel/Clip/EditClipCommonPropertiesAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Clip/EditClipCommonPropertiesAction.cpp
@@ -7,8 +7,8 @@
 #include <algorithm>
 
 namespace {
-    void applyArgs(Clip *clip, const Clip::ClipCommonProperties &args,
-                   const bool updateAudioTiming) {
+    void applyArgs(Clip *clip, const Clip::ClipCommonProperties &args, const bool updateAudioTiming,
+                   const bool preserveAudioTickCaches) {
         // opendspx requires clip.pos = start + clipStart to stay non-negative.
         auto safeArgs = Clip::ClipCommonProperties(args);
         safeArgs.start = std::max(safeArgs.start, -safeArgs.clipStart);
@@ -22,8 +22,8 @@ namespace {
         if (clip->clipType() == IClip::Audio && updateAudioTiming) {
             // The tick snapshot may predate a tempo change; the ms truth
             // carried in the args re-derives the caches under the current map
-            static_cast<AudioClip *>(clip)->applyRealTimeAnchorFromProperties(safeArgs,
-                                                                              appModel->timeline());
+            static_cast<AudioClip *>(clip)->applyRealTimeAnchorFromProperties(
+                safeArgs, appModel->timeline(), !preserveAudioTickCaches);
         }
     }
 }
@@ -60,14 +60,14 @@ EditClipCommonPropertiesAction *
 
 void EditClipCommonPropertiesAction::execute() {
     m_track->removeClip(m_clip);
-    applyArgs(m_clip, m_newArgs, m_audioTimingChanged);
+    applyArgs(m_clip, m_newArgs, m_audioTimingChanged, false);
     m_track->insertClip(m_clip);
     m_clip->notifyPropertyChanged();
 }
 
 void EditClipCommonPropertiesAction::undo() {
     m_track->removeClip(m_clip);
-    applyArgs(m_clip, m_oldArgs, m_audioTimingChanged);
+    applyArgs(m_clip, m_oldArgs, m_audioTimingChanged, true);
     m_track->insertClip(m_clip);
     m_clip->notifyPropertyChanged();
 }

--- a/src/app/Controller/Actions/AppModel/Clip/EditClipCommonPropertiesAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Clip/EditClipCommonPropertiesAction.cpp
@@ -7,7 +7,8 @@
 #include <algorithm>
 
 namespace {
-    void applyArgs(Clip *clip, const Clip::ClipCommonProperties &args) {
+    void applyArgs(Clip *clip, const Clip::ClipCommonProperties &args,
+                   const bool updateAudioTiming) {
         // opendspx requires clip.pos = start + clipStart to stay non-negative.
         auto safeArgs = Clip::ClipCommonProperties(args);
         safeArgs.start = std::max(safeArgs.start, -safeArgs.clipStart);
@@ -18,7 +19,7 @@ namespace {
         clip->setClipLen(safeArgs.clipLen);
         clip->setGain(safeArgs.gain);
         clip->setMute(safeArgs.mute);
-        if (clip->clipType() == IClip::Audio) {
+        if (clip->clipType() == IClip::Audio && updateAudioTiming) {
             // The tick snapshot may predate a tempo change; the ms truth
             // carried in the args re-derives the caches under the current map
             static_cast<AudioClip *>(clip)->applyRealTimeAnchorFromProperties(safeArgs,
@@ -52,20 +53,21 @@ EditClipCommonPropertiesAction *
             AudioClip::deriveTruthForProperties(a->m_newArgs, timeline);
             AudioClip::preserveUnchangedTruth(a->m_newArgs, a->m_oldArgs);
         }
+        a->m_audioTimingChanged = !AudioClip::timingPropertiesEqual(a->m_oldArgs, a->m_newArgs);
     }
     return a;
 }
 
 void EditClipCommonPropertiesAction::execute() {
     m_track->removeClip(m_clip);
-    applyArgs(m_clip, m_newArgs);
+    applyArgs(m_clip, m_newArgs, m_audioTimingChanged);
     m_track->insertClip(m_clip);
     m_clip->notifyPropertyChanged();
 }
 
 void EditClipCommonPropertiesAction::undo() {
     m_track->removeClip(m_clip);
-    applyArgs(m_clip, m_oldArgs);
+    applyArgs(m_clip, m_oldArgs, m_audioTimingChanged);
     m_track->insertClip(m_clip);
     m_clip->notifyPropertyChanged();
 }

--- a/src/app/Controller/Actions/AppModel/Clip/EditClipCommonPropertiesAction.h
+++ b/src/app/Controller/Actions/AppModel/Clip/EditClipCommonPropertiesAction.h
@@ -19,6 +19,7 @@ private:
     Clip::ClipCommonProperties m_newArgs;
     Clip *m_clip = nullptr;
     Track *m_track = nullptr;
+    bool m_audioTimingChanged = false;
 };
 
 

--- a/src/app/Controller/Actions/AppModel/Clip/MoveClipToTrackAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Clip/MoveClipToTrackAction.cpp
@@ -6,7 +6,8 @@
 #include <lite/ProjectModel/AppModel/Track.h>
 
 namespace {
-    void applyArgs(Clip *clip, const Clip::ClipCommonProperties &args) {
+    void applyArgs(Clip *clip, const Clip::ClipCommonProperties &args,
+                   const bool updateAudioTiming) {
         clip->setName(args.name);
         clip->setStart(args.start);
         clip->setClipStart(args.clipStart);
@@ -14,7 +15,7 @@ namespace {
         clip->setClipLen(args.clipLen);
         clip->setGain(args.gain);
         clip->setMute(args.mute);
-        if (clip->clipType() == IClip::Audio) {
+        if (clip->clipType() == IClip::Audio && updateAudioTiming) {
             static_cast<AudioClip *>(clip)->applyRealTimeAnchorFromProperties(args,
                                                                               appModel->timeline());
         }
@@ -46,6 +47,7 @@ MoveClipToTrackAction *MoveClipToTrackAction::build(const Clip::ClipCommonProper
             AudioClip::deriveTruthForProperties(a->m_newArgs, timeline);
             AudioClip::preserveUnchangedTruth(a->m_newArgs, a->m_oldArgs);
         }
+        a->m_audioTimingChanged = !AudioClip::timingPropertiesEqual(a->m_oldArgs, a->m_newArgs);
     }
     return a;
 }
@@ -56,7 +58,7 @@ void MoveClipToTrackAction::execute() {
         previousWordStates =
             SingingClipPhonemeNormalizer::captureWordStates(*static_cast<SingingClip *>(m_clip));
     m_oldTrack->removeClip(m_clip);
-    applyArgs(m_clip, m_newArgs);
+    applyArgs(m_clip, m_newArgs, m_audioTimingChanged);
     m_newTrack->insertClip(m_clip);
     if (m_clip->clipType() == IClip::Singing) {
         const auto singingClip = static_cast<SingingClip *>(m_clip);
@@ -82,7 +84,7 @@ void MoveClipToTrackAction::execute() {
 
 void MoveClipToTrackAction::undo() {
     m_newTrack->removeClip(m_clip);
-    applyArgs(m_clip, m_oldArgs);
+    applyArgs(m_clip, m_oldArgs, m_audioTimingChanged);
     m_oldTrack->insertClip(m_clip);
     if (m_clip->clipType() == IClip::Singing) {
         const auto singingClip = static_cast<SingingClip *>(m_clip);

--- a/src/app/Controller/Actions/AppModel/Clip/MoveClipToTrackAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Clip/MoveClipToTrackAction.cpp
@@ -6,8 +6,8 @@
 #include <lite/ProjectModel/AppModel/Track.h>
 
 namespace {
-    void applyArgs(Clip *clip, const Clip::ClipCommonProperties &args,
-                   const bool updateAudioTiming) {
+    void applyArgs(Clip *clip, const Clip::ClipCommonProperties &args, const bool updateAudioTiming,
+                   const bool preserveAudioTickCaches) {
         clip->setName(args.name);
         clip->setStart(args.start);
         clip->setClipStart(args.clipStart);
@@ -16,8 +16,8 @@ namespace {
         clip->setGain(args.gain);
         clip->setMute(args.mute);
         if (clip->clipType() == IClip::Audio && updateAudioTiming) {
-            static_cast<AudioClip *>(clip)->applyRealTimeAnchorFromProperties(args,
-                                                                              appModel->timeline());
+            static_cast<AudioClip *>(clip)->applyRealTimeAnchorFromProperties(
+                args, appModel->timeline(), !preserveAudioTickCaches);
         }
     }
 }
@@ -58,7 +58,7 @@ void MoveClipToTrackAction::execute() {
         previousWordStates =
             SingingClipPhonemeNormalizer::captureWordStates(*static_cast<SingingClip *>(m_clip));
     m_oldTrack->removeClip(m_clip);
-    applyArgs(m_clip, m_newArgs, m_audioTimingChanged);
+    applyArgs(m_clip, m_newArgs, m_audioTimingChanged, false);
     m_newTrack->insertClip(m_clip);
     if (m_clip->clipType() == IClip::Singing) {
         const auto singingClip = static_cast<SingingClip *>(m_clip);
@@ -84,7 +84,7 @@ void MoveClipToTrackAction::execute() {
 
 void MoveClipToTrackAction::undo() {
     m_newTrack->removeClip(m_clip);
-    applyArgs(m_clip, m_oldArgs, m_audioTimingChanged);
+    applyArgs(m_clip, m_oldArgs, m_audioTimingChanged, true);
     m_oldTrack->insertClip(m_clip);
     if (m_clip->clipType() == IClip::Singing) {
         const auto singingClip = static_cast<SingingClip *>(m_clip);

--- a/src/app/Controller/Actions/AppModel/Clip/MoveClipToTrackAction.h
+++ b/src/app/Controller/Actions/AppModel/Clip/MoveClipToTrackAction.h
@@ -22,6 +22,7 @@ private:
     Clip *m_clip = nullptr;
     Track *m_oldTrack = nullptr;
     Track *m_newTrack = nullptr;
+    bool m_audioTimingChanged = false;
 };
 
 #endif // MOVECLIPTOTRACKACTION_H

--- a/src/app/Controller/Actions/AppModel/Tempo/EditTemposAction.cpp
+++ b/src/app/Controller/Actions/AppModel/Tempo/EditTemposAction.cpp
@@ -1,6 +1,7 @@
 #include "EditTemposAction.h"
 
 #include <lite/ProjectModel/AppModel/AppModel.h>
+#include <lite/ProjectModel/AppModel/AudioClip.h>
 #include <lite/ProjectModel/AppModel/SingingClip.h>
 #include <lite/ProjectModel/AppModel/Track.h>
 
@@ -37,6 +38,15 @@ EditTemposAction *EditTemposAction::build(const QList<Tempo> &oldTempos,
     a->m_oldTempos = oldTempos;
     a->m_newTempos = newTempos;
     a->m_model = model;
+    for (const auto track : model->tracks()) {
+        for (const auto clip : track->clips()) {
+            if (clip->clipType() != IClip::Audio)
+                continue;
+            const auto audioClip = static_cast<AudioClip *>(clip);
+            a->m_audioClipTicks.append({track, audioClip, audioClip->start(), audioClip->length(),
+                                        audioClip->clipStart(), audioClip->clipLen()});
+        }
+    }
     return a;
 }
 
@@ -63,6 +73,21 @@ void EditTemposAction::undo() {
     auto timeline = m_model->timeline();
     timeline.setTempos(m_oldTempos);
     m_model->setTimeline(std::move(timeline));
+    for (const auto &snapshot : m_audioClipTicks) {
+        const bool changed = snapshot.clip->start() != snapshot.start ||
+                             snapshot.clip->length() != snapshot.length ||
+                             snapshot.clip->clipStart() != snapshot.clipStart ||
+                             snapshot.clip->clipLen() != snapshot.clipLen;
+        if (!changed)
+            continue;
+        snapshot.track->removeClip(snapshot.clip);
+        snapshot.clip->setStart(snapshot.start);
+        snapshot.clip->setLength(snapshot.length);
+        snapshot.clip->setClipStart(snapshot.clipStart);
+        snapshot.clip->setClipLen(snapshot.clipLen);
+        snapshot.track->insertClip(snapshot.clip);
+        snapshot.clip->notifyPropertyChanged();
+    }
     for (const auto &reset : m_resetRecords) {
         SingingClipPhonemeNormalizer::restoreEditedOffsets(reset.records);
         reset.clip->notifyNoteChanged(

--- a/src/app/Controller/Actions/AppModel/Tempo/EditTemposAction.h
+++ b/src/app/Controller/Actions/AppModel/Tempo/EditTemposAction.h
@@ -9,7 +9,9 @@
 #include <QList>
 
 class AppModel;
+class AudioClip;
 class SingingClip;
+class Track;
 
 // Replaces the whole tempo sequence of the project timeline. Used by project
 // import when the source contains more than a single tempo point.
@@ -27,9 +29,20 @@ private:
         QList<SingingClipPhonemeNormalizer::ResetRecord> records;
     };
 
+    class AudioClipTickSnapshot {
+    public:
+        Track *track = nullptr;
+        AudioClip *clip = nullptr;
+        int start = 0;
+        int length = 0;
+        int clipStart = 0;
+        int clipLen = 0;
+    };
+
     QList<Tempo> m_oldTempos;
     QList<Tempo> m_newTempos;
     QList<ClipResetRecords> m_resetRecords;
+    QList<AudioClipTickSnapshot> m_audioClipTicks;
     AppModel *m_model = nullptr;
 };
 

--- a/src/libs/ProjectModel/AppModel/AudioClip.cpp
+++ b/src/libs/ProjectModel/AppModel/AudioClip.cpp
@@ -161,6 +161,14 @@ void AudioClip::preserveUnchangedTruth(ClipCommonProperties &newArgs,
     newArgs.materialLengthMs = qMax(newArgs.playLengthMs, oldArgs.materialLengthMs);
 }
 
+bool AudioClip::timingPropertiesEqual(const ClipCommonProperties &left,
+                                      const ClipCommonProperties &right) {
+    return left.start == right.start && left.length == right.length &&
+           left.clipStart == right.clipStart && left.clipLen == right.clipLen &&
+           left.trimStartMs == right.trimStartMs && left.playLengthMs == right.playLengthMs &&
+           left.materialLengthMs == right.materialLengthMs;
+}
+
 void AudioClip::applyRealTimeAnchorFromProperties(const ClipCommonProperties &args,
                                                   const Timeline &timeline) {
     if (args.playLengthMs >= 0)

--- a/src/libs/ProjectModel/AppModel/AudioClip.cpp
+++ b/src/libs/ProjectModel/AppModel/AudioClip.cpp
@@ -67,7 +67,8 @@ const AudioInfoModel &AudioClip::audioInfo() const {
 void AudioClip::setAudioInfo(const AudioInfoModel &audioInfo) {
     m_info = audioInfo;
     if (m_info.sampleRate > 0 && m_info.frames > 0)
-        m_materialLengthMs = static_cast<double>(m_info.frames) * 1000.0 / m_info.sampleRate;
+        m_materialLengthMs = qMax(m_trimStartMs + m_playLengthMs,
+                                  static_cast<double>(m_info.frames) * 1000.0 / m_info.sampleRate);
     emit propertyChanged();
 }
 
@@ -91,7 +92,7 @@ void AudioClip::setRealTimeAnchor(const double trimStartMs, const double playLen
                                   const double materialLengthMs) {
     m_trimStartMs = qMax(0.0, trimStartMs);
     m_playLengthMs = qMax(0.0, playLengthMs);
-    m_materialLengthMs = qMax(m_playLengthMs, materialLengthMs);
+    m_materialLengthMs = qMax(m_trimStartMs + m_playLengthMs, materialLengthMs);
 }
 
 void AudioClip::syncTruthFromTicks(const Timeline &timeline) {
@@ -102,10 +103,11 @@ void AudioClip::syncTruthFromTicks(const Timeline &timeline) {
     m_playLengthMs = qMax(0.0, timeline.tickToMs(visibleStart + m_clipLen) - visibleMs);
     const double materialMs = timeline.tickToMs(m_start + m_length) - originMs;
     // Prefer the decoded file duration when available; ticks are a fallback
-    if (m_info.sampleRate > 0 && m_info.frames > 0)
-        m_materialLengthMs = static_cast<double>(m_info.frames) * 1000.0 / m_info.sampleRate;
-    else
-        m_materialLengthMs = qMax(m_playLengthMs, materialMs);
+    const double decodedMaterialMs =
+        m_info.sampleRate > 0 && m_info.frames > 0
+            ? static_cast<double>(m_info.frames) * 1000.0 / m_info.sampleRate
+            : materialMs;
+    m_materialLengthMs = qMax(m_trimStartMs + m_playLengthMs, decodedMaterialMs);
 }
 
 bool AudioClip::updateTicksFromTruth(const Timeline &timeline) {
@@ -146,8 +148,8 @@ void AudioClip::deriveTruthForProperties(ClipCommonProperties &args, const Timel
     const double visibleMs = timeline.tickToMs(visibleStart);
     args.trimStartMs = qMax(0.0, visibleMs - originMs);
     args.playLengthMs = qMax(0.0, timeline.tickToMs(visibleStart + args.clipLen) - visibleMs);
-    args.materialLengthMs =
-        qMax(args.playLengthMs, timeline.tickToMs(args.start + args.length) - originMs);
+    args.materialLengthMs = qMax(args.trimStartMs + args.playLengthMs,
+                                 timeline.tickToMs(args.start + args.length) - originMs);
 }
 
 void AudioClip::preserveUnchangedTruth(ClipCommonProperties &newArgs,
@@ -158,7 +160,8 @@ void AudioClip::preserveUnchangedTruth(ClipCommonProperties &newArgs,
         newArgs.trimStartMs = oldArgs.trimStartMs;
     if (newArgs.clipLen == oldArgs.clipLen)
         newArgs.playLengthMs = oldArgs.playLengthMs;
-    newArgs.materialLengthMs = qMax(newArgs.playLengthMs, oldArgs.materialLengthMs);
+    newArgs.materialLengthMs =
+        qMax(newArgs.trimStartMs + newArgs.playLengthMs, oldArgs.materialLengthMs);
 }
 
 bool AudioClip::timingPropertiesEqual(const ClipCommonProperties &left,
@@ -170,10 +173,12 @@ bool AudioClip::timingPropertiesEqual(const ClipCommonProperties &left,
 }
 
 void AudioClip::applyRealTimeAnchorFromProperties(const ClipCommonProperties &args,
-                                                  const Timeline &timeline) {
+                                                  const Timeline &timeline,
+                                                  const bool updateTickCaches) {
     if (args.playLengthMs >= 0)
         setRealTimeAnchor(args.trimStartMs, args.playLengthMs, args.materialLengthMs);
     else
         syncTruthFromTicks(timeline);
-    updateTicksFromTruth(timeline);
+    if (updateTickCaches)
+        updateTicksFromTruth(timeline);
 }

--- a/src/libs/ProjectModel/AppModel/AudioClip.h
+++ b/src/libs/ProjectModel/AppModel/AudioClip.h
@@ -92,10 +92,10 @@ public:
                                        const ClipCommonProperties &oldArgs);
     static bool timingPropertiesEqual(const ClipCommonProperties &left,
                                       const ClipCommonProperties &right);
-    // Apply properties' truth (or adopt its ticks when no ms is carried) and
-    // re-derive the tick caches; for undoable actions
+    // Apply properties' truth (or adopt its ticks when no ms is carried). Forward edits
+    // re-derive tick caches; undo may preserve a legacy tick snapshot verbatim.
     void applyRealTimeAnchorFromProperties(const ClipCommonProperties &args,
-                                           const Timeline &timeline);
+                                           const Timeline &timeline, bool updateTickCaches = true);
 
 signals:
     void pathChanged();

--- a/src/libs/ProjectModel/AppModel/AudioClip.h
+++ b/src/libs/ProjectModel/AppModel/AudioClip.h
@@ -90,6 +90,8 @@ public:
     // material duration is a property of the file and is always preserved.
     static void preserveUnchangedTruth(ClipCommonProperties &newArgs,
                                        const ClipCommonProperties &oldArgs);
+    static bool timingPropertiesEqual(const ClipCommonProperties &left,
+                                      const ClipCommonProperties &right);
     // Apply properties' truth (or adopt its ticks when no ms is carried) and
     // re-derive the tick caches; for undoable actions
     void applyRealTimeAnchorFromProperties(const ClipCommonProperties &args,

--- a/src/tests/TestAutomationCatalogContract/main.cpp
+++ b/src/tests/TestAutomationCatalogContract/main.cpp
@@ -212,6 +212,9 @@ namespace {
         EXPECTED_DESCRIPTOR(notes::remove, "AFC-CATALOG-062", "notes", Command, Synchronous, Write,
                             Increment, Record, None, Core, Reversible, InternalOnly,
                             DocumentGeneration),
+        EXPECTED_DESCRIPTOR(notes::reset_phoneme_offsets, "AFC-CATALOG-123", "notes", Command,
+                            Synchronous, Write, Increment, Record, None, Core, Reversible,
+                            InternalOnly, DocumentGeneration),
         EXPECTED_DESCRIPTOR(notes::resize_left, "AFC-CATALOG-063", "notes", Command, Synchronous,
                             Write, Increment, Record, None, Core, Reversible, InternalOnly,
                             DocumentGeneration),
@@ -428,8 +431,8 @@ int main(int argc, char *argv[]) {
     const auto &catalog = testRuntime.runtime().catalog();
 
     bool ok = true;
-    ok &= expect(kExpectedOperations.size() == 122,
-                 QStringLiteral("the explicit descriptor table must contain 122 operations"));
+    ok &= expect(kExpectedOperations.size() == 123,
+                 QStringLiteral("the explicit descriptor table must contain 123 operations"));
     ok &= expect(catalog.entries().size() == kExpectedOperations.size(),
                  QStringLiteral("the real Catalog size differs from the explicit table"));
 

--- a/src/tests/TestAutomationCore/main.cpp
+++ b/src/tests/TestAutomationCore/main.cpp
@@ -654,7 +654,7 @@ int main(int argc, char *argv[]) {
     ok &= expect(capabilities && capabilities.get().maxConcurrentDocuments == 1 &&
                      capabilities.get().maxConcurrentWindows == 1,
                  "capabilities must declare the single document/window boundary");
-    ok &= expect(Automation::OperationIds::all().size() == 122,
+    ok &= expect(Automation::OperationIds::all().size() == 123,
                  "centralized operation registry must retain the approved phase-one surface");
     ok &= expect(capabilities && capabilities.get().operationIds == Automation::OperationIds::all(),
                  "Catalog and the centralized operation registry must match");

--- a/src/tests/TestAutomationDocumentLifecycle/main.cpp
+++ b/src/tests/TestAutomationDocumentLifecycle/main.cpp
@@ -326,8 +326,12 @@ namespace {
                     "commit-import must retain identity and create one History/revision change");
 
         const LoopSettings openedLoop(true, 480, 1440);
-        const auto openedDocument = makeDocumentDraft(QStringLiteral("Opened Lifecycle Track"),
-                                                      QStringLiteral("open-lifecycle"), openedLoop);
+        auto openedDocument = makeDocumentDraft(QStringLiteral("Opened Lifecycle Track"),
+                                                QStringLiteral("open-lifecycle"), openedLoop);
+        auto &legacyProperties = openedDocument.tracks.first().clips.first().properties;
+        legacyProperties.length = 960;
+        legacyProperties.clipStart = 240;
+        legacyProperties.clipLen = 1440;
         const QString openedPath = QStringLiteral("fixtures/opened-lifecycle.dspx");
         const auto committedOpen = runtime.documents().commitOpenedDocument(
             commandContext(runtime), openedDocument, openedPath,
@@ -335,6 +339,7 @@ namespace {
         const auto afterOpen = runtime.documentVersion();
         const auto openSnapshot = runtime.documents().getDocument(afterOpen.documentId);
         const auto openHistory = runtime.history().getState(afterOpen.documentId);
+        const auto openedProject = runtime.project().getProject(afterOpen.documentId);
         const auto staleSnapshot = runtime.documents().getDocument(afterImport.documentId);
 
         test.expect(committedOpen && committedOpen.get().changed &&
@@ -343,16 +348,24 @@ namespace {
                         afterOpen.documentId != afterImport.documentId && afterOpen.revision == 0,
                     "AFC-DOC-LIFECYCLE-004",
                     "commit-open must rotate the document generation and reset revision");
-        test.expect(openSnapshot && openSnapshot.get().path == openedPath &&
-                        openSnapshot.get().projectName == QStringLiteral("opened-lifecycle.dspx") &&
-                        openSnapshot.get().saved && openHistory && !openHistory.get().canUndo &&
-                        !openHistory.get().canRedo && openHistory.get().onSavePoint &&
-                        fixture.host.loopSettings == openedLoop && !staleSnapshot &&
-                        staleSnapshot.getError().code ==
-                            Automation::AutomationErrorCode::DocumentChanged,
-                    "AFC-DOC-LIFECYCLE-004",
-                    "commit-open must publish its identity/savepoint and reject the old "
-                    "generation");
+        test.expect(
+            openSnapshot && openSnapshot.get().path == openedPath &&
+                openSnapshot.get().projectName == QStringLiteral("opened-lifecycle.dspx") &&
+                openSnapshot.get().saved && openHistory && !openHistory.get().canUndo &&
+                !openHistory.get().canRedo && openHistory.get().onSavePoint && openedProject &&
+                openedProject.get().tracks.size() == 1 &&
+                openedProject.get().tracks.first().clips.size() == 1 &&
+                openedProject.get().tracks.first().clips.first().data.properties.length ==
+                    legacyProperties.length &&
+                openedProject.get().tracks.first().clips.first().data.properties.clipStart ==
+                    legacyProperties.clipStart &&
+                openedProject.get().tracks.first().clips.first().data.properties.clipLen ==
+                    legacyProperties.clipLen &&
+                fixture.host.loopSettings == openedLoop && !staleSnapshot &&
+                staleSnapshot.getError().code == Automation::AutomationErrorCode::DocumentChanged,
+            "AFC-DOC-LIFECYCLE-004",
+            "commit-open must preserve legacy clip geometry, publish its savepoint, and "
+            "reject the old generation");
     }
 
     void testFailureAndCancellationRollback(TestRun &test) {

--- a/src/tests/TestAutomationEditingDimensions/main.cpp
+++ b/src/tests/TestAutomationEditingDimensions/main.cpp
@@ -579,14 +579,14 @@ namespace {
                     }, .missingObject =
                     [](Fixture &fixture, const CommandContext &context, int) {
                         auto draft = singingClipDraft(QStringLiteral("invalid"));
-                        draft.properties.clipLen = draft.properties.length + 1;
+                        draft.properties.length = -1;
                         return fixture.runtime().project().insertClips(
                             context, {
                                          {.trackId = TrackId(999999), .clip = draft}});
                     }, .invalidDomain =
                     [](Fixture &fixture, const CommandContext &context, int) {
                         auto draft = singingClipDraft(QStringLiteral("invalid"));
-                        draft.properties.clipLen = draft.properties.length + 1;
+                        draft.properties.length = -1;
                         return fixture.runtime().project().insertClips(
                             context, {
                                          {.trackId = fixture.trackA, .clip = draft}});

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -602,8 +602,15 @@ namespace {
                     commandContext(runtime), {
                                                  {.trackId = second, .clip = copiedDraft}
                 });
-                suite.expect(copied && copied.get().createdObjects.size() == 1,
-                             QStringLiteral("a legacy audio snapshot must be reusable by paste"));
+                const auto copiedSnapshot =
+                    copied && !copied.get().affectedObjects.isEmpty()
+                        ? clipSnapshot(runtime, ClipId(copied.get().affectedObjects.first().value))
+                        : std::nullopt;
+                suite.expect(
+                    copied && copied.get().createdObjects.size() == 1 && copiedSnapshot &&
+                        sameClipTiming(copiedSnapshot->data.properties, copiedDraft.properties),
+                    QStringLiteral(
+                        "a pasted legacy audio snapshot must preserve its exact timing geometry"));
             });
 
         suite.run(

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -420,7 +420,7 @@ namespace {
                 suite.expect(empty && !empty.get().changed && runtime.documentVersion() == base,
                              QStringLiteral("empty insert must be a no-op"));
                 auto invalidDraft = singingClipDraft(QStringLiteral("Invalid"));
-                invalidDraft.properties.clipLen = invalidDraft.properties.length + 1;
+                invalidDraft.properties.length = -1;
                 const auto invalid = runtime.project().insertClips(
                     commandContext(runtime), {
                                                  {.trackId = second, .clip = invalidDraft}
@@ -452,7 +452,7 @@ namespace {
 
         suite.run(
             Automation::OperationIds::clips::set_properties,
-            QStringLiteral("move-and-edit-atomically"), [&] {
+            QStringLiteral("legacy-range-move-and-edit-atomically"), [&] {
                 testRuntime.history()->reset();
                 const auto before = clipSnapshot(runtime, clip);
                 suite.expect(before.has_value(), QStringLiteral("fixture clip must exist"));
@@ -460,9 +460,9 @@ namespace {
                 edit.id = clip;
                 edit.name = QStringLiteral("Moved Clip");
                 edit.start = 960;
-                edit.length = 2880;
-                edit.clipStart = 120;
-                edit.clipLen = 2400;
+                edit.length = 100;
+                edit.clipStart = 50;
+                edit.clipLen = 100;
                 edit.gain = 0.8;
                 edit.mute = true;
                 auto invalid = edit;
@@ -472,15 +472,6 @@ namespace {
                 suite.expect(isError(rejected, AutomationErrorCode::InvalidArgument,
                                      QStringLiteral("properties")),
                              QStringLiteral("invalid clip properties must not partially move"));
-                auto outsideMaterial = edit;
-                outsideMaterial.length = 100;
-                outsideMaterial.clipStart = 50;
-                outsideMaterial.clipLen = 100;
-                const auto rejectedRange = runtime.project().setClipProperties(
-                    commandContext(runtime, true), outsideMaterial, third);
-                suite.expect(isError(rejectedRange, AutomationErrorCode::InvalidArgument,
-                                     QStringLiteral("properties")),
-                             QStringLiteral("clip range must stay inside material length"));
                 const auto base = runtime.documentVersion();
                 const auto preview =
                     runtime.project().setClipProperties(commandContext(runtime, true), edit, third);
@@ -493,8 +484,13 @@ namespace {
                 suite.expect(
                     changed && changed.get().current.revision == base.revision + 1 && after &&
                         after->trackId == third && after->data.properties.name == edit.name &&
-                        after->data.properties.start == edit.start && after->data.properties.mute,
-                    QStringLiteral("clip move and properties must commit once"));
+                        after->data.properties.start == edit.start &&
+                        after->data.properties.length == edit.length &&
+                        after->data.properties.clipStart == edit.clipStart &&
+                        after->data.properties.clipLen == edit.clipLen &&
+                        after->data.properties.mute,
+                    QStringLiteral(
+                        "legacy clip range and move must commit once without normalization"));
                 const auto noOp =
                     runtime.project().setClipProperties(commandContext(runtime), edit, third);
                 suite.expect(noOp && !noOp.get().changed &&

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -138,6 +138,14 @@ namespace {
         return result;
     }
 
+    bool sameClipTiming(const Automation::ClipPropertiesDto &left,
+                        const Automation::ClipPropertiesDto &right) {
+        return left.start == right.start && left.length == right.length &&
+               left.clipStart == right.clipStart && left.clipLen == right.clipLen &&
+               left.trimStartMs == right.trimStartMs && left.playLengthMs == right.playLengthMs &&
+               left.materialLengthMs == right.materialLengthMs;
+    }
+
     Automation::NoteDraftDto noteDraft(const int start, const int length, const int key,
                                        const QString &lyric, const QString &clientRef = {}) {
         Automation::NoteDraftDto result;
@@ -581,6 +589,21 @@ namespace {
                         snapshot->data.properties.clipStart == 50 &&
                         snapshot->data.properties.clipLen == 100,
                     QStringLiteral("legacy audio geometry must be inserted without normalization"));
+                if (!snapshot)
+                    return;
+
+                const auto reusable = Automation::validate(snapshot->data);
+                suite.expect(static_cast<bool>(reusable),
+                             QStringLiteral("a legacy audio snapshot must validate for reuse"));
+                auto copiedDraft = snapshot->data;
+                copiedDraft.clientRef = QStringLiteral("legacy-audio-copy");
+                copiedDraft.properties.start = 480;
+                const auto copied = runtime.project().insertClips(
+                    commandContext(runtime), {
+                                                 {.trackId = second, .clip = copiedDraft}
+                });
+                suite.expect(copied && copied.get().createdObjects.size() == 1,
+                             QStringLiteral("a legacy audio snapshot must be reusable by paste"));
             });
 
         suite.run(
@@ -600,24 +623,14 @@ namespace {
                 const auto after = clipSnapshot(runtime, legacyAudioClip);
                 suite.expect(
                     changed && after && after->trackId == second &&
-                        after->data.properties.length == before->data.properties.length &&
-                        after->data.properties.clipStart == before->data.properties.clipStart &&
-                        after->data.properties.clipLen == before->data.properties.clipLen &&
-                        after->data.properties.trimStartMs == before->data.properties.trimStartMs &&
-                        after->data.properties.playLengthMs ==
-                            before->data.properties.playLengthMs &&
-                        after->data.properties.materialLengthMs ==
-                            before->data.properties.materialLengthMs,
+                        sameClipTiming(after->data.properties, before->data.properties),
                     QStringLiteral(
                         "audio metadata edit must preserve legacy ticks and realtime truth"));
                 const auto undoEdit = runtime.history().undo(commandContext(runtime));
                 const auto restored = clipSnapshot(runtime, legacyAudioClip);
-                suite.expect(
-                    undoEdit && restored && restored->trackId == second &&
-                        restored->data.properties.length == before->data.properties.length &&
-                        restored->data.properties.clipStart == before->data.properties.clipStart &&
-                        restored->data.properties.clipLen == before->data.properties.clipLen,
-                    QStringLiteral("undo must restore legacy audio geometry exactly"));
+                suite.expect(undoEdit && restored && restored->trackId == second &&
+                                 sameClipTiming(restored->data.properties, before->data.properties),
+                             QStringLiteral("undo must restore legacy audio geometry exactly"));
 
                 testRuntime.history()->reset();
                 auto moveProperties = before->data.properties;
@@ -627,19 +640,56 @@ namespace {
                 const auto movedSnapshot = clipSnapshot(runtime, legacyAudioClip);
                 suite.expect(
                     moved && movedSnapshot && movedSnapshot->trackId == third &&
-                        movedSnapshot->data.properties.length == before->data.properties.length &&
-                        movedSnapshot->data.properties.clipStart ==
-                            before->data.properties.clipStart &&
-                        movedSnapshot->data.properties.clipLen == before->data.properties.clipLen,
+                        sameClipTiming(movedSnapshot->data.properties, before->data.properties),
                     QStringLiteral("cross-track move must preserve legacy audio geometry"));
                 const auto undoMove = runtime.history().undo(commandContext(runtime));
                 const auto movedBack = clipSnapshot(runtime, legacyAudioClip);
                 suite.expect(
                     undoMove && movedBack && movedBack->trackId == second &&
-                        movedBack->data.properties.length == before->data.properties.length &&
-                        movedBack->data.properties.clipStart == before->data.properties.clipStart &&
-                        movedBack->data.properties.clipLen == before->data.properties.clipLen,
+                        sameClipTiming(movedBack->data.properties, before->data.properties),
                     QStringLiteral("undoing a cross-track move must preserve legacy geometry"));
+            });
+
+        suite.run(
+            Automation::OperationIds::clips::set_properties,
+            QStringLiteral("legacy-audio-timing-edit-undo-restores-raw-range"), [&] {
+                testRuntime.history()->reset();
+                const auto before = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(before.has_value(), QStringLiteral("legacy audio fixture must exist"));
+                if (!before)
+                    return;
+                auto edit = before->data.properties;
+                edit.id = legacyAudioClip;
+                edit.start += 240;
+                const auto changed =
+                    runtime.project().setClipProperties(commandContext(runtime), edit, second);
+                const auto undo = runtime.history().undo(commandContext(runtime));
+                const auto restored = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(
+                    changed && undo && restored && restored->trackId == second &&
+                        sameClipTiming(restored->data.properties, before->data.properties),
+                    QStringLiteral("undoing an audio timing edit must restore raw legacy ticks"));
+            });
+
+        suite.run(
+            Automation::OperationIds::clips::set_properties,
+            QStringLiteral("legacy-audio-timing-move-undo-restores-raw-range"), [&] {
+                testRuntime.history()->reset();
+                const auto before = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(before.has_value(), QStringLiteral("legacy audio fixture must exist"));
+                if (!before)
+                    return;
+                auto edit = before->data.properties;
+                edit.id = legacyAudioClip;
+                edit.start += 480;
+                const auto changed =
+                    runtime.project().setClipProperties(commandContext(runtime), edit, third);
+                const auto undo = runtime.history().undo(commandContext(runtime));
+                const auto restored = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(
+                    changed && undo && restored && restored->trackId == second &&
+                        sameClipTiming(restored->data.properties, before->data.properties),
+                    QStringLiteral("undoing an audio timing move must restore raw legacy ticks"));
             });
 
         suite.run(Automation::OperationIds::clips::set_default_language,

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -124,6 +124,20 @@ namespace {
         return result;
     }
 
+    Automation::ClipDraftDto audioClipDraft(const QString &name, const QString &clientRef = {}) {
+        Automation::ClipDraftDto result;
+        result.clientRef = clientRef;
+        result.type = Automation::ClipDraftDto::Type::Audio;
+        result.properties.name = name;
+        result.properties.start = 0;
+        result.properties.length = 100;
+        result.properties.clipStart = 50;
+        result.properties.clipLen = 100;
+        result.properties.gain = 1.0;
+        result.audioPath = QStringLiteral("fixture-audio.wav");
+        return result;
+    }
+
     Automation::NoteDraftDto noteDraft(const int start, const int length, const int key,
                                        const QString &lyric, const QString &clientRef = {}) {
         Automation::NoteDraftDto result;
@@ -428,16 +442,29 @@ namespace {
                 suite.expect(isError(invalid, AutomationErrorCode::InvalidArgument,
                                      QStringLiteral("clip.properties")),
                              QStringLiteral("invalid clip geometry must be rejected"));
-                auto overflowDraft = singingClipDraft(QStringLiteral("Overflow"));
-                overflowDraft.properties.clipStart = std::numeric_limits<int>::max();
-                overflowDraft.properties.clipLen = 1;
-                const auto overflow = runtime.project().insertClips(
-                    commandContext(runtime), {
-                                                 {.trackId = second, .clip = overflowDraft}
+                auto visibleOverflowDraft = singingClipDraft(QStringLiteral("Visible Overflow"));
+                visibleOverflowDraft.properties.start = std::numeric_limits<int>::max();
+                visibleOverflowDraft.properties.clipStart = 0;
+                visibleOverflowDraft.properties.clipLen = 1;
+                const auto visibleOverflow = runtime.project().insertClips(
+                    commandContext(runtime),
+                    {
+                        {.trackId = second, .clip = visibleOverflowDraft}
                 });
-                suite.expect(isError(overflow, AutomationErrorCode::InvalidArgument,
+                suite.expect(isError(visibleOverflow, AutomationErrorCode::InvalidArgument,
                                      QStringLiteral("clip.properties")),
                              QStringLiteral("visible clip end must fit the model tick type"));
+                auto localOverflowDraft = singingClipDraft(QStringLiteral("Local Overflow"));
+                localOverflowDraft.properties.start = -std::numeric_limits<int>::max();
+                localOverflowDraft.properties.clipStart = std::numeric_limits<int>::max();
+                localOverflowDraft.properties.clipLen = 1;
+                const auto localOverflow = runtime.project().insertClips(
+                    commandContext(runtime), {
+                                                 {.trackId = second, .clip = localOverflowDraft}
+                });
+                suite.expect(isError(localOverflow, AutomationErrorCode::InvalidArgument,
+                                     QStringLiteral("clip.properties")),
+                             QStringLiteral("clip-local end must fit the model tick type"));
                 const auto draft =
                     singingClipDraft(QStringLiteral("歌声 Clip"), QStringLiteral("clip-main"));
                 const auto preview = runtime.project().insertClips(
@@ -482,16 +509,26 @@ namespace {
                 suite.expect(isError(rejected, AutomationErrorCode::InvalidArgument,
                                      QStringLiteral("properties")),
                              QStringLiteral("invalid clip properties must not partially move"));
-                auto overflow = edit;
-                overflow.start = 0;
-                overflow.clipStart = std::numeric_limits<int>::max();
-                overflow.clipLen = 1;
-                const auto rejectedOverflow = runtime.project().setClipProperties(
-                    commandContext(runtime, true), overflow, third);
+                auto visibleOverflow = edit;
+                visibleOverflow.start = std::numeric_limits<int>::max();
+                visibleOverflow.clipStart = 0;
+                visibleOverflow.clipLen = 1;
+                const auto rejectedVisibleOverflow = runtime.project().setClipProperties(
+                    commandContext(runtime, true), visibleOverflow, third);
                 suite.expect(
-                    isError(rejectedOverflow, AutomationErrorCode::InvalidArgument,
+                    isError(rejectedVisibleOverflow, AutomationErrorCode::InvalidArgument,
                             QStringLiteral("properties")),
                     QStringLiteral("clip edit must reject an unrepresentable visible end"));
+                auto localOverflow = edit;
+                localOverflow.start = -std::numeric_limits<int>::max();
+                localOverflow.clipStart = std::numeric_limits<int>::max();
+                localOverflow.clipLen = 1;
+                const auto rejectedLocalOverflow = runtime.project().setClipProperties(
+                    commandContext(runtime, true), localOverflow, third);
+                suite.expect(
+                    isError(rejectedLocalOverflow, AutomationErrorCode::InvalidArgument,
+                            QStringLiteral("properties")),
+                    QStringLiteral("clip edit must reject an unrepresentable clip-local end"));
                 const auto base = runtime.documentVersion();
                 const auto preview =
                     runtime.project().setClipProperties(commandContext(runtime, true), edit, third);
@@ -521,6 +558,88 @@ namespace {
                 suite.expect(undo && restored && restored->trackId == second &&
                                  restored->data.properties.name == before->data.properties.name,
                              QStringLiteral("combined clip move/edit must undo atomically"));
+            });
+
+        ClipId legacyAudioClip;
+        suite.run(
+            Automation::OperationIds::clips::insert, QStringLiteral("legacy-audio-range-create"),
+            [&] {
+                const auto insert = runtime.project().insertClips(
+                    commandContext(runtime),
+                    {
+                        {.trackId = second,
+                         .clip = audioClipDraft(QStringLiteral("Legacy Audio"),
+                         QStringLiteral("legacy-audio"))}
+                });
+                if (insert && !insert.get().affectedObjects.isEmpty())
+                    legacyAudioClip = ClipId(insert.get().affectedObjects.first().value);
+                const auto snapshot = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(
+                    insert && snapshot &&
+                        snapshot->data.type == Automation::ClipDraftDto::Type::Audio &&
+                        snapshot->data.properties.length == 100 &&
+                        snapshot->data.properties.clipStart == 50 &&
+                        snapshot->data.properties.clipLen == 100,
+                    QStringLiteral("legacy audio geometry must be inserted without normalization"));
+            });
+
+        suite.run(
+            Automation::OperationIds::clips::set_properties,
+            QStringLiteral("legacy-audio-metadata-edit-preserves-range"), [&] {
+                testRuntime.history()->reset();
+                const auto before = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(before.has_value(), QStringLiteral("legacy audio fixture must exist"));
+                if (!before)
+                    return;
+                auto edit = before->data.properties;
+                edit.id = legacyAudioClip;
+                edit.name = QStringLiteral("Renamed Legacy Audio");
+                edit.gain = 0.75;
+                const auto changed =
+                    runtime.project().setClipProperties(commandContext(runtime), edit, second);
+                const auto after = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(
+                    changed && after && after->trackId == second &&
+                        after->data.properties.length == before->data.properties.length &&
+                        after->data.properties.clipStart == before->data.properties.clipStart &&
+                        after->data.properties.clipLen == before->data.properties.clipLen &&
+                        after->data.properties.trimStartMs == before->data.properties.trimStartMs &&
+                        after->data.properties.playLengthMs ==
+                            before->data.properties.playLengthMs &&
+                        after->data.properties.materialLengthMs ==
+                            before->data.properties.materialLengthMs,
+                    QStringLiteral(
+                        "audio metadata edit must preserve legacy ticks and realtime truth"));
+                const auto undoEdit = runtime.history().undo(commandContext(runtime));
+                const auto restored = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(
+                    undoEdit && restored && restored->trackId == second &&
+                        restored->data.properties.length == before->data.properties.length &&
+                        restored->data.properties.clipStart == before->data.properties.clipStart &&
+                        restored->data.properties.clipLen == before->data.properties.clipLen,
+                    QStringLiteral("undo must restore legacy audio geometry exactly"));
+
+                testRuntime.history()->reset();
+                auto moveProperties = before->data.properties;
+                moveProperties.id = legacyAudioClip;
+                const auto moved = runtime.project().setClipProperties(commandContext(runtime),
+                                                                       moveProperties, third);
+                const auto movedSnapshot = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(
+                    moved && movedSnapshot && movedSnapshot->trackId == third &&
+                        movedSnapshot->data.properties.length == before->data.properties.length &&
+                        movedSnapshot->data.properties.clipStart ==
+                            before->data.properties.clipStart &&
+                        movedSnapshot->data.properties.clipLen == before->data.properties.clipLen,
+                    QStringLiteral("cross-track move must preserve legacy audio geometry"));
+                const auto undoMove = runtime.history().undo(commandContext(runtime));
+                const auto movedBack = clipSnapshot(runtime, legacyAudioClip);
+                suite.expect(
+                    undoMove && movedBack && movedBack->trackId == second &&
+                        movedBack->data.properties.length == before->data.properties.length &&
+                        movedBack->data.properties.clipStart == before->data.properties.clipStart &&
+                        movedBack->data.properties.clipLen == before->data.properties.clipLen,
+                    QStringLiteral("undoing a cross-track move must preserve legacy geometry"));
             });
 
         suite.run(Automation::OperationIds::clips::set_default_language,

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -428,6 +428,16 @@ namespace {
                 suite.expect(isError(invalid, AutomationErrorCode::InvalidArgument,
                                      QStringLiteral("clip.properties")),
                              QStringLiteral("invalid clip geometry must be rejected"));
+                auto overflowDraft = singingClipDraft(QStringLiteral("Overflow"));
+                overflowDraft.properties.clipStart = std::numeric_limits<int>::max();
+                overflowDraft.properties.clipLen = 1;
+                const auto overflow = runtime.project().insertClips(
+                    commandContext(runtime), {
+                                                 {.trackId = second, .clip = overflowDraft}
+                });
+                suite.expect(isError(overflow, AutomationErrorCode::InvalidArgument,
+                                     QStringLiteral("clip.properties")),
+                             QStringLiteral("visible clip end must fit the model tick type"));
                 const auto draft =
                     singingClipDraft(QStringLiteral("歌声 Clip"), QStringLiteral("clip-main"));
                 const auto preview = runtime.project().insertClips(
@@ -472,6 +482,16 @@ namespace {
                 suite.expect(isError(rejected, AutomationErrorCode::InvalidArgument,
                                      QStringLiteral("properties")),
                              QStringLiteral("invalid clip properties must not partially move"));
+                auto overflow = edit;
+                overflow.start = 0;
+                overflow.clipStart = std::numeric_limits<int>::max();
+                overflow.clipLen = 1;
+                const auto rejectedOverflow = runtime.project().setClipProperties(
+                    commandContext(runtime, true), overflow, third);
+                suite.expect(
+                    isError(rejectedOverflow, AutomationErrorCode::InvalidArgument,
+                            QStringLiteral("properties")),
+                    QStringLiteral("clip edit must reject an unrepresentable visible end"));
                 const auto base = runtime.documentVersion();
                 const auto preview =
                     runtime.project().setClipProperties(commandContext(runtime, true), edit, third);

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -611,6 +611,40 @@ namespace {
                         sameClipTiming(copiedSnapshot->data.properties, copiedDraft.properties),
                     QStringLiteral(
                         "a pasted legacy audio snapshot must preserve its exact timing geometry"));
+
+                auto conflictingDraft = copiedDraft;
+                conflictingDraft.clientRef = QStringLiteral("conflicting-audio-anchor");
+                conflictingDraft.properties.start = 960;
+                conflictingDraft.properties.length = 480;
+                conflictingDraft.properties.clipStart = 0;
+                conflictingDraft.properties.clipLen = 480;
+                conflictingDraft.properties.trimStartMs = 0.0;
+                conflictingDraft.properties.playLengthMs = 1000.0;
+                conflictingDraft.properties.materialLengthMs = 1000.0;
+                const auto conflicting = runtime.project().insertClips(
+                    commandContext(runtime), {
+                                                 {.trackId = second, .clip = conflictingDraft}
+                });
+                const auto conflictingSnapshot =
+                    conflicting && !conflicting.get().affectedObjects.isEmpty()
+                        ? clipSnapshot(runtime,
+                                       ClipId(conflicting.get().affectedObjects.first().value))
+                        : std::nullopt;
+                suite.expect(
+                    conflicting && conflictingSnapshot &&
+                        conflictingSnapshot->data.properties.start +
+                                conflictingSnapshot->data.properties.clipStart ==
+                            conflictingDraft.properties.start +
+                                conflictingDraft.properties.clipStart &&
+                        conflictingSnapshot->data.properties.clipLen !=
+                            conflictingDraft.properties.clipLen &&
+                        conflictingSnapshot->data.properties.length >=
+                            conflictingSnapshot->data.properties.clipStart +
+                                conflictingSnapshot->data.properties.clipLen &&
+                        conflictingSnapshot->data.properties.playLengthMs ==
+                            conflictingDraft.properties.playLengthMs,
+                    QStringLiteral(
+                        "an inconsistent anchored draft must reconcile ticks to realtime truth"));
             });
 
         suite.run(

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -645,6 +645,38 @@ namespace {
                             conflictingDraft.properties.playLengthMs,
                     QStringLiteral(
                         "an inconsistent anchored draft must reconcile ticks to realtime truth"));
+
+                auto oversizedDraft = conflictingDraft;
+                oversizedDraft.clientRef = QStringLiteral("oversized-audio-material");
+                oversizedDraft.properties.start = 1920;
+                oversizedDraft.properties.length = 9600;
+                oversizedDraft.properties.clipLen = 480;
+                oversizedDraft.properties.playLengthMs = 500.0;
+                oversizedDraft.properties.materialLengthMs = 500.0;
+                const auto oversized = runtime.project().insertClips(
+                    commandContext(runtime), {
+                                                 {.trackId = second, .clip = oversizedDraft}
+                });
+                const auto oversizedSnapshot =
+                    oversized && !oversized.get().affectedObjects.isEmpty()
+                        ? clipSnapshot(runtime,
+                                       ClipId(oversized.get().affectedObjects.first().value))
+                        : std::nullopt;
+                suite.expect(
+                    oversized && oversizedSnapshot &&
+                        oversizedSnapshot->data.properties.start ==
+                            oversizedDraft.properties.start &&
+                        oversizedSnapshot->data.properties.clipStart ==
+                            oversizedDraft.properties.clipStart &&
+                        oversizedSnapshot->data.properties.clipLen ==
+                            oversizedDraft.properties.clipLen &&
+                        oversizedSnapshot->data.properties.length !=
+                            oversizedDraft.properties.length &&
+                        oversizedSnapshot->data.properties.length ==
+                            oversizedSnapshot->data.properties.clipStart +
+                                oversizedSnapshot->data.properties.clipLen,
+                    QStringLiteral(
+                        "an oversized anchored length must reconcile to its material duration"));
             });
 
         suite.run(

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -1521,6 +1521,42 @@ namespace {
             });
 
         suite.run(
+            Automation::OperationIds::tempos::set,
+            QStringLiteral("legacy-audio-tempo-undo-restores-raw-range"), [&] {
+                const auto trackId = insertedTrack(runtime, QStringLiteral("Audio Tempo"));
+                const auto insert = runtime.project().insertClips(
+                    commandContext(runtime),
+                    {
+                        {.trackId = trackId,
+                         .clip = audioClipDraft(QStringLiteral("Legacy Tempo Audio"))}
+                });
+                const auto clipId = insert && !insert.get().affectedObjects.isEmpty()
+                                        ? ClipId(insert.get().affectedObjects.first().value)
+                                        : ClipId{};
+                testRuntime.history()->reset();
+                const auto before = clipSnapshot(runtime, clipId);
+                const auto changed = runtime.timeline().setTempo(commandContext(runtime), 0, 90.0);
+                const auto changedSnapshot = clipSnapshot(runtime, clipId);
+                const auto undo = runtime.history().undo(commandContext(runtime));
+                const auto restored = clipSnapshot(runtime, clipId);
+                const auto redo = runtime.history().redo(commandContext(runtime));
+                const auto redone = clipSnapshot(runtime, clipId);
+                const auto undoAgain = runtime.history().undo(commandContext(runtime));
+                const auto restoredAgain = clipSnapshot(runtime, clipId);
+                suite.expect(
+                    trackId.isValid() && insert && before && changed && changedSnapshot &&
+                        changedSnapshot->data.properties.length >=
+                            changedSnapshot->data.properties.clipStart +
+                                changedSnapshot->data.properties.clipLen &&
+                        undo && restored &&
+                        sameClipTiming(restored->data.properties, before->data.properties) &&
+                        redo && redone && undoAgain && restoredAgain &&
+                        sameClipTiming(restoredAgain->data.properties, before->data.properties),
+                    QStringLiteral(
+                        "tempo undo must restore raw legacy audio ticks across redo cycles"));
+            });
+
+        suite.run(
             Automation::OperationIds::time_signatures::set,
             QStringLiteral("invalid-preview-sorted-replace-noop"), [&] {
                 const auto base = runtime.documentVersion();


### PR DESCRIPTION
## 问题

Automation Facade 在工程载入和片段属性编辑入口额外要求 `clipStart + clipLen <= length`。DSPX 1.0 schema 与 OpenDSPX 只约束这些字段各自非负，不定义该跨字段关系；旧版 MIDI 导入也曾生成超出此关系的合法可播放工程，因此该校验会让既有工程整体无法打开。

## 改动

- 从 Clip draft/工程载入及 `clips.set_properties` 校验中移除该跨字段限制。
- 保留非负值、可见区间可表示性、有限增益/时间与音频锚点等独立有效性校验。
- 打开旧工程时不裁剪、不归一化、不改写原始 clip tick 几何。
- 为旧音频 tick 建立自洽的内部实时锚点，使快照仍能复制/粘贴；素材元数据变更不会把兼容几何归一化。
- 正向时序编辑仍按实时锚点重算；undo 精确恢复原始 tick 与实时锚点，同轨及跨轨路径一致。
- 补齐主分支新增 `notes.reset_phoneme_offsets` 后遗漏的第 123 项 Registry/Catalog 契约顺序与计数。
- 回归覆盖旧几何工程打开、原值保留、validate-only、提交/no-op/undo、复制插入、同轨/跨轨时序撤销及 operation 维度矩阵。
- 保留 MIDI 导入生成规范化几何的既有测试。

## 验证

- Debug preset `all` 完整构建：通过
- 全量 CTest：53/53 通过，0 失败