### PR TITLE
fix(options): prevent early description wrapping

### DIFF
--- a/src/libs/GUI/Controls/OptionsCardItem.cpp
+++ b/src/libs/GUI/Controls/OptionsCardItem.cpp
@@ -23,8 +23,8 @@ OptionsCardItem::OptionsCardItem(QWidget *parent) : QWidget(parent) {
     titleDescLayout->setSpacing(2);
 
     m_mainLayout = new QHBoxLayout;
-    m_mainLayout->addLayout(titleDescLayout);
-    m_mainLayout->addSpacerItem(new QSpacerItem(8, 4, QSizePolicy::Expanding));
+    m_mainLayout->addLayout(titleDescLayout, 1);
+    m_mainLayout->addSpacing(8);
     m_mainLayout->setContentsMargins(0, 3, 0, 3);
     setLayout(m_mainLayout);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);

--- a/src/libs/GUI/Controls/OptionsCardItem.cpp
+++ b/src/libs/GUI/Controls/OptionsCardItem.cpp
@@ -24,7 +24,6 @@ OptionsCardItem::OptionsCardItem(QWidget *parent) : QWidget(parent) {
 
     m_mainLayout = new QHBoxLayout;
     m_mainLayout->addLayout(titleDescLayout, 1);
-    m_mainLayout->addSpacing(8);
     m_mainLayout->setContentsMargins(0, 3, 0, 3);
     setLayout(m_mainLayout);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);


### PR DESCRIPTION
## Summary

- let the title and description column consume the available card width
- keep a fixed gap before the trailing control so controls retain their intended size

## Verification

- built DsEditorLite with the debug CMake preset
- reproduced and verified the Developer Options layout with Computer Use