### PR TITLE
fix(audio): wait for inference before export

### DIFF
--- a/src/app/Automation/AudioExportAutomationAdapter.cpp
+++ b/src/app/Automation/AudioExportAutomationAdapter.cpp
@@ -8,7 +8,11 @@
 
 #include <QCoreApplication>
 #include <QDir>
+#include <QEventLoop>
+#include <QPointer>
 #include <QTimer>
+
+#include <atomic>
 
 namespace Automation {
 
@@ -51,7 +55,8 @@ namespace Automation {
     class AudioExportJobAdapter final : public IAudioExportJob {
     public:
         AudioExportJobAdapter(AppModel *model, QString projectPath, AudioExportConfigDto config)
-            : m_exporter(std::make_unique<Audio::AudioExporter>(nullptr)) {
+            : m_audioContext(AudioContext::instance()),
+              m_exporter(std::make_unique<Audio::AudioExporter>(nullptr)) {
             m_config = std::move(config);
             if (m_config.sourceOption == Audio::AudioExporterConfig::SO_All) {
                 m_config.sources.clear();
@@ -60,7 +65,7 @@ namespace Automation {
                     m_config.sources.append(index);
             }
             m_exporter->configureAutomationBackend(model, std::move(projectPath),
-                                                   AudioContext::instance());
+                                                   m_audioContext.data());
             m_exporter->setConfigInternal(fromAutomationDto(m_config));
         }
 
@@ -74,6 +79,29 @@ namespace Automation {
         }
 
         AudioExportBackendResult execute(const AudioExportObserver &observer) override {
+            if (!m_audioContext) {
+                return {.state = AudioExportBackendState::Failed,
+                        .errorMessage = QStringLiteral("Audio context is unavailable")};
+            }
+            auto inferenceStatus = m_audioContext->exportInferenceStatus();
+            while (inferenceStatus == AudioContext::ExportInferenceStatus::Pending &&
+                   !m_cancellationRequested.load(std::memory_order_acquire)) {
+                QEventLoop loop;
+                QTimer::singleShot(25, &loop, &QEventLoop::quit);
+                loop.exec();
+                if (m_audioContext)
+                    inferenceStatus = m_audioContext->exportInferenceStatus();
+            }
+            if (m_cancellationRequested.load(std::memory_order_acquire))
+                return {.state = AudioExportBackendState::Canceled};
+            if (!m_audioContext) {
+                return {.state = AudioExportBackendState::Failed,
+                        .errorMessage = QStringLiteral("Audio context is unavailable")};
+            }
+            if (inferenceStatus == AudioContext::ExportInferenceStatus::Failed) {
+                return {.state = AudioExportBackendState::Failed,
+                        .errorMessage = QStringLiteral("Inference failed")};
+            }
             const auto progressConnection = QObject::connect(
                 m_exporter.get(), &Audio::AudioExporter::progressChanged,
                 [callback = observer.progress](const double progress, const int sourceIndex) {
@@ -110,6 +138,7 @@ namespace Automation {
         }
 
         void cancel() override {
+            m_cancellationRequested.store(true, std::memory_order_release);
             m_exporter->cancelInternal(false, {});
         }
 
@@ -118,8 +147,10 @@ namespace Automation {
         }
 
     private:
+        QPointer<AudioContext> m_audioContext;
         std::unique_ptr<Audio::AudioExporter> m_exporter;
         AudioExportConfigDto m_config;
+        std::atomic_bool m_cancellationRequested = false;
     };
 
     AudioExportRuntimeServices createAudioExportAutomationServices() {

--- a/src/app/Automation/AudioExportAutomationAdapter.cpp
+++ b/src/app/Automation/AudioExportAutomationAdapter.cpp
@@ -166,6 +166,8 @@ namespace Automation {
     private:
         [[nodiscard]] bool resolveSourceTracks(QList<Track *> &result) const {
             result.clear();
+            if (!m_model)
+                return false;
             const auto tracks = m_model->tracks();
             if (m_config.sourceOption == Audio::AudioExporterConfig::SO_All &&
                 tracks.size() != m_sourceTracks.size()) {
@@ -183,7 +185,7 @@ namespace Automation {
             return true;
         }
 
-        AppModel *m_model;
+        QPointer<AppModel> m_model;
         QPointer<AudioContext> m_audioContext;
         std::unique_ptr<Audio::AudioExporter> m_exporter;
         AudioExportConfigDto m_config;

--- a/src/app/Automation/AudioExportAutomationAdapter.cpp
+++ b/src/app/Automation/AudioExportAutomationAdapter.cpp
@@ -5,6 +5,7 @@
 #include "Modules/Audio/AudioExporter_p.h"
 
 #include <lite/ProjectModel/AppModel/AppModel.h>
+#include <lite/ProjectModel/AppModel/Track.h>
 
 #include <QCoreApplication>
 #include <QDir>
@@ -55,7 +56,7 @@ namespace Automation {
     class AudioExportJobAdapter final : public IAudioExportJob {
     public:
         AudioExportJobAdapter(AppModel *model, QString projectPath, AudioExportConfigDto config)
-            : m_audioContext(AudioContext::instance()),
+            : m_model(model), m_audioContext(AudioContext::instance()),
               m_exporter(std::make_unique<Audio::AudioExporter>(nullptr)) {
             m_config = std::move(config);
             if (m_config.sourceOption == Audio::AudioExporterConfig::SO_All) {
@@ -64,6 +65,10 @@ namespace Automation {
                 for (int index = 0; index < model->tracks().size(); ++index)
                     m_config.sources.append(index);
             }
+            const auto tracks = model->tracks();
+            m_sourceTracks.reserve(m_config.sources.size());
+            for (const auto source : m_config.sources)
+                m_sourceTracks.append(tracks.at(source));
             m_exporter->configureAutomationBackend(model, std::move(projectPath),
                                                    m_audioContext.data());
             m_exporter->setConfigInternal(fromAutomationDto(m_config));
@@ -83,14 +88,26 @@ namespace Automation {
                 return {.state = AudioExportBackendState::Failed,
                         .errorMessage = QStringLiteral("Audio context is unavailable")};
             }
-            auto inferenceStatus = m_audioContext->exportInferenceStatus();
+            QList<Track *> sourceTracks;
+            if (!resolveSourceTracks(sourceTracks)) {
+                return {.state = AudioExportBackendState::Failed,
+                        .errorMessage = QStringLiteral("Audio export sources changed")};
+            }
+            auto inferenceStatus = m_audioContext->exportInferenceStatus(sourceTracks);
             while (inferenceStatus == AudioContext::ExportInferenceStatus::Pending &&
                    !m_cancellationRequested.load(std::memory_order_acquire)) {
                 QEventLoop loop;
                 QTimer::singleShot(25, &loop, &QEventLoop::quit);
                 loop.exec();
-                if (m_audioContext)
-                    inferenceStatus = m_audioContext->exportInferenceStatus();
+                if (!m_audioContext) {
+                    return {.state = AudioExportBackendState::Failed,
+                            .errorMessage = QStringLiteral("Audio context is unavailable")};
+                }
+                if (!resolveSourceTracks(sourceTracks)) {
+                    return {.state = AudioExportBackendState::Failed,
+                            .errorMessage = QStringLiteral("Audio export sources changed")};
+                }
+                inferenceStatus = m_audioContext->exportInferenceStatus(sourceTracks);
             }
             if (m_cancellationRequested.load(std::memory_order_acquire))
                 return {.state = AudioExportBackendState::Canceled};
@@ -147,9 +164,30 @@ namespace Automation {
         }
 
     private:
+        [[nodiscard]] bool resolveSourceTracks(QList<Track *> &result) const {
+            result.clear();
+            const auto tracks = m_model->tracks();
+            if (m_config.sourceOption == Audio::AudioExporterConfig::SO_All &&
+                tracks.size() != m_sourceTracks.size()) {
+                return false;
+            }
+            for (int i = 0; i < m_config.sources.size(); ++i) {
+                const auto source = m_config.sources.at(i);
+                const auto track = m_sourceTracks.at(i);
+                if (!track || source < 0 || source >= tracks.size() ||
+                    tracks.at(source) != track.data()) {
+                    return false;
+                }
+                result.append(track.data());
+            }
+            return true;
+        }
+
+        AppModel *m_model;
         QPointer<AudioContext> m_audioContext;
         std::unique_ptr<Audio::AudioExporter> m_exporter;
         AudioExportConfigDto m_config;
+        QList<QPointer<Track>> m_sourceTracks;
         std::atomic_bool m_cancellationRequested = false;
     };
 
@@ -165,7 +203,7 @@ namespace Automation {
                 return error;
             }
             for (const auto source : config.sources) {
-                if (source >= model->tracks().size()) {
+                if (source < 0 || source >= model->tracks().size()) {
                     return AutomationError::invalidArgument(
                         QStringLiteral("config.sources"),
                         QStringLiteral("Audio export source index is out of range"));

--- a/src/app/Automation/AudioExportAutomationFacade.cpp
+++ b/src/app/Automation/AudioExportAutomationFacade.cpp
@@ -314,6 +314,10 @@ namespace Automation {
                 }
 
                 auto state = std::make_shared<PendingJobState>();
+                {
+                    const QMutexLocker locker(&state->mutex);
+                    state->job = validationJob.get();
+                }
                 const auto task = m_tasks.createTask(
                     OperationIds::exports::audio::start, session.version(), std::nullopt,
                     [weak = std::weak_ptr<PendingJobState>(state)] {
@@ -340,9 +344,9 @@ namespace Automation {
                     Q_ASSERT(bound);
                 }
 
-                auto execute = [this, taskId = task.taskId, base = session.version(), config,
+                auto execute = [this, taskId = task.taskId, base = session.version(),
                                 observer = std::move(observer), state]() mutable {
-                    executeTask(taskId, base, std::move(config), std::move(observer), state);
+                    executeTask(taskId, base, std::move(observer), state);
                 };
                 if (m_services.schedule)
                     m_services.schedule(execute);
@@ -388,46 +392,38 @@ namespace Automation {
 
     void AudioExportAutomationFacade::executeTask(const TaskId &taskId,
                                                   const DocumentVersion baseDocument,
-                                                  AudioExportConfigDto config,
                                                   AudioExportObserver observer,
                                                   const std::shared_ptr<PendingJobState> &state) {
-        if (m_tasks.isCancellationRequested(taskId)) {
+        std::shared_ptr<IAudioExportJob> job;
+        bool cancelBeforeRun = false;
+        {
+            const QMutexLocker locker(&state->mutex);
+            job = state->job;
+            cancelBeforeRun = state->cancellationRequested;
+        }
+        if (!job) {
+            m_tasks.fail(taskId, taskError(unavailable(), taskId));
+            return;
+        }
+        const auto cleanup = [state] {
+            if (const auto current = state->claimCleanup())
+                current->cleanup();
+        };
+        const auto cleanupIfRequested = [state] {
+            if (const auto current = state->claimRequestedCleanup())
+                current->cleanup();
+        };
+        if (cancelBeforeRun || m_tasks.isCancellationRequested(taskId)) {
+            if (!cancelBeforeRun)
+                job->cancel();
             m_tasks.cancel(taskId);
+            cleanupIfRequested();
             return;
         }
         auto resolved = resolveDocumentGeneration(baseDocument);
         if (!resolved) {
-            m_tasks.fail(taskId, taskError(resolved.getError(), taskId));
-            return;
-        }
-        if (!m_services.createJob) {
-            m_tasks.fail(taskId, taskError(unavailable(), taskId));
-            return;
-        }
-        auto created =
-            m_services.createJob(resolved.get().get().model(), resolved.get().get().path(), config);
-        if (!created) {
-            m_tasks.fail(taskId, taskError(created.getError(), taskId));
-            return;
-        }
-        bool cancelBeforeRun = false;
-        {
-            const QMutexLocker locker(&state->mutex);
-            state->job = created.get();
-            cancelBeforeRun = state->cancellationRequested;
-        }
-        const auto cleanup = [state] {
-            if (const auto job = state->claimCleanup())
-                job->cleanup();
-        };
-        const auto cleanupIfRequested = [state] {
-            if (const auto job = state->claimRequestedCleanup())
-                job->cleanup();
-        };
-        if (cancelBeforeRun || m_tasks.isCancellationRequested(taskId)) {
-            created.get()->cancel();
-            m_tasks.cancel(taskId);
             cleanupIfRequested();
+            m_tasks.fail(taskId, taskError(resolved.getError(), taskId));
             return;
         }
         if (!m_tasks.markRunning(taskId)) {
@@ -463,7 +459,7 @@ namespace Automation {
                 callback(message, sourceIndex);
         };
 
-        const auto result = created.get()->execute(taskObserver);
+        const auto result = job->execute(taskObserver);
         if (result.state == AudioExportBackendState::Canceled ||
             m_tasks.isCancellationRequested(taskId)) {
             m_tasks.cancel(taskId);

--- a/src/app/Automation/AudioExportAutomationFacade.cpp
+++ b/src/app/Automation/AudioExportAutomationFacade.cpp
@@ -395,7 +395,7 @@ namespace Automation {
             m_tasks.cancel(taskId);
             return;
         }
-        auto resolved = resolveVersion(baseDocument);
+        auto resolved = resolveDocumentGeneration(baseDocument);
         if (!resolved) {
             m_tasks.fail(taskId, taskError(resolved.getError(), taskId));
             return;
@@ -481,37 +481,38 @@ namespace Automation {
             return;
         }
 
-        resolved = resolveVersion(baseDocument);
+        resolved = resolveDocumentGeneration(baseDocument);
         if (!resolved) {
             cleanup();
             m_tasks.fail(taskId, taskError(resolved.getError(), taskId));
             return;
         }
+        const auto currentDocument = resolved.get().get().version();
         const auto committing = m_tasks.beginCommitting(taskId);
         if (!committing || !committing.get()) {
             cleanup();
             return;
         }
         MutationResult mutation;
-        mutation.previous = baseDocument;
-        mutation.current = baseDocument;
+        mutation.previous = currentDocument;
+        mutation.current = currentDocument;
         mutation.warnings = std::move(warnings);
         if (!m_tasks.succeed(taskId, std::move(mutation)))
             cleanupIfRequested();
     }
 
     AutomationResult<std::reference_wrapper<DocumentSession>>
-        AudioExportAutomationFacade::resolveVersion(const DocumentVersion &version) const {
+        AudioExportAutomationFacade::resolveDocumentGeneration(
+            const DocumentVersion &version) const {
         auto resolved = m_documentResolver.resolveDocument(version.documentId);
         if (!resolved)
             return resolved.getError();
         auto &session = resolved.get().get();
         if (session.lifecycleState() != DocumentLifecycleState::Active)
             return AutomationError::documentBusy(session.documentId());
-        if (session.revision() != version.revision) {
-            return AutomationError::revisionConflict(session.documentId(), version.revision,
-                                                     session.revision());
-        }
+        const auto rebased = rebaseTaskVersionWithinGeneration(version, session.version());
+        if (!rebased)
+            return rebased.getError();
         return std::ref(session);
     }
 

--- a/src/app/Automation/AudioExportAutomationFacade.h
+++ b/src/app/Automation/AudioExportAutomationFacade.h
@@ -100,7 +100,7 @@ namespace Automation {
 
         void registerOperations();
         void executeTask(const TaskId &taskId, DocumentVersion baseDocument,
-                         AudioExportConfigDto config, AudioExportObserver observer,
+                         AudioExportObserver observer,
                          const std::shared_ptr<PendingJobState> &state);
         AutomationResult<std::reference_wrapper<DocumentSession>>
             resolveDocumentGeneration(const DocumentVersion &version) const;

--- a/src/app/Automation/AudioExportAutomationFacade.h
+++ b/src/app/Automation/AudioExportAutomationFacade.h
@@ -103,7 +103,7 @@ namespace Automation {
                          AudioExportConfigDto config, AudioExportObserver observer,
                          const std::shared_ptr<PendingJobState> &state);
         AutomationResult<std::reference_wrapper<DocumentSession>>
-            resolveVersion(const DocumentVersion &version) const;
+            resolveDocumentGeneration(const DocumentVersion &version) const;
 
         OperationCatalog &m_catalog;
         AutomationDispatcher &m_dispatcher;

--- a/src/app/Modules/Audio/AudioContext.cpp
+++ b/src/app/Modules/Audio/AudioContext.cpp
@@ -231,6 +231,23 @@ AudioContext *AudioContext::instance() {
     return m_instance;
 }
 
+AudioContext::ExportInferenceStatus AudioContext::exportInferenceStatus() const {
+    auto result = ExportInferenceStatus::Ready;
+    for (const auto track : m_trackInferDict.keys()) {
+        for (const auto clip : track->clips()) {
+            if (clip->clipType() != Clip::Singing)
+                continue;
+            for (const auto piece : static_cast<SingingClip *>(clip)->pieces()) {
+                if (piece->acousticInferStatus == Failed)
+                    return ExportInferenceStatus::Failed;
+                if (piece->acousticInferStatus != Success)
+                    result = ExportInferenceStatus::Pending;
+            }
+        }
+    }
+    return result;
+}
+
 Track *AudioContext::getTrackFromContext(const talcs::DspxTrackContext *trackContext) const {
     Q_UNUSED(this)
     return trackContext->data().value<Track *>();
@@ -644,19 +661,7 @@ bool AudioContext::willStartCallback(AudioExporter *exporter) {
     for (const auto trackInferenceHandler : m_trackInferDict.values()) {
         trackInferenceHandler->setMode(talcs::DspxTrackInferenceContext::Export);
     }
-    const bool isOK = [this] {
-        for (const auto track : m_trackInferDict.keys()) {
-            for (const auto clip : track->clips()) {
-                if (clip->clipType() != Clip::Singing)
-                    continue;
-                for (const auto piece : static_cast<SingingClip *>(clip)->pieces()) {
-                    if (piece->acousticInferStatus == Failed)
-                        return false;
-                }
-            }
-        }
-        return true;
-    }();
+    const bool isOK = exportInferenceStatus() != ExportInferenceStatus::Failed;
     if (!isOK)
         exporter->cancel(true, tr("Inference failed"));
     return isOK;

--- a/src/app/Modules/Audio/AudioContext.cpp
+++ b/src/app/Modules/Audio/AudioContext.cpp
@@ -232,8 +232,13 @@ AudioContext *AudioContext::instance() {
 }
 
 AudioContext::ExportInferenceStatus AudioContext::exportInferenceStatus() const {
+    return exportInferenceStatus(m_trackInferDict.keys());
+}
+
+AudioContext::ExportInferenceStatus
+    AudioContext::exportInferenceStatus(const QList<Track *> &tracks) const {
     auto result = ExportInferenceStatus::Ready;
-    for (const auto track : m_trackInferDict.keys()) {
+    for (const auto track : tracks) {
         for (const auto clip : track->clips()) {
             if (clip->clipType() != Clip::Singing)
                 continue;

--- a/src/app/Modules/Audio/AudioContext.h
+++ b/src/app/Modules/Audio/AudioContext.h
@@ -41,6 +41,7 @@ public:
     static AudioContext *instance();
 
     [[nodiscard]] ExportInferenceStatus exportInferenceStatus() const;
+    [[nodiscard]] ExportInferenceStatus exportInferenceStatus(const QList<Track *> &tracks) const;
 
     Track *getTrackFromContext(const talcs::DspxTrackContext *trackContext) const;
     AudioClip *getAudioClipFromContext(const talcs::DspxAudioClipContext *audioClipContext) const;

--- a/src/app/Modules/Audio/AudioContext.h
+++ b/src/app/Modules/Audio/AudioContext.h
@@ -29,10 +29,18 @@ class AudioContextAudioExporterListener;
 class AudioContext : public talcs::DspxProjectContext, public Audio::AudioExporterListener {
     Q_OBJECT
 public:
+    enum class ExportInferenceStatus {
+        Ready,
+        Pending,
+        Failed,
+    };
+
     explicit AudioContext(QObject *parent = nullptr);
     ~AudioContext() override;
 
     static AudioContext *instance();
+
+    [[nodiscard]] ExportInferenceStatus exportInferenceStatus() const;
 
     Track *getTrackFromContext(const talcs::DspxTrackContext *trackContext) const;
     AudioClip *getAudioClipFromContext(const talcs::DspxAudioClipContext *audioClipContext) const;

--- a/src/tests/TestAutomationAsyncDimensions/main.cpp
+++ b/src/tests/TestAutomationAsyncDimensions/main.cpp
@@ -942,28 +942,99 @@ namespace {
                    QStringLiteral("I/O failure must be queryable and release the key"));
         });
 
-        matrix.run(operationId, "AFD-EXP-AUDIO-006-REVISION-BEFORE-RUN", [&] {
+        matrix.run(operationId, "AFD-EXP-AUDIO-006-SAME-GENERATION-REBASE", [&] {
             matrix.cover("Queued");
+            matrix.cover("Running");
+            matrix.cover("CancelRequested");
             matrix.cover("terminal");
-            RuntimeHarness harness;
-            const auto base = harness.runtime().documentVersion();
-            const auto accepted = harness.runtime().audioExports().start(
-                harness.context(), audioConfig(harness, QStringLiteral("stale.wav")), {});
-            const auto edit = harness.runtime().timeline().setTempo(harness.context(), 1440, 139.0);
-            const auto released = harness.audioScheduler.runNext();
-            const auto terminal =
-                accepted ? harness.runtime().tasks().getTask(base.documentId, accepted.get().taskId)
-                         : Automation::AutomationResult<Automation::AutomationTaskSnapshot>(
-                               Automation::AutomationError{});
-            EXPECT(matrix,
-                   accepted && edit && released && terminal &&
-                       terminal.get().state == Automation::AutomationTaskState::Failed &&
-                       terminal.get().error &&
-                       terminal.get().error->code ==
-                           Automation::AutomationErrorCode::RevisionConflict &&
-                       harness.audioExportState()->executeCount == 0 &&
-                       harness.runtime().documentVersion().revision == base.revision + 1,
-                   QStringLiteral("revision drift must fail before file execution"));
+            {
+                RuntimeHarness harness;
+                const auto base = harness.runtime().documentVersion();
+                const auto accepted = harness.runtime().audioExports().start(
+                    harness.context(), audioConfig(harness, QStringLiteral("queued-rebase.wav")),
+                    {});
+                const auto edit =
+                    harness.runtime().timeline().setTempo(harness.context(), 1440, 139.0);
+                const auto current = harness.runtime().documentVersion();
+                const auto released = harness.audioScheduler.runNext();
+                const auto terminal =
+                    accepted
+                        ? harness.runtime().tasks().getTask(base.documentId, accepted.get().taskId)
+                        : Automation::AutomationResult<Automation::AutomationTaskSnapshot>(
+                              Automation::AutomationError{});
+                EXPECT(matrix,
+                       accepted && edit && released && terminal &&
+                           terminal.get().state == Automation::AutomationTaskState::Succeeded &&
+                           terminal.get().mutation &&
+                           terminal.get().mutation->previous == current &&
+                           terminal.get().mutation->current == current &&
+                           harness.audioExportState()->executeCount == 1 &&
+                           current.revision == base.revision + 1,
+                       QStringLiteral("queued export must rebase before file execution"));
+            }
+
+            {
+                RuntimeHarness harness;
+                const auto base = harness.runtime().documentVersion();
+                std::optional<Automation::AutomationResult<Automation::MutationResult>> edit;
+                harness.audioExportState()->executeHook = [&] {
+                    edit.emplace(
+                        harness.runtime().timeline().setTempo(harness.context(), 1440, 139.0));
+                };
+                const auto accepted = harness.runtime().audioExports().start(
+                    harness.context(), audioConfig(harness, QStringLiteral("running-rebase.wav")),
+                    {});
+                const auto released = harness.audioScheduler.runNext();
+                const auto current = harness.runtime().documentVersion();
+                const auto terminal =
+                    accepted
+                        ? harness.runtime().tasks().getTask(base.documentId, accepted.get().taskId)
+                        : Automation::AutomationResult<Automation::AutomationTaskSnapshot>(
+                              Automation::AutomationError{});
+                EXPECT(matrix,
+                       accepted && released && edit && *edit && terminal &&
+                           terminal.get().state == Automation::AutomationTaskState::Succeeded &&
+                           terminal.get().mutation &&
+                           terminal.get().mutation->previous == current &&
+                           terminal.get().mutation->current == current &&
+                           harness.audioExportState()->executeCount == 1 &&
+                           current.revision == base.revision + 1,
+                       QStringLiteral("running export must rebase after file execution"));
+            }
+
+            {
+                RuntimeHarness harness;
+                const auto base = harness.runtime().documentVersion();
+                Automation::TaskId taskId;
+                std::optional<Automation::AutomationResult<Automation::MutationResult>> edit;
+                std::optional<Automation::AutomationResult<Automation::AutomationTaskSnapshot>>
+                    cancel;
+                harness.audioExportState()->executeHook = [&] {
+                    edit.emplace(
+                        harness.runtime().timeline().setTempo(harness.context(), 1440, 139.0));
+                    cancel.emplace(harness.runtime().tasks().cancelTask(harness.context(), taskId));
+                };
+                const auto accepted = harness.runtime().audioExports().start(
+                    harness.context(), audioConfig(harness, QStringLiteral("running-cancel.wav")),
+                    {});
+                if (accepted)
+                    taskId = accepted.get().taskId;
+                const auto released = harness.audioScheduler.runNext();
+                const auto terminal =
+                    accepted
+                        ? harness.runtime().tasks().getTask(base.documentId, accepted.get().taskId)
+                        : Automation::AutomationResult<Automation::AutomationTaskSnapshot>(
+                              Automation::AutomationError{});
+                EXPECT(matrix,
+                       accepted && released && edit && *edit && cancel && *cancel && terminal &&
+                           cancel->get().state ==
+                               Automation::AutomationTaskState::CancelRequested &&
+                           terminal.get().state == Automation::AutomationTaskState::Canceled &&
+                           harness.audioExportState()->executeCount == 1 &&
+                           harness.audioExportState()->cancelCount == 1 &&
+                           harness.runtime().documentVersion().revision == base.revision + 1,
+                       QStringLiteral("revision drift must not prevent running cancellation"));
+            }
         });
 
         matrix.run(operationId, "AFD-EXP-AUDIO-007-GENERATION-BEFORE-RUN", [&] {

--- a/src/tests/TestAutomationAsyncDimensions/main.cpp
+++ b/src/tests/TestAutomationAsyncDimensions/main.cpp
@@ -859,9 +859,9 @@ namespace {
             EXPECT(matrix,
                    terminal && terminal.get().state == Automation::AutomationTaskState::Succeeded &&
                        terminalReplay && terminalReplay.get() == first.get() &&
-                       harness.audioExportState()->createCount == 2 &&
+                       harness.audioExportState()->createCount == 1 &&
                        harness.audioExportState()->executeCount == 1,
-                   QStringLiteral("terminal replay must keep the accepted TaskId"));
+                   QStringLiteral("terminal replay must execute the accepted preview job"));
         });
 
         matrix.run(operationId, "AFD-EXP-AUDIO-003-QUEUED-CANCEL", [&] {

--- a/src/tests/TestAutomationIdempotency/main.cpp
+++ b/src/tests/TestAutomationIdempotency/main.cpp
@@ -1012,12 +1012,13 @@ namespace {
         return expect(acceptedOnce,
                       QStringLiteral(
                           "accepted async replay must return one TaskId and schedule once")) &&
-               expect(ran && completed && *completed &&
-                          completed->get().state == Automation::AutomationTaskState::Succeeded &&
-                          terminalReplay && terminalReplay.get() == first.get() &&
-                          harness.scheduler().size() == 0 && harness.control().createCount == 2 &&
-                          harness.control().executeCount == 1,
-                      QStringLiteral("successful async replay must retain the original TaskId"));
+               expect(
+                   ran && completed && *completed &&
+                       completed->get().state == Automation::AutomationTaskState::Succeeded &&
+                       terminalReplay && terminalReplay.get() == first.get() &&
+                       harness.scheduler().size() == 0 && harness.control().createCount == 1 &&
+                       harness.control().executeCount == 1,
+                   QStringLiteral("successful async replay must execute the accepted preview job"));
     }
 
     bool asyncPreAcceptanceFailuresDoNotClaimKeys() {


### PR DESCRIPTION
## Summary

- keep accepted audio exports bound to the active document generation while allowing inference writebacks to advance its revision
- wait for acoustic inference before opening output files or entering the blocking TALCS render path
- keep the preparation wait responsive to cancellation and reuse AudioContext inference-state inspection

## Root cause

The automation facade rechecked the request revision before and after the backend ran. Duration, pitch, and variance writebacks legitimately advance the same document generation, so an export accepted during inference could fail with a revision conflict. The exporter also entered TALCS block-read mode while inference was pending; TALCS only observes interruption between reads, so cancel could not complete until the pending inference read returned.

## Verification

- Computer Use reproduction with a temporary interruptible 90-second duration-inference delay
  - confirmed the old build failed with `Expected revision 3, actual revision is 6`
  - confirmed the old cancel remained stuck until inference finished
  - confirmed the fixed build stays at `Preparing...` / 0% while inference is pending
  - confirmed cancel reaches `Export aborted` immediately during that wait
  - confirmed waiting through inference completes the WAV export without a revision error
- `TestAutomationAsyncDimensions`: 233 scenarios, 261 assertions, 0 failures
- Release `DsEditorLite` target build