### PR TITLE
fix(piano-roll): block note commands in pitch modes

### DIFF
--- a/src/app/Controller/EditorViewController.cpp
+++ b/src/app/Controller/EditorViewController.cpp
@@ -311,7 +311,23 @@ EditorInteraction::Target EditorViewController::activeEditTarget() const {
     return m_activeEditTarget;
 }
 
+void EditorViewController::syncPianoRollEditMode(
+    const EditorViewGlobal::PianoRollEditMode mode) {
+    if (m_pianoRollEditMode == mode)
+        return;
+    m_pianoRollEditMode = mode;
+    emit editCommandCapabilitiesChanged();
+}
+
+bool EditorViewController::supportsEditCommand(const EditorInteraction::Command command) const {
+    if (m_activeEditTarget == EditorInteraction::Target::PianoRoll)
+        return EditorInteraction::supportsCommand(m_activeEditTarget, command, m_pianoRollEditMode);
+    return EditorInteraction::supportsCommand(m_activeEditTarget, command);
+}
+
 void EditorViewController::requestEditCommand(const EditorInteraction::Command command) {
+    if (!supportsEditCommand(command))
+        return;
     emit editCommandRequested(m_activeEditTarget, command);
 }
 

--- a/src/app/Controller/EditorViewController.h
+++ b/src/app/Controller/EditorViewController.h
@@ -67,11 +67,14 @@ public:
                                EditorInteraction::Target target);
     void unregisterInteractionArea(QObject *area);
     [[nodiscard]] EditorInteraction::Target activeEditTarget() const;
+    void syncPianoRollEditMode(EditorViewGlobal::PianoRollEditMode mode);
+    [[nodiscard]] bool supportsEditCommand(EditorInteraction::Command command) const;
     void requestEditCommand(EditorInteraction::Command command);
 
 signals:
     void activePanelChanged(AppGlobal::PanelType panel);
     void activeEditTargetChanged(EditorInteraction::Target target);
+    void editCommandCapabilitiesChanged();
     void editCommandRequested(EditorInteraction::Target target, EditorInteraction::Command command);
 
 private:
@@ -102,6 +105,7 @@ private:
     AppGlobal::PanelType m_activePanel = AppGlobal::TracksEditor;
     EditorInteraction::Target m_activeEditTarget = EditorInteraction::Target::Tracks;
     EditorInteraction::Target m_lastClipEditTarget = EditorInteraction::Target::PianoRoll;
+    EditorViewGlobal::PianoRollEditMode m_pianoRollEditMode = EditorViewGlobal::Select;
 };
 
 #endif // EDITORVIEWCONTROLLER_H

--- a/src/app/Interface/EditorInteraction.h
+++ b/src/app/Interface/EditorInteraction.h
@@ -2,6 +2,7 @@
 #define EDITORINTERACTION_H
 
 #include "Global/AppGlobal.h"
