### PR TITLE
refactor(audio): redesign export dialog workflow

### DIFF
--- a/src/app/Automation/AppOptionsAutomationAdapter.cpp
+++ b/src/app/Automation/AppOptionsAutomationAdapter.cpp
@@ -244,7 +244,6 @@ namespace Automation {
                     AudioSettings::audioExporterClippingCheckEnabled(),
                 .audioExporterIgnoredWarningFlags =
                     AudioSettings::audioExporterIgnoredWarningFlag(),
-                .audioExporterUseTemporaryFile = AudioSettings::audioExporterUseTemporaryFile(),
             };
             for (int index = 0; index < 4; ++index) {
                 result.pseudoSingerSynthesizers.append({
@@ -341,8 +340,6 @@ namespace Automation {
                 value.audioExporterClippingCheckEnabled;
             object[QStringLiteral("audioExporterIgnoredWarningFlag")] =
                 value.audioExporterIgnoredWarningFlags;
-            object[QStringLiteral("audioExporterUseTemporaryFile")] =
-                value.audioExporterUseTemporaryFile;
             QJsonObject presets;
             for (const auto &preset : value.audioExporterPresets) {
                 const auto &config = preset.config;

--- a/src/app/Automation/SettingsAutomationFacade.h
+++ b/src/app/Automation/SettingsAutomationFacade.h
@@ -195,7 +195,6 @@ namespace Automation {
         int vstPluginPort = 28082;
         bool audioExporterClippingCheckEnabled = true;
         int audioExporterIgnoredWarningFlags = 0;
-        bool audioExporterUseTemporaryFile = true;
         QList<AudioExportPresetDto> audioExporterPresets;
         QString currentAudioExporterPreset;
         int legacyAudioExporterPresetIndex = 0;

--- a/src/app/Modules/Audio/AudioExporter.cpp
+++ b/src/app/Modules/Audio/AudioExporter.cpp
@@ -19,6 +19,10 @@
 #include <QStandardPaths>
 #include <QHash>
 
+#ifdef Q_OS_WIN
+#  include <qt_windows.h>
+#endif
+
 #include <TalcsCore/TransportAudioSource.h>
 #include <TalcsCore/MixerAudioSource.h>
 #include <TalcsFormat/AudioFormatIO.h>
@@ -27,6 +31,19 @@
 #include <TalcsDspx/DspxTrackContext.h>
 
 #include <Modules/Audio/AudioSettings.h>
+
+namespace {
+    bool replaceFile(const QString &source, const QString &target) {
+#ifdef Q_OS_WIN
+        return MoveFileExW(reinterpret_cast<LPCWSTR>(source.utf16()),
+                           reinterpret_cast<LPCWSTR>(target.utf16()),
+                           MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+#else
+        QFile::remove(target);
+        return QFile::rename(source, target);
+#endif
+    }
+}
 
 namespace Audio {
     using namespace Internal;
@@ -738,15 +755,11 @@ namespace Audio {
                                   .mid(0, 8);
             for (int i = 0; i < d->fileList.size(); i++) {
                 QString filename = d->fileList.at(i);
-                if (AudioSettings::audioExporterUseTemporaryFile()) {
-                    auto temporaryFileName = QFileInfo(filename).dir().filePath(
-                        ".ds$" + uuid + QFileInfo(filename).fileName() + ".exporting");
-                    temporaryFiles.insert(filename, temporaryFileName);
-                    d->temporaryFileList.append(temporaryFileName);
-                    filename = temporaryFileName;
-                } else {
-                    d->temporaryFileList.append(filename);
-                }
+                auto temporaryFileName = QFileInfo(filename).dir().filePath(
+                    ".ds$" + uuid + QFileInfo(filename).fileName() + ".exporting");
+                temporaryFiles.insert(filename, temporaryFileName);
+                d->temporaryFileList.append(temporaryFileName);
+                filename = temporaryFileName;
                 const auto file = new QFile(filename, &o);
                 if (!file->open(QIODevice::WriteOnly)) {
                     setErrorString(tr("Cannot open file for writing: %1").arg(filename));
@@ -858,22 +871,18 @@ namespace Audio {
         d->temporaryFileList.clear();
 
         // rename temporary files
-        if (AudioSettings::audioExporterUseTemporaryFile()) {
-            auto temporaryFileErrorString = tr("Cannot rename temporary files to target files");
-            bool failFlag = false;
-            for (const auto &filename : temporaryFiles.keys()) {
-                QFile::remove(filename);
-                auto temporaryFile = QFile(temporaryFiles.value(filename));
-                if (!temporaryFile.rename(filename)) {
-                    temporaryFileErrorString += "\n" + filename;
-                    setErrorString(temporaryFileErrorString);
-                    failFlag = true;
-                    d->temporaryFileList.append(temporaryFile.fileName());
-                }
+        auto temporaryFileErrorString = tr("Cannot rename temporary files to target files");
+        bool failFlag = false;
+        for (auto it = temporaryFiles.constBegin(); it != temporaryFiles.constEnd(); ++it) {
+            if (!replaceFile(it.value(), it.key())) {
+                temporaryFileErrorString += "\n" + it.key();
+                setErrorString(temporaryFileErrorString);
+                failFlag = true;
+                d->temporaryFileList.append(it.value());
             }
-            if (failFlag)
-                return R_Fail;
         }
+        if (failFlag)
+            return R_Fail;
 
         return R_Ok;
     }

--- a/src/app/Modules/Audio/AudioExporter.h
+++ b/src/app/Modules/Audio/AudioExporter.h
@@ -25,6 +25,7 @@ namespace Audio {
 
     namespace Internal {
         class AudioExportDialog;
+        class AudioExportProgressDialog;
     }
 
     class AudioExporter;
@@ -119,6 +120,7 @@ namespace Audio {
         Q_OBJECT
         Q_DECLARE_PRIVATE(AudioExporter)
         friend class Internal::AudioExportDialog;
+        friend class Internal::AudioExportProgressDialog;
         friend class Automation::AudioExportJobAdapter;
 
     public:

--- a/src/app/Modules/Audio/AudioSettings.cpp
+++ b/src/app/Modules/Audio/AudioSettings.cpp
@@ -145,6 +145,3 @@ AUDIO_AUDIO_SETTINGS_OPTION_IMPLEMENTATION_2(audioExporterClippingCheckEnabled,
 AUDIO_AUDIO_SETTINGS_OPTION_IMPLEMENTATION_1(audioExporterIgnoredWarningFlag,
                                              setAudioExporterIgnoredWarningFlag,
                                              audioExporterIgnoredWarningFlags)
-AUDIO_AUDIO_SETTINGS_OPTION_IMPLEMENTATION_2(audioExporterUseTemporaryFile,
-                                             setAudioExporterUseTemporaryFile, true,
-                                             audioExporterUseTemporaryFile)

--- a/src/app/Modules/Audio/AudioSettings.h
+++ b/src/app/Modules/Audio/AudioSettings.h
@@ -66,8 +66,6 @@ class AudioSettings {
                                             setAudioExporterClippingCheckEnabled, bool)
     AUDIO_AUDIO_SETTINGS_OPTION_DECLARATION(audioExporterIgnoredWarningFlag,
                                             setAudioExporterIgnoredWarningFlag, int)
-    AUDIO_AUDIO_SETTINGS_OPTION_DECLARATION(audioExporterUseTemporaryFile,
-                                            setAudioExporterUseTemporaryFile, bool)
 };
 
 #endif // AUDIOSETTINGS_H

--- a/src/app/Resources/translate/translation_zh_CN.ts
+++ b/src/app/Resources/translate/translation_zh_CN.ts
@@ -212,102 +212,102 @@
 <context>
     <name>Audio::AudioExporter</name>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="502"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="519"/>
         <source>WAV - Mixed</source>
         <translation>WAV - 混合</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="503"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="520"/>
         <source>WAV - Separated</source>
         <translation>WAV - 分离</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="504"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="521"/>
         <source>FLAC - Mixed</source>
         <translation>FLAC - 混合</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="505"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="522"/>
         <source>FLAC - Separated</source>
         <translation>FLAC - 分离</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="506"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="523"/>
         <source>Ogg/Vorbis - Mixed</source>
         <translation>Ogg/Vorbis - 混合</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="507"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="524"/>
         <source>Ogg/Vorbis - Separated</source>
         <translation>Ogg/Vorbis - 分离</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="623"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="640"/>
         <source>No file will be exported. Please check if any source is selected.</source>
         <translation>没有文件将被导出。请检查是否已选择任何源。</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="626"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="643"/>
         <source>The files to be exported contain files with duplicate names. Please check if the file name template is unique for each source.</source>
         <translation>待导出的文件包含重名文件。请检查文件名模板是否对每个源都是唯一的。</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="630"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="647"/>
         <source>The files to be exported contain files with the same name as existing files. If continue, the existing files will be overwritten.</source>
         <translation>待导出的文件与现有文件重名。如果继续，现有文件将被覆盖。</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="634"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="651"/>
         <source>Unrecognized file name template. Please check the syntax of the file name template.</source>
         <translation>无法识别的文件名模板。请检查文件名模板的语法。</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="638"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="655"/>
         <source>The currently selected file type is a lossy format. To avoid loss of sound quality, please use WAV or FLAC format.</source>
         <translation>当前选择的文件类型为有损格式。为避免音质损失，请使用 WAV 或 FLAC 格式。</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="662"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="679"/>
         <source>Audio export runtime is unavailable</source>
         <translation>音频导出运行时不可用</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="706"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="723"/>
         <source>Audio export failed</source>
         <translation>音频导出失败</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="752"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="765"/>
         <source>Cannot open file for writing: %1</source>
         <translation>无法打开文件写入：%1</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="761"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="774"/>
         <source>Format not supported: %1</source>
         <translation>不支持的格式：%1</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="811"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="824"/>
         <source>Cannot reopen audio after exported</source>
         <translation>导出后无法重新打开音频</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="817"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="830"/>
         <source>Cannot start audio exporting</source>
         <translation>无法开始音频导出</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="851"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="864"/>
         <source>Internal Error</source>
         <translation>内部错误</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="862"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="874"/>
         <source>Cannot rename temporary files to target files</source>
         <translation>无法将临时文件重命名为目标文件</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="918"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="927"/>
         <source>Unknown error</source>
         <translation>未知错误</translation>
     </message>
@@ -315,29 +315,29 @@
 <context>
     <name>Audio::AudioExporterConfig</name>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="75"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="92"/>
         <source>32-bit float (IEEE 754)</source>
         <translation>32 位浮点 (IEEE 754)</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="77"/>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="83"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="94"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="100"/>
         <source>24-bit PCM</source>
         <translation>24 位 PCM</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="78"/>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="84"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="95"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="101"/>
         <source>16-bit PCM</source>
         <translation>16 位 PCM</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="79"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="96"/>
         <source>Unsigned 8-bit PCM</source>
         <translation>无符号 8 位 PCM</translation>
     </message>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="85"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="102"/>
         <source>8-bit PCM</source>
         <translation>8 位 PCM</translation>
     </message>
@@ -345,7 +345,7 @@
 <context>
     <name>Audio::AudioExporterPrivate</name>
     <message>
-        <location filename="../../Modules/Audio/AudioExporter.cpp" line="221"/>
+        <location filename="../../Modules/Audio/AudioExporter.cpp" line="238"/>
         <source>Untitled</source>
         <translation>未命名</translation>
     </message>
@@ -353,42 +353,42 @@
 <context>
     <name>Audio::Internal::AudioExportDialog</name>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="42"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="46"/>
         <source>Export Audio</source>
         <translation>导出音频</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="57"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="61"/>
         <source>&amp;Delete</source>
         <translation>删除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="59"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="63"/>
         <source>&amp;Preset</source>
         <translation>预设(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="69"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="73"/>
         <source>File Path</source>
         <translation>文件路径</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="55"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="59"/>
         <source>Save &amp;As...</source>
         <translation>另存为(&amp;A)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="71"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="75"/>
         <source>&amp;Browse...</source>
         <translation>浏览(&amp;B)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="78"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="82"/>
         <source>Template</source>
         <translation>模板</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="111"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="115"/>
         <source>&lt;p&gt;You can specify the name (including extension name) of exported files.&lt;/p&gt;&lt;p&gt;Template tags in the file name will be replaced with the corresponding text. The following are the available template tags:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;b&gt;${projectName}&lt;/b&gt;: the base name of the project file (excluding extension name)&lt;/li&gt;&lt;li&gt;&lt;b&gt;${sampleRate}&lt;/b&gt;: the sample rate specified in export configuration&lt;/li&gt;&lt;li&gt;&lt;b&gt;${today}&lt;/b&gt;: today&apos;s date in &quot;yyyyMMdd&quot; format (e. g. &quot;19260817&quot; for August 17, 1926)&lt;/li&gt;&lt;li&gt;&lt;b&gt;${$}&lt;/b&gt;: a single &quot;$&quot; character&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;In particular, the following template tags are available only when the mixing option is not &quot;mixed&quot;:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;b&gt;${trackName}&lt;/b&gt;: the name of track&lt;/li&gt;&lt;li&gt;&lt;b&gt;${trackIndex}&lt;/b&gt;: the index of track (starting from 1)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;You can select the template tag in the pop-up menu. The selected template tag will be appended to the end of the file name.&lt;/p&gt;</source>
         <translation>您可以指定导出文件的名称（包括扩展名）。文件名中的模板标签将被替换为相应的文本。以下是可用的模板标签：
 • ${projectName}：工程文件的基本名称（不含扩展名）
@@ -401,315 +401,323 @@
 您可以在弹出菜单中选择模板标签。选中的模板标签将追加到文件名的末尾。</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="133"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="137"/>
         <source>&amp;Name</source>
         <translation>名称(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="139"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="143"/>
         <source>(Project directory)</source>
         <translation>（项目目录）</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="140"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="144"/>
         <source>Dire&amp;ctory</source>
         <translation>目录(&amp;c)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="142"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="146"/>
         <source>WAV</source>
         <translation>WAV</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="142"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="146"/>
         <source>FLAC</source>
         <translation>FLAC</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="142"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="146"/>
         <source>Ogg Vorbis</source>
         <translation>Ogg Vorbis</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="142"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="146"/>
         <source>MP3</source>
         <translation>MP3</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="143"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="147"/>
         <source>&amp;Type</source>
         <translation>类型(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="147"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="151"/>
         <source>Format</source>
         <translation>格式</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="151"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="155"/>
         <source>Mono</source>
         <translation>单声道</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="151"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="155"/>
         <source>Stereo</source>
         <translation>立体声</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="152"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="156"/>
         <source>C&amp;hannel</source>
         <translation>声道(&amp;h)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="154"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="158"/>
         <source>&amp;Option</source>
         <translation>选项(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="165"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="169"/>
         <source>&amp;Quality</source>
         <translation>质量(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="180"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="184"/>
         <source>&amp;Sample rate</source>
         <translation>采样率(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="184"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="188"/>
         <source>Mixer</source>
         <translation>混音器</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="188"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="192"/>
         <source>Mixed</source>
         <translation>混合</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="189"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="193"/>
         <source>Separated</source>
         <translation>分离</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="190"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="194"/>
         <source>Separated (through master track)</source>
         <translation>分离（通过主轨）</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="196"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="200"/>
         <source>&amp;Mixing option</source>
         <translation>混音选项(&amp;M)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="197"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="201"/>
         <source>Enable m&amp;ute/solo</source>
         <translation>启用静音/独奏(&amp;u)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="202"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="206"/>
         <source>All tracks</source>
         <translation>所有轨道</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="203"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="207"/>
         <source>Selected tracks</source>
         <translation>选中轨道</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="204"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="208"/>
         <source>Custom</source>
         <translation>自定义</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="207"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="211"/>
         <source>&amp;Source</source>
         <translation>源(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="235"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="239"/>
         <source>Time Range</source>
         <translation>时间范围</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="238"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="242"/>
         <source>A&amp;ll</source>
         <translation>全部(&amp;l)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="241"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="245"/>
         <source>Loop s&amp;ection</source>
         <translation>循环选区(&amp;e)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="254"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="258"/>
         <source>&amp;Keep this dialog open after successful export</source>
         <translation>导出成功后保持此对话框打开(&amp;K)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="258"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="262"/>
         <source>Dry &amp;Run</source>
         <translation>预演(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="262"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="266"/>
         <source>&quot;Dry Run&quot; shows the paths of files to export. No files will actually be exported.</source>
         <translation>「预演」显示将要导出的文件路径。实际上不会导出任何文件。</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="268"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="272"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="270"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="274"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="273"/>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="663"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="389"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="393"/>
         <source>Preset name</source>
         <translation>预设名称</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="395"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="399"/>
         <source>Preset &quot;%1&quot; already exists. Overwrite it?</source>
         <translation>预设「%1」已存在。是否覆盖？</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="465"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="470"/>
         <source>WAV (*.wav)</source>
         <translation>WAV (*.wav)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="466"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="471"/>
         <source>FLAC (*.flac)</source>
         <translation>FLAC (*.flac)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="467"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="472"/>
         <source>Ogg Vorbis (*.ogg)</source>
         <translation>Ogg Vorbis (*.ogg)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="468"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="473"/>
         <source>MP3 (*.mp3)</source>
         <translation>MP3 (*.mp3)</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="497"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="502"/>
         <source>File List</source>
         <translation>文件列表</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="526"/>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="713"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="531"/>
         <source>Warnings</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="542"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="547"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="548"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="553"/>
         <source>Dry Run</source>
         <translation>预演</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="644"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="632"/>
+        <source>Export canceled</source>
+        <translation>已取消导出</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="749"/>
+        <source>Continue to export?</source>
+        <translation>继续导出？</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="754"/>
+        <source>Don&apos;t ask again</source>
+        <translation>不再询问</translation>
+    </message>
+</context>
+<context>
+    <name>Audio::Internal::AudioExportProgressDialog</name>
+    <message>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="26"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="27"/>
+        <source>Export Audio</source>
+        <translation>导出音频</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="36"/>
         <source>Preparing...</source>
         <translation>准备中...</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="655"/>
-        <source>&amp;Keep partial files</source>
-        <translation>保留部分文件(&amp;K)</translation>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="61"/>
+        <source>Open Folder</source>
+        <translation>打开目录</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="677"/>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="688"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="64"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="67"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="85"/>
         <source>Exporting...</source>
-        <translation>导出中...</translation>
+        <translation>正在导出...</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="702"/>
-        <source>Inferring...</source>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="102"/>
+        <source>Running inference...</source>
         <translation>正在推理...</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="718"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="108"/>
         <source>Clipping is detected</source>
         <translation>检测到削波</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="720"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="110"/>
         <source>Clipping is detected in track %L1 &quot;%2&quot;</source>
         <translation>轨道 %L1“%2”中检测到削波</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="728"/>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="741"/>
-        <source>%Ln warning(s)</source>
-        <translation>
-            <numerusform>%Ln 个警告</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="793"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="132"/>
         <source>Export finished with %Ln warning(s)</source>
         <translation>
             <numerusform>导出完成，但有 %Ln 个警告</numerusform>
         </translation>
     </message>
-    <message numerus="yes">
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="798"/>
-        <source>Export aborted with %Ln warning(s)</source>
-        <translation>
-            <numerusform>导出已中止，有 %Ln 个警告</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="804"/>
-        <source>Export failed with %Ln warning(s)
-%1</source>
-        <translation>
-            <numerusform>导出失败，有 %Ln 个警告
-%1</numerusform>
-        </translation>
+    <message>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="135"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="137"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="138"/>
+        <source>Export finished</source>
+        <translation>导出完成</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="789"/>
-        <source>Close</source>
-        <translation>关闭</translation>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="144"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="146"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="147"/>
+        <source>Export failed</source>
+        <translation>导出失败</translation>
     </message>
     <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="818"/>
-        <source>Export aborted</source>
-        <translation>导出已中止</translation>
-    </message>
-    <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="824"/>
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="145"/>
         <source>Export failed
 %1</source>
         <translation>导出失败
 %1</translation>
     </message>
-    <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="859"/>
-        <source>Continue to export?</source>
-        <translation>继续导出？</translation>
-    </message>
-    <message>
-        <location filename="../../UI/Dialogs/Audio/AudioExportDialog.cpp" line="864"/>
-        <source>Don&apos;t ask again</source>
-        <translation>不再询问</translation>
+    <message numerus="yes">
+        <location filename="../../UI/Dialogs/Audio/AudioExportProgressDialog.cpp" line="186"/>
+        <source>%Ln warning(s)</source>
+        <translation>
+            <numerusform>%Ln 个警告</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3342,76 +3350,76 @@ Regex values are merged with | for FullMatch. Array values are exact match.</sou
         <translation>另存为 MIDI 文件</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="268"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="591"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="871"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="269"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="592"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="872"/>
         <source>&amp;Undo</source>
         <translation>撤销(&amp;U)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="270"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="599"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="872"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="271"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="600"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="873"/>
         <source>&amp;Redo</source>
         <translation>重做(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="529"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="858"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="530"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="859"/>
         <source>&amp;New</source>
         <translation>新建(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="535"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="859"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="536"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="860"/>
         <source>&amp;Open...</source>
         <translation>打开(&amp;O)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="546"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="861"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="547"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="862"/>
         <source>&amp;Save</source>
         <translation>保存(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="618"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="874"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="619"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="875"/>
         <source>&amp;Delete</source>
         <translation>删除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="625"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="875"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="626"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="876"/>
         <source>Cu&amp;t</source>
         <translation>剪切(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="631"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="876"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="632"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="877"/>
         <source>&amp;Copy</source>
         <translation>复制(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="637"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="877"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="638"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="878"/>
         <source>&amp;Paste</source>
         <translation>粘贴(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="643"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="878"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="644"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="879"/>
         <source>Move an octave up</source>
         <translation>上移八度</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="648"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="879"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="649"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="880"/>
         <source>Move an octave down</source>
         <translation>下移八度</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="551"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="862"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="552"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="863"/>
         <source>Save &amp;as...</source>
         <translation>另存为(&amp;A)...</translation>
     </message>
@@ -3451,187 +3459,187 @@ Regex values are merged with | for FullMatch. Array values are exact match.</sou
         <translation>歌声工程文件 (%1)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="319"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="320"/>
         <source>Please select a singing clip first</source>
         <translation>请先选择一个歌声剪辑</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="332"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="333"/>
         <source>Please add an audio file first</source>
         <translation>请先添加一个音频文件</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="541"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="860"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="542"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="861"/>
         <source>Clear Recent Projects</source>
         <translation>清除最近工程</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="557"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="573"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="863"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="867"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="558"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="574"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="864"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="868"/>
         <source>MIDI file...</source>
         <translation>MIDI 文件...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="561"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="864"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="562"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="865"/>
         <source>DiffScope project file...</source>
         <translation>DiffScope 工程文件...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="565"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="865"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="566"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="866"/>
         <source>Project file (LibreSVIP)...</source>
         <translation>工程文件 (LibreSVIP)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="569"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="866"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="570"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="867"/>
         <source>Audio file...</source>
         <translation>音频文件...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="577"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="868"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="578"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="869"/>
         <source>Manage packages...</source>
         <translation>管理包...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="584"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="869"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="585"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="870"/>
         <source>E&amp;xit</source>
         <translation>退出(&amp;X)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="611"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="873"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="612"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="874"/>
         <source>Select &amp;all</source>
         <translation>全选(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="653"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="881"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="654"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="882"/>
         <source>Fill lyrics...</source>
         <translation>填入歌词...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="661"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="882"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="662"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="883"/>
         <source>Search lyrics...</source>
         <translation>搜索歌词...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="668"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="883"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="669"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="884"/>
         <source>Extract pitch parameter...</source>
         <translation>提取音高参数...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="671"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="880"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="672"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="881"/>
         <source>Quantize...</source>
         <translation>量化...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="707"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="895"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="708"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="896"/>
         <source>&amp;File</source>
         <translation>文件(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="711"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="896"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="712"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="897"/>
         <source>Recent Projects</source>
         <translation>最近工程</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="725"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="897"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="726"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="898"/>
         <source>Import</source>
         <translation>导入</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="733"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="898"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="734"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="899"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="751"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="899"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="752"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="900"/>
         <source>&amp;Edit</source>
         <translation>编辑(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="788"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="885"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="789"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="886"/>
         <source>&amp;General...</source>
         <translation>常规(&amp;G)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="792"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="886"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="793"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="887"/>
         <source>&amp;Audio...</source>
         <translation>音频(&amp;A)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="796"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="887"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="797"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="888"/>
         <source>&amp;MIDI...</source>
         <translation>&amp;MIDI...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="800"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="888"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="801"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="889"/>
         <source>A&amp;ppearance...</source>
         <translation>外观(&amp;P)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="809"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="889"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="810"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="890"/>
         <source>&amp;Inference...</source>
         <translation>推理(&amp;I)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="813"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="890"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="814"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="891"/>
         <source>&amp;Developer Options...</source>
         <translation>开发者选项(&amp;D)...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="818"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="900"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="819"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="901"/>
         <source>&amp;Options</source>
         <translation>选项(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="832"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="891"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="833"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="892"/>
         <source>Check for updates</source>
         <translation>检查更新</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="835"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="836"/>
         <source>You are already up to date</source>
         <translation>已是最新版本</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="836"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="892"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="837"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="893"/>
         <source>About...</source>
         <translation>关于...</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="848"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="901"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="849"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="902"/>
         <source>&amp;Help</source>
         <translation>帮助(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="843"/>
-        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="893"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="844"/>
+        <location filename="../../UI/Views/MainTitleBar/MainMenuView.cpp" line="894"/>
         <source>Open Log Folder...</source>
         <translation>打开日志目录...</translation>
     </message>

--- a/src/app/UI/Dialogs/Audio/AudioExportDialog.cpp
+++ b/src/app/UI/Dialogs/Audio/AudioExportDialog.cpp
@@ -1,11 +1,11 @@
 #include "AudioExportDialog.h"
+#include "AudioExportProgressDialog.h"
 #include "AppContext.h"
 #include "Automation/CoreRuntime.h"
 #include <lite/ProjectModel/AppModel/AppModel.h>
 #include <lite/ProjectModel/AppModel/Track.h>
 #include "Modules/Audio/AudioSettings.h"
 
-#include <QApplication>
 #include <limits>
 
 #include <QBoxLayout>
@@ -23,12 +23,15 @@
 #include <QLabel>
 #include <QMessageBox>
 #include <QInputDialog>
-#include <QProgressBar>
+#include <QState>
+#include <QStateMachine>
 #include <QTimer>
 
 #include <lite/GUI/Controls/SvsExpressionSpinBox.h>
 #include <lite/GUI/Controls/ComboBox.h>
 #include <lite/GUI/Controls/SmoothScroller.h>
+#include <lite/GUI/Controls/Toast.h>
+#include <lite/Support/ShellUtils.h>
 
 #include <Modules/Audio/AudioExporter_p.h>
 
@@ -38,7 +41,8 @@ namespace Audio::Internal {
     static bool m_hasTemporaryPreset = false;
 
     AudioExportDialog::AudioExportDialog(Core::IProjectWindow *windowHandle, QWidget *parent)
-        : Dialog(parent), m_audioExporter(new AudioExporter(windowHandle, this)) {
+        : Dialog(parent), m_audioExporter(new AudioExporter(windowHandle, this)),
+          m_stateMachine(nullptr) {
         setWindowTitle(tr("Export Audio"));
         auto mainLayout = new QVBoxLayout(body());
 
@@ -446,6 +450,7 @@ namespace Audio::Internal {
 
         connect(exportButton, &QAbstractButton::clicked, this, &AudioExportDialog::runExport);
         connect(cancelButton, &QAbstractButton::clicked, this, &Dialog::reject);
+        initializeStateMachine();
     }
 
     AudioExportDialog::~AudioExportDialog() {
@@ -609,6 +614,37 @@ namespace Audio::Internal {
         updateConfig();
     }
 
+    void AudioExportDialog::initializeStateMachine() {
+        m_stateMachine = new QStateMachine(this);
+        const auto configuringState = new QState(m_stateMachine);
+        const auto runningState = new QState(m_stateMachine);
+        const auto canceledState = new QState(m_stateMachine);
+
+        m_stateMachine->setInitialState(configuringState);
+        configuringState->addTransition(this, &AudioExportDialog::exportStarted, runningState);
+        runningState->addTransition(this, &AudioExportDialog::exportFinished, configuringState);
+        runningState->addTransition(this, &AudioExportDialog::exportFailed, configuringState);
+        runningState->addTransition(this, &AudioExportDialog::exportCanceled, canceledState);
+        canceledState->addTransition(this, &AudioExportDialog::exportDismissed, configuringState);
+
+        connect(runningState, &QState::entered, this, &QWidget::hide);
+        connect(canceledState, &QState::entered, this, [this] {
+            Toast::show(tr("Export canceled"));
+            m_exportOutcome = ExportOutcome::None;
+            showConfiguration();
+            emit exportDismissed();
+        });
+        m_stateMachine->start();
+    }
+
+    void AudioExportDialog::showConfiguration() {
+        updateView();
+        setWindowModality(Qt::WindowModal);
+        open();
+        raise();
+        activateWindow();
+    }
+
     void AudioExportDialog::runExport() {
         const auto warning = m_audioExporter->warning();
         if (warning & AudioExporter::W_LossyFormat) {
@@ -632,207 +668,66 @@ namespace Audio::Internal {
                 return;
         }
 
-        QDialog progressDialog(this);
-        const auto layout = new QVBoxLayout;
-        layout->setSizeConstraint(QLayout::SetMinAndMaxSize);
+        m_exportedFiles = m_audioExporter->dryRun();
+        m_exportOutcome = ExportOutcome::None;
+        const auto progressDialog =
+            new AudioExportProgressDialog(m_audioExporter, Dialog::globalParent());
+        progressDialog->setAttribute(Qt::WA_DeleteOnClose);
+        m_progressDialog = progressDialog;
 
-        const auto mainPromptLayout = new QHBoxLayout;
-        const auto iconLabel = new QLabel;
-        iconLabel->setPixmap(style()->standardIcon(QStyle::SP_MessageBoxCritical).pixmap(24, 24));
-        iconLabel->setVisible(false);
-        mainPromptLayout->addWidget(iconLabel);
-        const auto mainPromptLabel = new QLabel(tr("Preparing..."));
-        mainPromptLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
-        mainPromptLayout->addWidget(mainPromptLabel, 1);
-        layout->addLayout(mainPromptLayout);
+        connect(progressDialog, &AudioExportProgressDialog::cancelRequested, this,
+                [this] { m_audioExporter->cancel(); });
+        connect(progressDialog, &AudioExportProgressDialog::openFolderRequested, this,
+                [](const QStringList &files) { ShellUtils::revealFiles(files); });
+        connect(progressDialog, &AudioExportProgressDialog::dismissed, this,
+                &AudioExportDialog::handleProgressDismissed);
 
-        const auto mainProgressBar = new QProgressBar;
-        mainProgressBar->setRange(0, 100);
-        mainProgressBar->setValue(0);
-        layout->addWidget(mainProgressBar);
-
-        const auto buttonLayout = new QHBoxLayout;
-        const auto keepPartialFileCheckBox = new QCheckBox(tr("&Keep partial files"));
-        keepPartialFileCheckBox->setVisible(false);
-        buttonLayout->addWidget(keepPartialFileCheckBox);
-        buttonLayout->addStretch();
-        const auto mainPromptWarningButton = new QPushButton;
-        mainPromptWarningButton->setVisible(false);
-        mainPromptWarningButton->setIcon(style()->standardIcon(QStyle::SP_MessageBoxWarning));
-        buttonLayout->addWidget(mainPromptWarningButton, 0);
-        const auto abortButton = new QPushButton(tr("Cancel"));
-        buttonLayout->addWidget(abortButton);
-        layout->addLayout(buttonLayout);
-
-        progressDialog.setLayout(layout);
-        progressDialog.resize(400, progressDialog.height());
-
-        bool isProgressing = false;
-        QHash<int, double> progressRatioHash;
-        if (m_audioExporter->config().mixingOption() == AudioExporterConfig::MO_Mixed) {
-            connect(m_audioExporter, &AudioExporter::progressChanged, &progressDialog,
-                    [=, &isProgressing](const double ratio) {
-                        if (!isProgressing) {
-                            isProgressing = true;
-                            mainPromptLabel->setText(tr("Exporting..."));
-                        }
-                        mainProgressBar->setValue(static_cast<int>(ratio * 100.0));
-                    });
-        } else {
-            const int sourceCount = m_audioExporter->config().source().size();
-            connect(
-                m_audioExporter, &AudioExporter::progressChanged, &progressDialog,
-                [=, &progressRatioHash, &isProgressing](const double ratio, const int sourceIndex) {
-                    if (!isProgressing) {
-                        isProgressing = true;
-                        mainPromptLabel->setText(tr("Exporting..."));
-                    }
-                    progressRatioHash[sourceIndex] = ratio;
-                    double totalRatio = 0;
-                    for (const auto value : progressRatioHash.values()) {
-                        totalRatio += value;
-                    }
-                    mainProgressBar->setValue(static_cast<int>(totalRatio / sourceCount * 100.0));
-                });
-        }
-        connect(m_audioExporter, &AudioExporter::inferenceProgressChanged, &progressDialog,
-                [=, &isProgressing](const double ratio) {
-                    if (isProgressing)
-                        return; // real export progress has priority once it starts
-                    mainPromptLabel->setText(tr("Inferring..."));
-                    mainProgressBar->setValue(static_cast<int>(ratio * 100.0));
-                });
-
-        QDialog warningListDialog(this);
-        const auto warningListDialogLayout = new QVBoxLayout;
-        const auto warningList = new QListWidget;
-        warningList->setSelectionMode(QAbstractItemView::NoSelection);
-        warningListDialogLayout->addWidget(warningList);
-        warningListDialog.setLayout(warningListDialogLayout);
-        warningListDialog.resize(300, 300);
-        warningListDialog.setWindowTitle(tr("Warnings"));
-        connect(m_audioExporter, &AudioExporter::clippingDetected, &progressDialog,
-                [warningList, mainPromptWarningButton, this](const int sourceIndex) {
-                    const auto item = new QListWidgetItem;
-                    if (sourceIndex == -1) {
-                        item->setText(tr("Clipping is detected"));
-                    } else {
-                        item->setText(tr("Clipping is detected in track %L1 \"%2\"")
-                                          .arg(sourceIndex + 1)
-                                          .arg(m_audioExporter->d_func()->trackName(sourceIndex)));
-                    }
-                    item->setIcon(style()->standardIcon(QStyle::SP_MessageBoxWarning));
-                    warningList->addItem(item);
-                    mainPromptWarningButton->setVisible(true);
-                    mainPromptWarningButton->setToolTip(
-                        tr("%Ln warning(s)", nullptr, warningList->count()));
-                    QApplication::beep();
-                });
-        connect(m_audioExporter, &AudioExporter::warningAdded, &progressDialog,
-                [warningList, mainPromptWarningButton, this](const QString &message,
-                                                             const int sourceIndex) {
-                    Q_UNUSED(sourceIndex); // may be used in future
-                    const auto item = new QListWidgetItem;
-                    item->setText(message);
-                    item->setIcon(style()->standardIcon(QStyle::SP_MessageBoxWarning));
-                    warningList->addItem(item);
-                    mainPromptWarningButton->setVisible(true);
-                    mainPromptWarningButton->setToolTip(
-                        tr("%Ln warning(s)", nullptr, warningList->count()));
-                    QApplication::beep();
-                });
-
-        connect(mainPromptWarningButton, &QAbstractButton::clicked, &progressDialog,
-                [&warningListDialog] { warningListDialog.exec(); });
-
-        bool interruptFlag = true;
-        connect(abortButton, &QAbstractButton::clicked, &progressDialog,
-                [&interruptFlag, &progressDialog, this] {
-                    if (interruptFlag) {
-                        m_audioExporter->cancel();
-                    } else {
-                        progressDialog.reject();
-                    }
-                });
-
-        class CloseEventFilter : public QObject {
-        public:
-            CloseEventFilter(QDialog *progressDialog, std::function<bool()> &&cb) : cb(cb) {
-                progressDialog->installEventFilter(this);
-            }
-
-            std::function<bool()> cb;
-
-            bool eventFilter(QObject *watched, QEvent *event) override {
-                if (event->type() == QEvent::Close) {
-                    if (cb())
-                        event->accept();
-                    else
-                        event->ignore();
-                    return true;
-                }
-                return QObject::eventFilter(watched, event);
-            }
-        } o(&progressDialog, [&interruptFlag, this] {
-            if (interruptFlag) {
-                m_audioExporter->cancel();
-                return false;
-            }
-            return true;
-        });
-
-        QTimer::singleShot(0, [abortButton, warningList, mainPromptLabel, iconLabel,
-                               keepPartialFileCheckBox, &interruptFlag, &progressDialog, this] {
+        emit exportStarted();
+        progressDialog->show();
+        QTimer::singleShot(0, progressDialog, [this, progressDialog] {
             QCoreApplication::processEvents();
             const auto ret = m_audioExporter->exec();
-            interruptFlag = false;
-            abortButton->setText(tr("Close"));
-            if (warningList->count()) {
-                switch (ret) {
-                    case AudioExporter::R_Ok:
-                        mainPromptLabel->setText(tr("Export finished with %Ln warning(s)", nullptr,
-                                                    warningList->count()));
-                        QApplication::beep();
-                        break;
-                    case AudioExporter::R_Abort:
-                        mainPromptLabel->setText(tr("Export aborted with %Ln warning(s)", nullptr,
-                                                    warningList->count()));
-                        QApplication::beep();
-                        keepPartialFileCheckBox->setVisible(true);
-                        break;
-                    case AudioExporter::R_Fail:
-                        mainPromptLabel->setText(tr("Export failed with %Ln warning(s)\n%1",
-                                                    nullptr, warningList->count())
-                                                     .arg(m_audioExporter->errorString()));
-                        iconLabel->setVisible(true);
-                        QApplication::beep();
-                        keepPartialFileCheckBox->setVisible(true);
-                        break;
-                }
-            } else {
-                switch (ret) {
-                    case AudioExporter::R_Ok:
-                        progressDialog.accept();
-                        break;
-                    case AudioExporter::R_Abort:
-                        mainPromptLabel->setText(tr("Export aborted"));
-                        QApplication::beep();
-                        keepPartialFileCheckBox->setVisible(true);
-                        break;
-                    case AudioExporter::R_Fail:
-                        mainPromptLabel->setText(
-                            tr("Export failed\n%1").arg(m_audioExporter->errorString()));
-                        iconLabel->setVisible(true);
-                        QApplication::beep();
-                        keepPartialFileCheckBox->setVisible(true);
-                        break;
-                }
+            m_audioExporter->cleanUp();
+            saveExporterSettings();
+            saveTemporaryPreset();
+
+            if (!m_progressDialog || m_progressDialog != progressDialog)
+                return;
+
+            switch (ret) {
+                case AudioExporter::R_Ok:
+                    m_exportOutcome = ExportOutcome::Succeeded;
+                    progressDialog->showSuccess(m_exportedFiles);
+                    emit exportFinished();
+                    break;
+                case AudioExporter::R_Abort:
+                    m_progressDialog = nullptr;
+                    progressDialog->dismissAfterCancellation();
+                    emit exportCanceled();
+                    break;
+                case AudioExporter::R_Fail:
+                    m_exportOutcome = ExportOutcome::Failed;
+                    progressDialog->showFailure(m_audioExporter->errorString());
+                    emit exportFailed();
+                    break;
             }
         });
-        const auto ret = progressDialog.exec();
-        if (!keepPartialFileCheckBox->isChecked()) {
-            m_audioExporter->cleanUp();
+    }
+
+    void AudioExportDialog::handleProgressDismissed() {
+        const auto outcome = m_exportOutcome;
+        m_exportOutcome = ExportOutcome::None;
+        m_progressDialog = nullptr;
+        emit exportDismissed();
+
+        if (outcome == ExportOutcome::Succeeded && !m_keepOpenCheckBox->isChecked()) {
+            accept();
+        } else {
+            showConfiguration();
         }
+    }
+
+    void AudioExportDialog::saveExporterSettings() const {
         const auto currentData = m_presetComboBox->currentData();
         if (auto *runtime = AppContext::instance<Automation::CoreRuntime>()) {
             const auto snapshot = runtime->settings().getSettings();
@@ -844,11 +739,6 @@ namespace Audio::Internal {
                 runtime->settings().updateAudio({}, settings);
             }
         }
-        saveTemporaryPreset();
-        if (ret == QDialog::Accepted && !m_keepOpenCheckBox->isChecked())
-            accept();
-        else
-            updateView();
     }
 
     bool AudioExportDialog::askWarningBeforeExport(const AudioExporter::Warning warning,

--- a/src/app/UI/Dialogs/Audio/AudioExportDialog.h
+++ b/src/app/UI/Dialogs/Audio/AudioExportDialog.h
@@ -5,6 +5,8 @@
 
 #include "UI/Dialogs/Base/Dialog.h"
 
+#include <QPointer>
+
 namespace Audio {
     class AudioExporter;
 }
@@ -23,8 +25,11 @@ class QDoubleSpinBox;
 class QListWidget;
 class QCheckBox;
 class QRadioButton;
+class QStateMachine;
 
 namespace Audio::Internal {
+
+    class AudioExportProgressDialog;
 
     class AudioExportDialog : public Dialog {
         Q_OBJECT
@@ -35,7 +40,16 @@ namespace Audio::Internal {
         explicit AudioExportDialog(Core::IProjectWindow *windowHandle, QWidget *parent = nullptr);
         ~AudioExportDialog() override;
 
+    signals:
+        void exportStarted();
+        void exportCanceled();
+        void exportFinished();
+        void exportFailed();
+        void exportDismissed();
+
     private:
+        enum class ExportOutcome { None, Succeeded, Failed };
+
         QComboBox *m_presetComboBox;
         QPushButton *m_presetDeleteButton;
         QLineEdit *m_fileDirectoryEdit;
@@ -59,6 +73,10 @@ namespace Audio::Internal {
         QString m_warningText;
 
         AudioExporter *m_audioExporter;
+        QStateMachine *m_stateMachine;
+        QPointer<AudioExportProgressDialog> m_progressDialog;
+        QStringList m_exportedFiles;
+        ExportOutcome m_exportOutcome = ExportOutcome::None;
 
         static QStringList projectTrackList();
 
@@ -67,10 +85,14 @@ namespace Audio::Internal {
         void showDryRunResult();
         void updateConfig() const;
         void updateView();
+        void initializeStateMachine();
+        void showConfiguration();
 
         bool skipUpdateFlag = false;
 
         void runExport();
+        void handleProgressDismissed();
+        void saveExporterSettings() const;
 
         bool askWarningBeforeExport(AudioExporter::Warning warning, bool canIgnored = false);
 

--- a/src/app/UI/Dialogs/Audio/AudioExportProgressDialog.cpp
+++ b/src/app/UI/Dialogs/Audio/AudioExportProgressDialog.cpp
@@ -1,0 +1,230 @@
+#include "AudioExportProgressDialog.h"
+
+#include "Modules/Audio/AudioExporter.h"
+#include "Modules/Audio/AudioExporter_p.h"
+
+#include <lite/GUI/Controls/AccentButton.h>
+#include <lite/GUI/Controls/Button.h>
+#include <lite/GUI/Controls/ProgressIndicator.h>
+#include <lite/GUI/Controls/ToolButton.h>
+
+#include <QApplication>
+#include <QCloseEvent>
+#include <QHBoxLayout>
+#include <QIcon>
+#include <QLabel>
+#include <QListWidget>
+#include <QStyle>
+#include <QVBoxLayout>
+
+#include <utility>
+
+namespace Audio::Internal {
+
+    AudioExportProgressDialog::AudioExportProgressDialog(AudioExporter *exporter, QWidget *parent)
+        : Dialog(parent), m_sourceCount(qMax(1, exporter->config().source().size())) {
+        setWindowTitle(tr("Export Audio"));
+        setTitle(tr("Export Audio"));
+        setMinimumWidth(420);
+        setWindowModality(Qt::ApplicationModal);
+
+        const auto mainLayout = new QVBoxLayout(body());
+        mainLayout->setContentsMargins({});
+        mainLayout->setSpacing(12);
+
+        const auto phaseLayout = new QHBoxLayout;
+        m_phaseLabel = new QLabel(tr("Preparing..."), this);
+        m_phaseLabel->setWordWrap(true);
+        phaseLayout->addWidget(m_phaseLabel, 1);
+
+        m_warningButton = new ToolButton(this);
+        m_warningButton->setIcon(style()->standardIcon(QStyle::SP_MessageBoxWarning));
+        m_warningButton->setCheckable(true);
+        m_warningButton->setVisible(false);
+        phaseLayout->addWidget(m_warningButton);
+        mainLayout->addLayout(phaseLayout);
+
+        m_progressIndicator = new ProgressIndicator(ProgressIndicator::HorizontalBar, this);
+        m_progressIndicator->setRange(0, 100);
+        m_progressIndicator->setValue(0);
+        mainLayout->addWidget(m_progressIndicator);
+
+        m_warningList = new QListWidget(this);
+        m_warningList->setSelectionMode(QAbstractItemView::NoSelection);
+        m_warningList->setWordWrap(true);
+        m_warningList->setVisible(false);
+        m_warningList->setMinimumHeight(120);
+        mainLayout->addWidget(m_warningList);
+
+        m_openFolderButton =
+            new AccentButton(QIcon(QStringLiteral(":/svg/icons/folder_open_16_regular.svg")),
+                             tr("Open Folder"), this);
+        m_openFolderButton->setVisible(false);
+        m_openFolderButton->setEnabled(false);
+        m_closeButton = new Button(tr("Close"), this);
+        m_closeButton->setVisible(false);
+        m_closeButton->setEnabled(false);
+        m_cancelButton = new Button(tr("Cancel"), this);
+        m_cancelButton->setDefault(true);
+        buttonBar()->addButton(m_openFolderButton);
+        buttonBar()->addButton(m_closeButton);
+        buttonBar()->addButton(m_cancelButton);
+
+        connect(m_warningButton, &QAbstractButton::toggled, m_warningList, &QWidget::setVisible);
+        connect(m_cancelButton, &QAbstractButton::clicked, this,
+                &AudioExportProgressDialog::requestCancel);
+        connect(m_closeButton, &QAbstractButton::clicked, this,
+                &AudioExportProgressDialog::dismissTerminal);
+        connect(m_openFolderButton, &QAbstractButton::clicked, this,
+                [this] { emit openFolderRequested(m_exportedFiles); });
+
+        connect(exporter, &AudioExporter::progressChanged, this,
+                [this, exporter](const double ratio, const int sourceIndex) {
+                    if (!m_isProgressing) {
+                        m_isProgressing = true;
+                        m_phaseLabel->setText(tr("Exporting..."));
+                    }
+                    if (exporter->config().mixingOption() == AudioExporterConfig::MO_Mixed ||
+                        sourceIndex < 0) {
+                        m_progressIndicator->setValue(ratio * 100.0);
+                        return;
+                    }
+                    m_sourceProgress[sourceIndex] = ratio;
+                    double totalRatio = 0;
+                    for (const auto value : std::as_const(m_sourceProgress))
+                        totalRatio += value;
+                    m_progressIndicator->setValue(totalRatio / m_sourceCount * 100.0);
+                });
+        connect(exporter, &AudioExporter::inferenceProgressChanged, this,
+                [this](const double ratio) {
+                    if (m_isProgressing)
+                        return;
+                    m_phaseLabel->setText(tr("Running inference..."));
+                    m_progressIndicator->setValue(ratio * 100.0);
+                });
+        connect(exporter, &AudioExporter::clippingDetected, this,
+                [this, exporter](const int sourceIndex) {
+                    if (sourceIndex < 0) {
+                        appendWarning(tr("Clipping is detected"));
+                    } else {
+                        appendWarning(tr("Clipping is detected in track %L1 \"%2\"")
+                                          .arg(sourceIndex + 1)
+                                          .arg(exporter->d_func()->trackName(sourceIndex)));
+                    }
+                });
+        connect(exporter, &AudioExporter::warningAdded, this,
+                [this](const QString &message, const int sourceIndex) {
+                    Q_UNUSED(sourceIndex);
+                    appendWarning(message);
+                });
+    }
+
+    bool AudioExportProgressDialog::isTerminal() const {
+        return m_uiState == UiState::Succeeded || m_uiState == UiState::Failed;
+    }
+
+    void AudioExportProgressDialog::showSuccess(const QStringList &files) {
+        m_exportedFiles = files;
+        m_progressIndicator->setValue(100);
+        if (m_warningList->count()) {
+            m_progressIndicator->setTaskStatus(TaskGlobal::Warning);
+            m_phaseLabel->setText(
+                tr("Export finished with %Ln warning(s)", nullptr, m_warningList->count()));
+            QApplication::beep();
+        } else {
+            m_phaseLabel->setText(tr("Export finished"));
+        }
+        setWindowTitle(tr("Export finished"));
+        setTitle(tr("Export finished"));
+        enterTerminalState(UiState::Succeeded);
+    }
+
+    void AudioExportProgressDialog::showFailure(const QString &errorString) {
+        m_progressIndicator->setTaskStatus(TaskGlobal::Error);
+        m_phaseLabel->setText(errorString.isEmpty() ? tr("Export failed")
+                                                    : tr("Export failed\n%1").arg(errorString));
+        setWindowTitle(tr("Export failed"));
+        setTitle(tr("Export failed"));
+        QApplication::beep();
+        enterTerminalState(UiState::Failed);
+    }
+
+    void AudioExportProgressDialog::dismissAfterCancellation() {
+        m_uiState = UiState::Dismissed;
+        hide();
+        deleteLater();
+    }
+
+    void AudioExportProgressDialog::reject() {
+        if (m_uiState == UiState::Running) {
+            requestCancel();
+            return;
+        }
+        if (isTerminal())
+            dismissTerminal();
+    }
+
+    void AudioExportProgressDialog::closeEvent(QCloseEvent *event) {
+        if (m_uiState == UiState::Running) {
+            requestCancel();
+            event->ignore();
+            return;
+        }
+        if (isTerminal()) {
+            event->ignore();
+            dismissTerminal();
+            return;
+        }
+        Dialog::closeEvent(event);
+    }
+
+    void AudioExportProgressDialog::appendWarning(const QString &message) {
+        const auto item =
+            new QListWidgetItem(style()->standardIcon(QStyle::SP_MessageBoxWarning), message);
+        m_warningList->addItem(item);
+        m_warningButton->setVisible(true);
+        m_warningButton->setToolTip(tr("%Ln warning(s)", nullptr, m_warningList->count()));
+        QApplication::beep();
+    }
+
+    void AudioExportProgressDialog::enterTerminalState(const UiState state) {
+        hide();
+        m_uiState = state;
+        setWindowModality(Qt::NonModal);
+        setModal(false);
+
+        m_cancelButton->setDefault(false);
+        m_cancelButton->setEnabled(false);
+        m_cancelButton->setVisible(false);
+        m_closeButton->setEnabled(true);
+        m_closeButton->setVisible(true);
+        m_openFolderButton->setVisible(state == UiState::Succeeded);
+        m_openFolderButton->setEnabled(state == UiState::Succeeded);
+        if (state == UiState::Succeeded) {
+            m_openFolderButton->setDefault(true);
+        } else {
+            m_closeButton->setDefault(true);
+        }
+
+        show();
+        raise();
+        activateWindow();
+    }
+
+    void AudioExportProgressDialog::requestCancel() {
+        if (m_uiState != UiState::Running || m_cancelPending)
+            return;
+        m_cancelPending = true;
+        m_cancelButton->setEnabled(false);
+        emit cancelRequested();
+    }
+
+    void AudioExportProgressDialog::dismissTerminal() {
+        if (!isTerminal())
+            return;
+        m_uiState = UiState::Dismissed;
+        emit dismissed();
+        done(QDialog::Accepted);
+    }
+
+}

--- a/src/app/UI/Dialogs/Audio/AudioExportProgressDialog.h
+++ b/src/app/UI/Dialogs/Audio/AudioExportProgressDialog.h
@@ -1,0 +1,70 @@
+#ifndef AUDIO_AUDIOEXPORTPROGRESSDIALOG_H
+#define AUDIO_AUDIOEXPORTPROGRESSDIALOG_H
+
+#include "UI/Dialogs/Base/Dialog.h"
+
+#include <QHash>
+#include <QStringList>
+
+class AccentButton;
+class Button;
+class QLabel;
+class QListWidget;
+class ProgressIndicator;
+class QCloseEvent;
+class ToolButton;
+
+namespace Audio {
+    class AudioExporter;
+}
+
+namespace Audio::Internal {
+
+    class AudioExportProgressDialog : public Dialog {
+        Q_OBJECT
+
+    public:
+        explicit AudioExportProgressDialog(AudioExporter *exporter, QWidget *parent = nullptr);
+
+        [[nodiscard]] bool isTerminal() const;
+        void showSuccess(const QStringList &files);
+        void showFailure(const QString &errorString);
+        void dismissAfterCancellation();
+
+    public slots:
+        void reject() override;
+
+    signals:
+        void cancelRequested();
+        void openFolderRequested(const QStringList &files);
+        void dismissed();
+
+    protected:
+        void closeEvent(QCloseEvent *event) override;
+
+    private:
+        enum class UiState { Running, Succeeded, Failed, Dismissed };
+
+        UiState m_uiState = UiState::Running;
+        QLabel *m_phaseLabel;
+        ToolButton *m_warningButton;
+        QListWidget *m_warningList;
+        ProgressIndicator *m_progressIndicator;
+        AccentButton *m_openFolderButton;
+        Button *m_closeButton;
+        Button *m_cancelButton;
+        QStringList m_exportedFiles;
+        QHash<int, double> m_sourceProgress;
+        int m_sourceCount;
+        bool m_isProgressing = false;
+        bool m_cancelPending = false;
+
+        void appendWarning(const QString &message);
+        void enterTerminalState(UiState state);
+        void requestCancel();
+        void dismissTerminal();
+    };
+
+}
+
+#endif // AUDIO_AUDIOEXPORTPROGRESSDIALOG_H

--- a/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
@@ -255,8 +255,9 @@ void MainMenuViewPrivate::onExportMidiFile() {
 
 void MainMenuViewPrivate::onExportAudioFile() {
     Q_Q(MainMenuView);
-    AudioExportDialog dlg(q);
-    dlg.exec();
+    const auto dialog = new AudioExportDialog(q);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->open();
 }
 
 void MainMenuViewPrivate::onUndoRedoChanged(bool canUndo, const QString &undoName, bool canRedo,

--- a/src/libs/Support/ShellUtils.cpp
+++ b/src/libs/Support/ShellUtils.cpp
@@ -1,17 +1,21 @@
 #include "ShellUtils.h"
 
+#ifdef Q_OS_WIN
 #include <QDir>
 #include <QFileInfo>
 #include <QHash>
 #include <QProcess>
+#include <QScopeGuard>
 
-#ifdef Q_OS_WIN
+#  include <objbase.h>
 #  include <shlobj_core.h>
 #  include <vector>
 
+#  pragma comment(lib, "ole32.lib")
 #  pragma comment(lib, "shell32.lib")
 #endif
 
+#ifdef Q_OS_WIN
 namespace {
     QHash<QString, QStringList> groupByDirectory(const QStringList &files) {
         QHash<QString, QStringList> result;
@@ -22,54 +26,67 @@ namespace {
         return result;
     }
 
-#ifdef Q_OS_WIN
     bool revealGroup(const QString &directory, const QStringList &files) {
-        const auto folderPidl = ILCreateFromPathW(reinterpret_cast<PCWSTR>(directory.utf16()));
+        const auto comResult = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+        if (FAILED(comResult) && comResult != RPC_E_CHANGED_MODE)
+            return false;
+        const auto comCleanup = qScopeGuard([comResult] {
+            if (SUCCEEDED(comResult))
+                CoUninitialize();
+        });
+
+        const auto nativeDirectory = QDir::toNativeSeparators(directory);
+        const auto folderPidl =
+            ILCreateFromPathW(reinterpret_cast<PCWSTR>(nativeDirectory.utf16()));
         if (!folderPidl)
             return false;
+        const auto folderCleanup = qScopeGuard([folderPidl] { ILFree(folderPidl); });
 
         std::vector<PIDLIST_ABSOLUTE> itemPidls;
+        itemPidls.reserve(files.size());
+        const auto itemCleanup = qScopeGuard([&itemPidls] {
+            for (const auto itemPidl : itemPidls)
+                ILFree(itemPidl);
+        });
+
         std::vector<PCUITEMID_CHILD> childPidls;
+        childPidls.reserve(files.size());
         for (const auto &file : files) {
-            const auto itemPidl = ILCreateFromPathW(reinterpret_cast<PCWSTR>(file.utf16()));
+            const auto nativeFile = QDir::toNativeSeparators(file);
+            const auto itemPidl =
+                ILCreateFromPathW(reinterpret_cast<PCWSTR>(nativeFile.utf16()));
             if (!itemPidl)
-                continue;
+                return false;
             itemPidls.push_back(itemPidl);
-            // Child PIDLs point into itemPidls and must not be freed separately.
             childPidls.push_back(ILFindLastID(itemPidl));
         }
 
-        const auto result =
-            childPidls.empty()
-                ? E_INVALIDARG
-                : SHOpenFolderAndSelectItems(folderPidl, static_cast<UINT>(childPidls.size()),
-                                             childPidls.data(), 0);
-
-        for (const auto itemPidl : itemPidls)
-            ILFree(itemPidl);
-        ILFree(folderPidl);
+        const auto result = childPidls.empty()
+                                ? E_INVALIDARG
+                                : SHOpenFolderAndSelectItems(folderPidl,
+                                                             static_cast<UINT>(childPidls.size()),
+                                                             childPidls.data(), 0);
         return SUCCEEDED(result);
     }
 
     void revealSingleFile(const QString &file) {
-        QProcess::startDetached(QStringLiteral("explorer.exe"),
-                                {QStringLiteral("/select,"), QDir::toNativeSeparators(file)});
+        QProcess::startDetached(
+            QStringLiteral("explorer.exe"),
+            {QStringLiteral("/select,%1").arg(QDir::toNativeSeparators(file))});
     }
-#endif
 }
+#endif
 
 namespace ShellUtils {
     void revealFiles(const QStringList &files) {
+#ifdef Q_OS_WIN
         const auto groups = groupByDirectory(files);
         for (auto it = groups.constBegin(); it != groups.constEnd(); ++it) {
-#ifdef Q_OS_WIN
             if (!revealGroup(it.key(), it.value()))
                 revealSingleFile(it.value().constFirst());
-#elif defined(Q_OS_MACOS)
-            QProcess::startDetached(QStringLiteral("open"), {it.key()});
-#else
-            QProcess::startDetached(QStringLiteral("xdg-open"), {it.key()});
-#endif
         }
+#else
+        Q_UNUSED(files);
+#endif
     }
 }

--- a/src/libs/Support/ShellUtils.cpp
+++ b/src/libs/Support/ShellUtils.cpp
@@ -1,0 +1,75 @@
+#include "ShellUtils.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QHash>
+#include <QProcess>
+
+#ifdef Q_OS_WIN
+#  include <shlobj_core.h>
+#  include <vector>
+
+#  pragma comment(lib, "shell32.lib")
+#endif
+
+namespace {
+    QHash<QString, QStringList> groupByDirectory(const QStringList &files) {
+        QHash<QString, QStringList> result;
+        for (const auto &file : files) {
+            const QFileInfo fileInfo(file);
+            result[fileInfo.absolutePath()].append(fileInfo.absoluteFilePath());
+        }
+        return result;
+    }
+
+#ifdef Q_OS_WIN
+    bool revealGroup(const QString &directory, const QStringList &files) {
+        const auto folderPidl = ILCreateFromPathW(reinterpret_cast<PCWSTR>(directory.utf16()));
+        if (!folderPidl)
+            return false;
+
+        std::vector<PIDLIST_ABSOLUTE> itemPidls;
+        std::vector<PCUITEMID_CHILD> childPidls;
+        for (const auto &file : files) {
+            const auto itemPidl = ILCreateFromPathW(reinterpret_cast<PCWSTR>(file.utf16()));
+            if (!itemPidl)
+                continue;
+            itemPidls.push_back(itemPidl);
+            // Child PIDLs point into itemPidls and must not be freed separately.
+            childPidls.push_back(ILFindLastID(itemPidl));
+        }
+
+        const auto result =
+            childPidls.empty()
+                ? E_INVALIDARG
+                : SHOpenFolderAndSelectItems(folderPidl, static_cast<UINT>(childPidls.size()),
+                                             childPidls.data(), 0);
+
+        for (const auto itemPidl : itemPidls)
+            ILFree(itemPidl);
+        ILFree(folderPidl);
+        return SUCCEEDED(result);
+    }
+
+    void revealSingleFile(const QString &file) {
+        QProcess::startDetached(QStringLiteral("explorer.exe"),
+                                {QStringLiteral("/select,"), QDir::toNativeSeparators(file)});
+    }
+#endif
+}
+
+namespace ShellUtils {
+    void revealFiles(const QStringList &files) {
+        const auto groups = groupByDirectory(files);
+        for (auto it = groups.constBegin(); it != groups.constEnd(); ++it) {
+#ifdef Q_OS_WIN
+            if (!revealGroup(it.key(), it.value()))
+                revealSingleFile(it.value().constFirst());
+#elif defined(Q_OS_MACOS)
+            QProcess::startDetached(QStringLiteral("open"), {it.key()});
+#else
+            QProcess::startDetached(QStringLiteral("xdg-open"), {it.key()});
+#endif
+        }
+    }
+}

--- a/src/libs/Support/ShellUtils.h
+++ b/src/libs/Support/ShellUtils.h
@@ -1,0 +1,10 @@
+#ifndef SHELLUTILS_H
+#define SHELLUTILS_H
+
+#include <QStringList>
+
+namespace ShellUtils {
+    void revealFiles(const QStringList &files);
+}
+
+#endif // SHELLUTILS_H


### PR DESCRIPTION
## Summary

- replace the export settings workflow with a dedicated modal progress dialog that supports cancellation
- write exports atomically and reopen the settings dialog only after cancellation
- reveal every separated-track output with `SHOpenFolderAndSelectItems` on Windows; leave other platforms unchanged
- remove the obsolete keep-open preference and translate the new progress states

## Verification

- `cmake --build --preset debug --target DsEditorLite`
- Computer Use: starting export hides the settings dialog and leaves only the cancellable progress dialog
- Computer Use: cancelling during export reopens the settings dialog without partial output files
- Computer Use: separated export opens Explorer with both generated files selected
- Computer Use: closing the completion dialog does not reopen settings and the main window remains interactive