### PR TITLE
fix(editor): block parameter edits behind unsupported prompt

### DIFF
--- a/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.cpp
+++ b/src/app/UI/Views/ClipEditor/ParamEditor/ParamEditorView.cpp
@@ -75,6 +75,7 @@ ParamEditorView::ParamEditorView(QWidget *parent) : QWidget(parent) {
 
     m_emptyState = new QWidget(m_graphicsView->viewport());
     m_emptyState->setObjectName("speakerMixEmptyState");
+    m_emptyState->setAttribute(Qt::WA_NoMousePropagation);
     m_emptyState->setAttribute(Qt::WA_StyledBackground);
     m_emptyState->setVisible(false);
 


### PR DESCRIPTION
## Summary

- stop the unsupported-parameter prompt overlay from forwarding mouse input to the curve editor
- keep parameter and tool selection available while the prompt is shown

## Validation

- full debug configure and build
- `TestParamSupport.exe`
- Computer Use regression with 绮萱 voicebank and 张力: dragging is blocked before clicking “仍然编辑” and works after confirmation