+#include "Interface/EditorViewState.h"
 
 namespace EditorInteraction {
 
@@ -14,6 +15,17 @@ namespace EditorInteraction {
         if (target == Target::Parameters)
             return command == Command::DeleteSelection;
         return target == Target::Tracks || target == Target::PianoRoll;
+    }
+
+    [[nodiscard]] constexpr bool
+        supportsCommand(const Target target, const Command command,
+                        const EditorViewGlobal::PianoRollEditMode pianoRollEditMode) noexcept {
+        if (!supportsCommand(target, command))
+            return false;
+        if (target != Target::PianoRoll || !EditorViewGlobal::isPitchEditMode(pianoRollEditMode))
+            return true;
+        return pianoRollEditMode == EditorViewGlobal::EditPitchAnchor &&
+               command == Command::DeleteSelection;
     }
 
     [[nodiscard]] constexpr Target

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
@@ -135,6 +135,10 @@ PianoRollView::~PianoRollView() {
 }
 
 void PianoRollView::executeEditCommand(const EditorInteraction::Command command) const {
+    if (!EditorInteraction::supportsCommand(EditorInteraction::Target::PianoRoll, command,
+                                            m_editMode))
+        return;
+
     switch (command) {
         case EditorInteraction::Command::Cut:
             m_contextMenuController->cutSelection();

--- a/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
+++ b/src/app/UI/Views/ClipEditor/PianoRoll/PianoRollView.cpp
@@ -135,10 +135,6 @@ PianoRollView::~PianoRollView() {
 }
 
 void PianoRollView::executeEditCommand(const EditorInteraction::Command command) const {
-    if (!EditorInteraction::supportsCommand(EditorInteraction::Target::PianoRoll, command,
-                                            m_editMode))
-        return;
-
     switch (command) {
         case EditorInteraction::Command::Cut:
             m_contextMenuController->cutSelection();
@@ -273,6 +269,7 @@ void PianoRollView::setDataContext(SingingClip *clip) const {
 
 void PianoRollView::onEditModeChanged(const PianoRollEditMode mode) const {
     m_editMode = mode;
+    editorViewController->syncPianoRollEditMode(mode);
     if (m_rhiView)
         m_rhiView->setEditMode(mode);
     else

--- a/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
@@ -430,7 +430,7 @@ void MainMenuViewPrivate::updateClipEditorActionState() {
 
     actionSelectAll->setEnabled(noteCommandsEnabled && clipController->canSelectAll());
     actionDelete->setEnabled(supports(EditorInteraction::Command::DeleteSelection) &&
-                             hasSelectedNotes);
+                             (!noteCommandsEnabled || hasSelectedNotes));
     actionCut->setEnabled(supports(EditorInteraction::Command::Cut) && hasSelectedNotes);
     actionCopy->setEnabled(supports(EditorInteraction::Command::Copy) && hasSelectedNotes);
     actionOctaveUp->setEnabled(noteCommandsEnabled && hasSelectedNotes);

--- a/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView.cpp
@@ -54,6 +54,8 @@ MainMenuView::MainMenuView(MainWindow *mainWindow)
 
     connect(editorViewController, &EditorViewController::activeEditTargetChanged, this,
             [=](const EditorInteraction::Target target) { d->onActiveEditTargetChanged(target); });
+    connect(editorViewController, &EditorViewController::editCommandCapabilitiesChanged, this,
+            [=] { d->onEditCommandCapabilitiesChanged(); });
 
     connect(QGuiApplication::clipboard(), &QClipboard::dataChanged, this,
             [this] { d_ptr->updatePasteActionState(); });
@@ -291,6 +293,11 @@ void MainMenuViewPrivate::onActiveEditTargetChanged(const EditorInteraction::Tar
         enterParametersEditorState();
 }
 
+void MainMenuViewPrivate::onEditCommandCapabilitiesChanged() {
+    if (m_editTarget == EditorInteraction::Target::PianoRoll)
+        updateClipEditorActionState();
+}
+
 void MainMenuViewPrivate::onSelectAll() {
     editorViewController->requestEditCommand(EditorInteraction::Command::SelectAll);
 }
@@ -380,74 +387,57 @@ void MainMenuViewPrivate::exitApp() {
 }
 
 void MainMenuViewPrivate::enterClipEditorState() {
-    bool hasSelectedNotes = clipController->hasSelectedNotes();
-
-    actionSelectAll->setEnabled(clipController->canSelectAll());
-    QObject::connect(clipController, &ClipController::canSelectAllChanged, actionSelectAll,
-                     &QAction::setEnabled);
-
-    actionDelete->setEnabled(hasSelectedNotes);
-    QObject::connect(clipController, &ClipController::hasSelectedNotesChanged, actionDelete,
-                     &QAction::setEnabled);
-
-    actionCut->setEnabled(hasSelectedNotes);
-    QObject::connect(clipController, &ClipController::hasSelectedNotesChanged, actionCut,
-                     &QAction::setEnabled);
-
-    actionCopy->setEnabled(hasSelectedNotes);
-    QObject::connect(clipController, &ClipController::hasSelectedNotesChanged, actionCopy,
-                     &QAction::setEnabled);
-
-    updatePasteActionState();
-
-    actionOctaveUp->setEnabled(hasSelectedNotes);
-    QObject::connect(clipController, &ClipController::hasSelectedNotesChanged, actionOctaveUp,
-                     &QAction::setEnabled);
-
-    actionOctaveDown->setEnabled(hasSelectedNotes);
-    QObject::connect(clipController, &ClipController::hasSelectedNotesChanged, actionOctaveDown,
-                     &QAction::setEnabled);
-
-    actionFillLyrics->setEnabled(hasSelectedNotes);
-    QObject::connect(clipController, &ClipController::hasSelectedNotesChanged, actionFillLyrics,
-                     &QAction::setEnabled);
-
-    // Quantize applies to selected notes or all notes in the active clip.
-    actionQuantize->setEnabled(true);
+    Q_Q(MainMenuView);
+    updateClipEditorActionState();
+    m_clipCanSelectAllConnection =
+        connect(clipController, &ClipController::canSelectAllChanged, q,
+                [this] { updateClipEditorActionState(); });
+    m_noteSelectionConnection =
+        connect(clipController, &ClipController::hasSelectedNotesChanged, q,
+                [this] { updateClipEditorActionState(); });
 }
 
 void MainMenuViewPrivate::exitClipEditorState() {
-    QObject::disconnect(clipController, &ClipController::canSelectAllChanged, actionSelectAll,
-                        &QAction::setEnabled);
+    disconnect(m_clipCanSelectAllConnection);
+    m_clipCanSelectAllConnection = {};
     actionSelectAll->setEnabled(false);
 
-    QObject::disconnect(clipController, &ClipController::hasSelectedNotesChanged, actionDelete,
-                        &QAction::setEnabled);
+    disconnect(m_noteSelectionConnection);
+    m_noteSelectionConnection = {};
     actionDelete->setEnabled(false);
 
-    QObject::disconnect(clipController, &ClipController::hasSelectedNotesChanged, actionCut,
-                        &QAction::setEnabled);
     actionCut->setEnabled(false);
 
-    QObject::disconnect(clipController, &ClipController::hasSelectedNotesChanged, actionCopy,
-                        &QAction::setEnabled);
     actionCopy->setEnabled(false);
 
     actionPaste->setEnabled(false);
 
-    QObject::disconnect(clipController, &ClipController::hasSelectedNotesChanged, actionOctaveUp,
-                        &QAction::setEnabled);
     actionOctaveUp->setEnabled(false);
 
-    QObject::disconnect(clipController, &ClipController::hasSelectedNotesChanged, actionOctaveDown,
-                        &QAction::setEnabled);
     actionOctaveDown->setEnabled(false);
 
-    QObject::disconnect(clipController, &ClipController::hasSelectedNotesChanged, actionFillLyrics,
-                        &QAction::setEnabled);
     actionFillLyrics->setEnabled(false);
 
     actionQuantize->setEnabled(false);
+}
+
+void MainMenuViewPrivate::updateClipEditorActionState() {
+    const auto supports = [](const EditorInteraction::Command command) {
+        return editorViewController->supportsEditCommand(command);
+    };
+    const auto hasSelectedNotes = clipController->hasSelectedNotes();
+    const auto noteCommandsEnabled = supports(EditorInteraction::Command::SelectAll);
+
+    actionSelectAll->setEnabled(noteCommandsEnabled && clipController->canSelectAll());
+    actionDelete->setEnabled(supports(EditorInteraction::Command::DeleteSelection) &&
+                             hasSelectedNotes);
+    actionCut->setEnabled(supports(EditorInteraction::Command::Cut) && hasSelectedNotes);
+    actionCopy->setEnabled(supports(EditorInteraction::Command::Copy) && hasSelectedNotes);
+    actionOctaveUp->setEnabled(noteCommandsEnabled && hasSelectedNotes);
+    actionOctaveDown->setEnabled(noteCommandsEnabled && hasSelectedNotes);
+    actionFillLyrics->setEnabled(noteCommandsEnabled && hasSelectedNotes);
+    actionQuantize->setEnabled(noteCommandsEnabled);
+    updatePasteActionState();
 }
 
 void MainMenuViewPrivate::enterTracksEditorState() {
@@ -505,6 +495,10 @@ void MainMenuViewPrivate::exitParametersEditorState() {
 }
 
 void MainMenuViewPrivate::updatePasteActionState() {
+    if (!editorViewController->supportsEditCommand(EditorInteraction::Command::Paste)) {
+        actionPaste->setEnabled(false);
+        return;
+    }
     const auto mimeData = QGuiApplication::clipboard()->mimeData();
     if (!mimeData) {
         actionPaste->setEnabled(false);
@@ -687,12 +681,15 @@ void MainMenuViewPrivate::initEditShortcuts() {
         auto *shortcut = EditorShortcutUtils::addApplication(
             q, key, isEditorWindow, editorViewController,
             [command] { editorViewController->requestEditCommand(command); });
-        const auto updateEnabled = [shortcut, command](const EditorInteraction::Target target) {
-            shortcut->setEnabled(EditorInteraction::supportsCommand(target, command));
+        const auto updateEnabled = [shortcut, command] {
+            shortcut->setEnabled(editorViewController->supportsEditCommand(command));
         };
         QObject::connect(editorViewController, &EditorViewController::activeEditTargetChanged,
-                         shortcut, updateEnabled);
-        updateEnabled(editorViewController->activeEditTarget());
+                         shortcut, [updateEnabled](EditorInteraction::Target) { updateEnabled(); });
+        QObject::connect(editorViewController,
+                         &EditorViewController::editCommandCapabilitiesChanged, shortcut,
+                         updateEnabled);
+        updateEnabled();
     };
 
     addShortcut(QKeySequence::Cut, EditorInteraction::Command::Cut);

--- a/src/app/UI/Views/MainTitleBar/MainMenuView_p.h
+++ b/src/app/UI/Views/MainTitleBar/MainMenuView_p.h
@@ -86,6 +86,8 @@ public:
     QString m_redoName;
 
     EditorInteraction::Target m_editTarget = EditorInteraction::Target::None;
+    QMetaObject::Connection m_clipCanSelectAllConnection;
+    QMetaObject::Connection m_noteSelectionConnection;
     QMetaObject::Connection m_clipSelectionConnection;
 
     void onNew() const;
@@ -103,6 +105,7 @@ public:
                            const QString &redoName);
 
     void onActiveEditTargetChanged(EditorInteraction::Target target);
+    void onEditCommandCapabilitiesChanged();
     void onSelectAll();
     void onDelete();
     void onCut();
@@ -120,6 +123,7 @@ public:
     void exitTracksEditorState();
     void enterParametersEditorState();
     void exitParametersEditorState();
+    void updateClipEditorActionState();
     void updatePasteActionState();
 
     void initActions();

--- a/src/tests/TestEditorViewController/main.cpp
+++ b/src/tests/TestEditorViewController/main.cpp
@@ -261,6 +261,37 @@ namespace {
                "the parameter editor must expose only its implemented delete command");
         expect(!EditorInteraction::supportsCommand(Target::None, Command::DeleteSelection),
                "a non-editor target must not expose edit commands");
+
+        const auto supportsNoCommands = [](const EditorViewGlobal::PianoRollEditMode mode) {
+            return !EditorInteraction::supportsCommand(Target::PianoRoll, Command::Cut, mode) &&
+                   !EditorInteraction::supportsCommand(Target::PianoRoll, Command::Copy, mode) &&
+                   !EditorInteraction::supportsCommand(Target::PianoRoll, Command::Paste, mode) &&
+                   !EditorInteraction::supportsCommand(Target::PianoRoll, Command::SelectAll,
+                                                       mode) &&
+                   !EditorInteraction::supportsCommand(Target::PianoRoll,
+                                                       Command::DeleteSelection, mode);
+        };
+        expect(supportsNoCommands(EditorViewGlobal::DrawPitch) &&
+                   supportsNoCommands(EditorViewGlobal::ErasePitch) &&
+                   supportsNoCommands(EditorViewGlobal::BakePitch),
+               "pitch drawing, erasing, and baking must reject note edit commands");
+        expect(!EditorInteraction::supportsCommand(Target::PianoRoll, Command::Cut,
+                                                   EditorViewGlobal::EditPitchAnchor) &&
+                   !EditorInteraction::supportsCommand(Target::PianoRoll, Command::Copy,
+                                                       EditorViewGlobal::EditPitchAnchor) &&
+                   !EditorInteraction::supportsCommand(Target::PianoRoll, Command::Paste,
+                                                       EditorViewGlobal::EditPitchAnchor) &&
+                   !EditorInteraction::supportsCommand(Target::PianoRoll, Command::SelectAll,
+                                                       EditorViewGlobal::EditPitchAnchor) &&
+                   EditorInteraction::supportsCommand(Target::PianoRoll,
+                                                      Command::DeleteSelection,
+                                                      EditorViewGlobal::EditPitchAnchor),
+               "pitch anchor editing must expose only anchor deletion");
+        expect(EditorInteraction::supportsCommand(Target::PianoRoll, Command::SelectAll,
+                                                  EditorViewGlobal::Select) &&
+                   EditorInteraction::supportsCommand(Target::PianoRoll, Command::Paste,
+                                                      EditorViewGlobal::DrawNote),
+               "note edit modes must retain piano-roll edit commands");
     }
 
     void testForwardingAndSnapshots(EditorViewController *controller) {

--- a/src/tests/TestEditorViewController/main.cpp
+++ b/src/tests/TestEditorViewController/main.cpp
@@ -294,6 +294,51 @@ namespace {
                "note edit modes must retain piano-roll edit commands");
     }
 
+    void testModeAwareCommandRouting(EditorViewController *controller) {
+        controller->setActivePanel(AppGlobal::ClipEditor);
+        controller->syncPianoRollEditMode(EditorViewGlobal::Select);
+
+        int capabilityChangeCount = 0;
+        int commandCount = 0;
+        EditorInteraction::Command requestedCommand = EditorInteraction::Command::Cut;
+        const auto capabilityConnection =
+            QObject::connect(controller, &EditorViewController::editCommandCapabilitiesChanged,
+                             [&capabilityChangeCount] { ++capabilityChangeCount; });
+        const auto commandConnection = QObject::connect(
+            controller, &EditorViewController::editCommandRequested,
+            [&commandCount, &requestedCommand](EditorInteraction::Target,
+                                                const EditorInteraction::Command command) {
+                ++commandCount;
+                requestedCommand = command;
+            });
+
+        controller->requestEditCommand(EditorInteraction::Command::SelectAll);
+        expect(commandCount == 1 && requestedCommand == EditorInteraction::Command::SelectAll,
+               "note modes must dispatch supported piano-roll commands");
+
+        controller->syncPianoRollEditMode(EditorViewGlobal::DrawPitch);
+        expect(capabilityChangeCount == 1 &&
+                   !controller->supportsEditCommand(EditorInteraction::Command::SelectAll),
+               "entering pitch drawing must publish disabled note command capabilities");
+        controller->requestEditCommand(EditorInteraction::Command::SelectAll);
+        controller->requestEditCommand(EditorInteraction::Command::DeleteSelection);
+        expect(commandCount == 1, "pitch drawing must not dispatch note edit commands");
+
+        controller->syncPianoRollEditMode(EditorViewGlobal::EditPitchAnchor);
+        expect(capabilityChangeCount == 2 &&
+                   controller->supportsEditCommand(EditorInteraction::Command::DeleteSelection),
+               "pitch anchor mode must publish anchor deletion capability");
+        controller->requestEditCommand(EditorInteraction::Command::DeleteSelection);
+        expect(commandCount == 2 &&
+                   requestedCommand == EditorInteraction::Command::DeleteSelection,
+               "pitch anchor mode must dispatch anchor deletion");
+
+        controller->syncPianoRollEditMode(EditorViewGlobal::Select);
+        QObject::disconnect(commandConnection);
+        QObject::disconnect(capabilityConnection);
+        controller->setActivePanel(AppGlobal::TracksEditor);
+    }
+
     void testForwardingAndSnapshots(EditorViewController *controller) {
         FakeEditorView view;
         view.state = sampleState();
@@ -603,6 +648,7 @@ int main(int argc, char *argv[]) {
 
     testNoView(controller);
     testCommandCapabilities();
+    testModeAwareCommandRouting(controller);
     testForwardingAndSnapshots(controller);
     testActivePanels(controller);
     testInteractionRouting(controller);


### PR DESCRIPTION
## Summary

- block note cut, copy, paste, select-all, and deletion while pitch tools are active
- preserve deletion of selected pitch anchors in anchor mode
- add regression coverage for mode-specific piano-roll command capabilities

## Verification

- Debug configure and DsEditorLite build via the project CMake preset script
- TestEditorViewController target and executable
- Computer Use regression: Ctrl+A is ignored in Draw Pitch and Pitch Anchor modes, and still selects notes in Select mode