### PR TITLE
fix(lyrics): keep split slurs in canonical note order

### DIFF
--- a/src/app/Controller/ClipController.cpp
+++ b/src/app/Controller/ClipController.cpp
@@ -27,6 +27,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPair>
+#include <QSet>
 
 #include <algorithm>
 #include <limits>
@@ -627,8 +628,16 @@ NotesParamsInfo ClipControllerPrivate::buildNoteParamsInfo() const {
 
 QList<Note *> ClipControllerPrivate::selectedNotesFromId(const QList<int> &notesId,
                                                          const SingingClip *clip) {
+    QSet<int> selectedIds;
+    selectedIds.reserve(notesId.size());
+    for (const auto id : notesId)
+        selectedIds.insert(id);
+
     QList<Note *> notes;
-    for (const auto &id : notesId)
-        notes.append(clip->findNoteById(id));
+    notes.reserve(selectedIds.size());
+    for (auto *note : clip->notes()) {
+        if (selectedIds.contains(note->id()))
+            notes.append(note);
+    }
     return notes;
 }

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollGraphicsView.cpp
@@ -83,7 +83,7 @@ PianoRollGraphicsView::PianoRollGraphicsView(PianoRollGraphicsScene *scene, QWid
     d->m_lyricToolTip = std::make_unique<NoteLyricToolTipController>(viewport());
 
     d->m_selectionModel =
-        new PianoRollSelectionModel(this, d->noteViews, d->noteViewIndex, d->m_notes, this);
+        new PianoRollSelectionModel(this, d->noteViews, d->noteViewIndex, this);
     d->m_interactionController = new NoteInteractionController(d->m_selectionModel, this, this);
 
     d->m_gridItem = new PianoRollBackground;
@@ -899,12 +899,7 @@ void PianoRollGraphicsView::reset() {
 
 QList<int> PianoRollGraphicsView::selectedNotesId() const {
     Q_D(const PianoRollGraphicsView);
-    QList<int> list;
-    for (const auto noteView : d->noteViews) {
-        if (noteView->isSelected())
-            list.append(noteView->id());
-    }
-    return list;
+    return d->m_selectionModel->selectedNoteIds();
 }
 
 void PianoRollGraphicsView::clearNoteSelections(const NoteView *except) {
@@ -1367,6 +1362,7 @@ void PianoRollGraphicsViewPrivate::moveToNullClipState() {
         disconnect(m_clip, nullptr, this, nullptr);
     }
     m_clip = nullptr;
+    m_selectionModel->setDataContext(nullptr);
     m_initialViewportPositionPending = false;
 }
 
@@ -1384,6 +1380,7 @@ void PianoRollGraphicsViewPrivate::moveToSingingClipState(SingingClip *clip) {
     }
 
     m_clip = clip;
+    m_selectionModel->setDataContext(clip);
     m_offset = clip->start();
     q->setOffset(m_offset);
     q->setSceneVisibility(true);

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollRhiWidget.cpp
@@ -683,22 +683,12 @@ public:
     }
 
     QList<int> orderedNoteIds() const {
-        QList<const Note *> ordered;
-        if (clip) {
-            ordered.reserve(clip->notes().count());
-            for (const auto *note : clip->notes())
-                ordered.append(note);
-        }
-        std::sort(ordered.begin(), ordered.end(), [](const Note *left, const Note *right) {
-            if (left->localStart() != right->localStart())
-                return left->localStart() < right->localStart();
-            return left->id() < right->id();
-        });
-
         QList<int> result;
-        result.reserve(ordered.size());
-        for (const auto *note : ordered)
-            result.append(note->id());
+        if (clip) {
+            result.reserve(clip->notes().count());
+            for (const auto *note : clip->notes())
+                result.append(note->id());
+        }
         return result;
     }
 
@@ -996,16 +986,7 @@ public:
         submitInlineText(text);
         if (!clip)
             return;
-        QList<Note *> ordered;
-        for (auto *note : clip->notes())
-            ordered.append(note);
-        std::sort(ordered.begin(), ordered.end(), [](const Note *left, const Note *right) {
-            if (left->localStart() != right->localStart())
-                return left->localStart() < right->localStart();
-            if (left->keyIndex() != right->keyIndex())
-                return left->keyIndex() > right->keyIndex();
-            return left->id() < right->id();
-        });
+        const auto ordered = clip->notes().toList();
         const auto current =
             std::find_if(ordered.begin(), ordered.end(),
                          [currentId](const Note *note) { return note->id() == currentId; });

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.cpp
@@ -3,38 +3,45 @@
 #include "NoteView.h"
 #include "PronunciationView.h"
 #include <lite/ProjectModel/AppModel/Note.h>
+#include <lite/ProjectModel/AppModel/SingingClip.h>
 #include "Model/AppStatus/AppStatus.h"
 #include "Global/AppGlobal.h"
 #include "UI/Views/ClipEditor/ClipEditorGlobal.h"
-#include <lite/Support/Linq.h>
 
 #include <QDebug>
 
 #include "UI/Views/Common/TimeGraphicsScene.h"
 
-#include <algorithm>
-
 PianoRollSelectionModel::PianoRollSelectionModel(PianoRollGraphicsView *view,
                                                  QList<NoteView *> &noteViews,
                                                  QHash<int, NoteView *> &noteViewIndex,
-                                                 QList<Note *> &notes, QObject *parent)
-    : QObject(parent), m_noteViews(noteViews), m_noteViewIndex(noteViewIndex), m_notes(notes),
-      m_view(view) {
+                                                 QObject *parent)
+    : QObject(parent), m_noteViews(noteViews), m_noteViewIndex(noteViewIndex), m_view(view) {
 }
 
 QList<NoteView *> PianoRollSelectionModel::selectedNoteItems() const {
-    return Linq::where(m_noteViews, L_PRED(n, n->isSelected()));
+    QList<NoteView *> result;
+    for (auto *item : orderedNoteItems()) {
+        if (item->isSelected())
+            result.append(item);
+    }
+    return result;
 }
 
 QList<NoteView *> PianoRollSelectionModel::orderedNoteItems() const {
-    auto orderedItems = m_noteViews;
-    std::sort(orderedItems.begin(), orderedItems.end(),
-              [](const NoteView *lhs, const NoteView *rhs) {
-                  if (lhs->rStart() != rhs->rStart())
-                      return lhs->rStart() < rhs->rStart();
-                  return lhs->id() < rhs->id();
-              });
-    return orderedItems;
+    QList<NoteView *> result;
+    if (!m_clip)
+        return result;
+    result.reserve(m_clip->notes().count());
+    for (const auto *note : m_clip->notes()) {
+        if (auto *item = m_noteViewIndex.value(note->id(), nullptr))
+            result.append(item);
+    }
+    return result;
+}
+
+void PianoRollSelectionModel::setDataContext(SingingClip *clip) {
+    m_clip = clip;
 }
 
 EditorSelectionUtils::PressResult
@@ -129,7 +136,9 @@ void PianoRollSelectionModel::updateSceneSelectionState() {
 }
 
 void PianoRollSelectionModel::updateOverlappedState() {
-    for (const auto note : m_notes) {
+    if (!m_clip)
+        return;
+    for (const auto note : m_clip->notes()) {
         const auto noteView = m_noteViewIndex.value(note->id(), nullptr);
         if (!noteView) {
             continue;

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.h
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollSelectionModel.h
@@ -9,7 +9,7 @@
 #include <functional>
 
 class NoteView;
-class Note;
+class SingingClip;
 class PianoRollGraphicsView;
 
 class PianoRollSelectionModel : public QObject {
@@ -19,11 +19,13 @@ public:
     using NoteSelectionMode = EditorSelectionUtils::SelectionMode;
 
     explicit PianoRollSelectionModel(PianoRollGraphicsView *view, QList<NoteView *> &noteViews,
-                                     QHash<int, NoteView *> &noteViewIndex, QList<Note *> &notes,
+                                     QHash<int, NoteView *> &noteViewIndex,
                                      QObject *parent = nullptr);
 
     [[nodiscard]] QList<NoteView *> selectedNoteItems() const;
     [[nodiscard]] QList<NoteView *> orderedNoteItems() const;
+    [[nodiscard]] QList<int> selectedNoteIds() const;
+    void setDataContext(SingingClip *clip);
     [[nodiscard]] EditorSelectionUtils::PressResult
         applyNoteSelection(NoteView *noteView, Qt::KeyboardModifiers modifiers);
     [[nodiscard]] EditorSelectionUtils::PressResult applyPressSelection(NoteView *noteView,
@@ -88,7 +90,6 @@ signals:
     void selectionChanged();
 
 private:
-    [[nodiscard]] QList<int> selectedNoteIds() const;
     [[nodiscard]] QList<int> orderedNoteIds() const;
     void applySelection(const QList<int> &selection) const;
 
@@ -101,7 +102,7 @@ private:
     // References held from PianoRollGraphicsViewPrivate
     QList<NoteView *> &m_noteViews;
     QHash<int, NoteView *> &m_noteViewIndex;
-    QList<Note *> &m_notes;
+    SingingClip *m_clip = nullptr;
     PianoRollGraphicsView *m_view = nullptr;
 };
 

--- a/src/libs/ProjectModel/AppModel/Note.cpp
+++ b/src/libs/ProjectModel/AppModel/Note.cpp
@@ -229,6 +229,15 @@ int Note::compareTo(const Note *obj) const {
         return -1;
     if (localStart() > otherStart)
         return 1;
+    const auto otherKeyIndex = obj->keyIndex();
+    if (keyIndex() > otherKeyIndex)
+        return -1;
+    if (keyIndex() < otherKeyIndex)
+        return 1;
+    if (id() < obj->id())
+        return -1;
+    if (id() > obj->id())
+        return 1;
     return 0;
 }
 

--- a/src/tests/TestPianoRollInteractions/CMakeLists.txt
+++ b/src/tests/TestPianoRollInteractions/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
         Qt${QT_VERSION_MAJOR}::Test
         Qt${QT_VERSION_MAJOR}::Widgets
         lite::MusicBase
+        lite::ProjectModel
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/tests/TestPianoRollInteractions/main.cpp
+++ b/src/tests/TestPianoRollInteractions/main.cpp
@@ -3,6 +3,8 @@
 #include "UI/Views/Common/EditorSelectionUtils.h"
 
 #include <lite/MusicBase/Timeline.h>
+#include <lite/ProjectModel/AppModel/Note.h>
+#include <lite/ProjectModel/AppModel/SingingClip.h>
 
 #include <QApplication>
 #include <QFontMetricsF>
@@ -47,6 +49,30 @@ namespace {
 
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
+
+    {
+        SingingClip clip;
+        auto makeNote = [](const int start, const int key) {
+            auto *note = new Note;
+            note->setLocalStart(start);
+            note->setLength(120);
+            note->setKeyIndex(key);
+            return note;
+        };
+        auto *first = makeNote(0, 60);
+        auto *sameStartHighFirst = makeNote(240, 72);
+        auto *sameStartHighSecond = makeNote(240, 72);
+        auto *sameStartLow = makeNote(240, 60);
+        auto *later = makeNote(480, 60);
+        auto *splitContinuation = makeNote(120, 60);
+        clip.insertNotes({later, sameStartHighSecond, sameStartLow, first, splitContinuation,
+                          sameStartHighFirst});
+
+        expect(clip.notes().toList() ==
+                   (QList<Note *>{first, splitContinuation, sameStartHighFirst,
+                                  sameStartHighSecond, sameStartLow, later}),
+               "model notes must use start, descending pitch, and id as their canonical order");
+    }
 
     constexpr int startTick = 480;
     constexpr int quantize = 120;


### PR DESCRIPTION
## 问题

旧版钢琴卷帘按视图创建顺序上报选择。切割工具创建的连音符会被追加到列表末尾，导致“填入歌词”面板的显示顺序和实际填词目标错位。RHI 后端另有独立排序，因此两个后端行为不一致。

## 修改

- 在模型层定义唯一音符顺序：起点升序、同起点音高降序、再按 ID 升序。
- 旧版选择模型、RHI 选择/行内编辑以及填词控制器统一复用模型顺序。
- 移除两套后端各自维护的音符排序逻辑。
- 增加模型顺序回归测试，覆盖乱序插入、切割后插入以及同起点多音高。

## 验证

- Debug preset 完整构建通过。
- `TestPianoRollInteractions` 通过。
- `TestFillLyricTaggerOrder` 通过。
- `TestAutomationCore` 通过。
- `TestAutomationRuntimeDomains`：86 scenarios / 214 assertions / 0 failures。
- Computer Use：
  - 修复前旧后端复现 `啦 啦 啦 啦 -`，导入 `a - b c d` 后映射为 `a / d / - / b / c`。
  - 修复后旧后端显示 `啦 - 啦 啦 啦`，导入后为 `a / - / b / c / d`。
  - 修复后 RHI 后端同样显示 `啦 - 啦 啦 啦`。