### PR TITLE
fix(editor): save the confirmed document revision

### DIFF
--- a/docs/automation/01-automation-facade/implementation-report.md
+++ b/docs/automation/01-automation-facade/implementation-report.md
@@ -40,8 +40,8 @@ MCP、Headless 宿主和多文档产品行为不在 Facade 层实现。GUI、内
 - 公共 MCP 持久文档写操作继续严格使用调用方提供的 `expected_revision`，不自动重定位；GUI 文档
   工作流 busy 时拒绝新的公共 MCP 持久写操作，但查询、任务取消、瞬时播放控制、可信 GUI 提交和
   内部派生写回仍可进入统一 Facade。已在 busy 前通过准入的异步任务可继续按原 generation/revision
-  契约完成，已提交幂等请求的重放先于 busy 拒绝。瞬时播放控制不修改持久文档，任务取消沿用 Task
-  状态契约。
+  契约完成；工作流 busy 租约由开始时的 generation 持有并跨文档换代保持，直到原工作流释放。已
+  提交幂等请求的重放先于 busy 拒绝。瞬时播放控制不修改持久文档，任务取消沿用 Task 状态契约。
 - Import、编辑、Undo、Redo 仅在实际改变时增加 revision。
 - Session 替换后，旧 DocumentId、旧对象 ID、排队命令和晚到异步写回不能进入新工程。
 

--- a/docs/automation/01-automation-facade/implementation-report.md
+++ b/docs/automation/01-automation-facade/implementation-report.md
@@ -31,8 +31,9 @@ MCP、Headless 宿主和多文档产品行为不在 Facade 层实现。GUI、内
 ### 3.1 文档生命周期
 
 - 应用启动时建立 untitled Session，revision 为 0。
-- New/Open 在旧文档外准备结果，提交点确认旧 DocumentId 未换代并使用当时的当前 revision；成功后
-  轮换 DocumentId、清空 History 与 generation 状态并把 revision 置 0。
+- New/Open 在旧文档外准备结果，提交点确认旧 DocumentId 未换代，且当前 revision 已被最后一次
+  保存或丢弃决定覆盖；准备期间 revision 再次推进时重新进入未保存保护，不静默丢弃新增修改。成功
+  后轮换 DocumentId、清空 History 与 generation 状态并把 revision 置 0。
 - New/Open 失败或取消不改变旧 Model、History、路径、loop、幂等缓存或任务记录。
 - GUI Save/Save As 在用户完成最后一次确认后立即解析同代当前 revision 并保存该状态；保存失败重试
   会重新解析，且绝不跨 DocumentId 换代。保存本身不轮换 DocumentId 和 revision，只更新路径、

--- a/docs/automation/01-automation-facade/implementation-report.md
+++ b/docs/automation/01-automation-facade/implementation-report.md
@@ -37,8 +37,9 @@ MCP、Headless 宿主和多文档产品行为不在 Facade 层实现。GUI、内
 - GUI Save/Save As 在用户完成最后一次确认后立即解析同代当前 revision 并保存该状态；保存失败重试
   会重新解析，且绝不跨 DocumentId 换代。保存本身不轮换 DocumentId 和 revision，只更新路径、
   工程名和 History savepoint。
-- 公共 MCP 文档写操作继续严格使用调用方提供的 `expected_revision`，不自动重定位；GUI 文档工作流
-  busy 时拒绝新的公共 MCP 写操作，但查询、可信 GUI 提交和内部派生写回仍可进入统一 Facade。
+- 公共 MCP 持久文档写操作继续严格使用调用方提供的 `expected_revision`，不自动重定位；GUI 文档
+  工作流 busy 时拒绝新的公共 MCP 持久写操作，但查询、任务取消、瞬时播放控制、可信 GUI 提交和
+  内部派生写回仍可进入统一 Facade。瞬时播放控制不修改持久文档，任务取消沿用 Task 状态契约。
 - Import、编辑、Undo、Redo 仅在实际改变时增加 revision。
 - Session 替换后，旧 DocumentId、旧对象 ID、排队命令和晚到异步写回不能进入新工程。
 

--- a/docs/automation/01-automation-facade/implementation-report.md
+++ b/docs/automation/01-automation-facade/implementation-report.md
@@ -39,7 +39,9 @@ MCP、Headless 宿主和多文档产品行为不在 Facade 层实现。GUI、内
   工程名和 History savepoint。
 - 公共 MCP 持久文档写操作继续严格使用调用方提供的 `expected_revision`，不自动重定位；GUI 文档
   工作流 busy 时拒绝新的公共 MCP 持久写操作，但查询、任务取消、瞬时播放控制、可信 GUI 提交和
-  内部派生写回仍可进入统一 Facade。瞬时播放控制不修改持久文档，任务取消沿用 Task 状态契约。
+  内部派生写回仍可进入统一 Facade。已在 busy 前通过准入的异步任务可继续按原 generation/revision
+  契约完成，已提交幂等请求的重放先于 busy 拒绝。瞬时播放控制不修改持久文档，任务取消沿用 Task
+  状态契约。
 - Import、编辑、Undo、Redo 仅在实际改变时增加 revision。
 - Session 替换后，旧 DocumentId、旧对象 ID、排队命令和晚到异步写回不能进入新工程。
 

--- a/docs/automation/01-automation-facade/implementation-report.md
+++ b/docs/automation/01-automation-facade/implementation-report.md
@@ -31,10 +31,14 @@ MCP、Headless 宿主和多文档产品行为不在 Facade 层实现。GUI、内
 ### 3.1 文档生命周期
 
 - 应用启动时建立 untitled Session，revision 为 0。
-- New/Open 在旧文档外准备结果，提交点再次校验旧 document/revision；成功后轮换 DocumentId、
-  清空 History 与 generation 状态并把 revision 置 0。
+- New/Open 在旧文档外准备结果，提交点确认旧 DocumentId 未换代并使用当时的当前 revision；成功后
+  轮换 DocumentId、清空 History 与 generation 状态并把 revision 置 0。
 - New/Open 失败或取消不改变旧 Model、History、路径、loop、幂等缓存或任务记录。
-- Save/Save As 不轮换 DocumentId 和 revision，只更新路径、工程名和 History savepoint。
+- GUI Save/Save As 在用户完成最后一次确认后立即解析同代当前 revision 并保存该状态；保存失败重试
+  会重新解析，且绝不跨 DocumentId 换代。保存本身不轮换 DocumentId 和 revision，只更新路径、
+  工程名和 History savepoint。
+- 公共 MCP 文档写操作继续严格使用调用方提供的 `expected_revision`，不自动重定位；GUI 文档工作流
+  busy 时拒绝新的公共 MCP 写操作，但查询、可信 GUI 提交和内部派生写回仍可进入统一 Facade。
 - Import、编辑、Undo、Redo 仅在实际改变时增加 revision。
 - Session 替换后，旧 DocumentId、旧对象 ID、排队命令和晚到异步写回不能进入新工程。
 

--- a/src/app/Automation/AutomationDispatcher.cpp
+++ b/src/app/Automation/AutomationDispatcher.cpp
@@ -9,6 +9,21 @@ namespace Automation {
         : m_documentResolver(documentResolver), m_windowContext(windowContext) {
     }
 
+    AutomationResult<DocumentVersion>
+        AutomationDispatcher::validateDocumentCommand(const CommandContext &context) {
+        return runSerialized([&]() -> AutomationResult<DocumentVersion> {
+            auto validated = resolveDocumentCommand(context);
+            if (!validated)
+                return validated.getError();
+            const auto &session = validated.get().get();
+            if (session.revision() != context.expected.revision) {
+                return AutomationError::revisionConflict(
+                    session.documentId(), context.expected.revision, session.revision());
+            }
+            return session.version();
+        });
+    }
+
     AutomationResult<MutationResult>
         AutomationDispatcher::dispatchDocumentCommand(const OperationId &operationId,
                                                       const CommandContext &context,
@@ -22,6 +37,19 @@ namespace Automation {
             const DocumentCommandHandler &handler) {
         return dispatchDocumentCommandResultWithoutRevisionCheck<MutationResult>(operationId,
                                                                                  context, handler);
+    }
+
+    AutomationResult<std::reference_wrapper<DocumentSession>>
+        AutomationDispatcher::resolveDocumentCommand(const CommandContext &context) {
+        auto resolved = m_documentResolver.resolveDocument(context.expected.documentId);
+        if (!resolved)
+            return resolved.getError();
+        auto &session = resolved.get().get();
+        if (session.lifecycleState() != DocumentLifecycleState::Active)
+            return AutomationError::documentBusy(session.documentId());
+        if (context.source == InvocationSource::PublicMcp && session.isBusy())
+            return AutomationError::documentBusy(session.documentId());
+        return std::ref(session);
     }
 
     AutomationResult<MutationResult> AutomationDispatcher::dispatchIdempotentDocumentCommand(

--- a/src/app/Automation/AutomationDispatcher.cpp
+++ b/src/app/Automation/AutomationDispatcher.cpp
@@ -12,7 +12,7 @@ namespace Automation {
     AutomationResult<DocumentVersion>
         AutomationDispatcher::validateDocumentCommand(const CommandContext &context) {
         return runSerialized([&]() -> AutomationResult<DocumentVersion> {
-            auto validated = resolveDocumentCommand(context);
+            auto validated = resolveDocumentCommand(context, true);
             if (!validated)
                 return validated.getError();
             const auto &session = validated.get().get();
@@ -31,6 +31,20 @@ namespace Automation {
         return dispatchDocumentCommandResult<MutationResult>(operationId, context, handler);
     }
 
+    AutomationResult<MutationResult> AutomationDispatcher::dispatchDocumentControlCommand(
+        const OperationId &operationId, const CommandContext &context,
+        const DocumentCommandHandler &handler) {
+        if (!context.idempotencyKey.isEmpty()) {
+            return decorateError(
+                AutomationError::invalidArgument(
+                    QStringLiteral("idempotency_key"),
+                    QStringLiteral("Operation does not support document idempotency")),
+                operationId);
+        }
+        return dispatchDocumentCommandResultImpl<MutationResult>(operationId, context, nullptr,
+                                                                 true, false, handler);
+    }
+
     AutomationResult<MutationResult>
         AutomationDispatcher::dispatchDocumentCommandWithoutRevisionCheck(
             const OperationId &operationId, const CommandContext &context,
@@ -40,15 +54,18 @@ namespace Automation {
     }
 
     AutomationResult<std::reference_wrapper<DocumentSession>>
-        AutomationDispatcher::resolveDocumentCommand(const CommandContext &context) {
+        AutomationDispatcher::resolveDocumentCommand(const CommandContext &context,
+                                                     const bool rejectPublicWhileBusy) {
         auto resolved = m_documentResolver.resolveDocument(context.expected.documentId);
         if (!resolved)
             return resolved.getError();
         auto &session = resolved.get().get();
         if (session.lifecycleState() != DocumentLifecycleState::Active)
             return AutomationError::documentBusy(session.documentId());
-        if (context.source == InvocationSource::PublicMcp && session.isBusy())
+        if (rejectPublicWhileBusy && context.source == InvocationSource::PublicMcp &&
+            session.isBusy()) {
             return AutomationError::documentBusy(session.documentId());
+        }
         return std::ref(session);
     }
 

--- a/src/app/Automation/AutomationDispatcher.cpp
+++ b/src/app/Automation/AutomationDispatcher.cpp
@@ -12,16 +12,26 @@ namespace Automation {
     AutomationResult<DocumentVersion>
         AutomationDispatcher::validateDocumentCommand(const CommandContext &context) {
         return runSerialized([&]() -> AutomationResult<DocumentVersion> {
-            auto validated = resolveDocumentCommand(context, true);
+            auto validated = resolveDocumentCommand(context);
             if (!validated)
                 return validated.getError();
             const auto &session = validated.get().get();
+            if (context.source == InvocationSource::PublicMcp && session.isBusy())
+                return AutomationError::documentBusy(session.documentId());
             if (session.revision() != context.expected.revision) {
                 return AutomationError::revisionConflict(
                     session.documentId(), context.expected.revision, session.revision());
             }
             return session.version();
         });
+    }
+
+    AutomationResult<DocumentVersion>
+        AutomationDispatcher::admitDocumentTask(CommandContext &context) {
+        auto validated = validateDocumentCommand(context);
+        if (validated && context.source == InvocationSource::PublicMcp)
+            context.source = InvocationSource::PublicMcpContinuation;
+        return validated;
     }
 
     AutomationResult<MutationResult>
@@ -54,18 +64,13 @@ namespace Automation {
     }
 
     AutomationResult<std::reference_wrapper<DocumentSession>>
-        AutomationDispatcher::resolveDocumentCommand(const CommandContext &context,
-                                                     const bool rejectPublicWhileBusy) {
+        AutomationDispatcher::resolveDocumentCommand(const CommandContext &context) {
         auto resolved = m_documentResolver.resolveDocument(context.expected.documentId);
         if (!resolved)
             return resolved.getError();
         auto &session = resolved.get().get();
         if (session.lifecycleState() != DocumentLifecycleState::Active)
             return AutomationError::documentBusy(session.documentId());
-        if (rejectPublicWhileBusy && context.source == InvocationSource::PublicMcp &&
-            session.isBusy()) {
-            return AutomationError::documentBusy(session.documentId());
-        }
         return std::ref(session);
     }
 

--- a/src/app/Automation/AutomationDispatcher.h
+++ b/src/app/Automation/AutomationDispatcher.h
@@ -22,6 +22,9 @@ namespace Automation {
         AutomationDispatcher(IDocumentSessionResolver &documentResolver,
                              SingleWindowContext &windowContext);
 
+        AutomationResult<DocumentVersion>
+            validateDocumentCommand(const CommandContext &context);
+
         template <typename T, typename Handler>
         AutomationResult<T> dispatchApplicationQuery(const OperationId &operationId,
                                                      Handler &&handler) {
@@ -210,16 +213,10 @@ namespace Automation {
                                                               const bool checkRevision,
                                                               Handler &&handler) {
             return runSerialized([&]() -> AutomationResult<T> {
-                auto resolved = m_documentResolver.resolveDocument(context.expected.documentId);
-                if (!resolved)
-                    return decorateError(resolved.getError(), operationId);
-                auto &session = resolved.get().get();
-                if (session.lifecycleState() != DocumentLifecycleState::Active)
-                    return decorateError(AutomationError::documentBusy(session.documentId()),
-                                         operationId);
-                if (context.source == InvocationSource::PublicMcp && session.isBusy())
-                    return decorateError(AutomationError::documentBusy(session.documentId()),
-                                         operationId);
+                auto validated = resolveDocumentCommand(context);
+                if (!validated)
+                    return decorateError(validated.getError(), operationId);
+                auto &session = validated.get().get();
 
                 QByteArray fingerprint;
                 if (!context.validateOnly && !context.idempotencyKey.isEmpty()) {
@@ -253,6 +250,9 @@ namespace Automation {
                 return result;
             });
         }
+
+        AutomationResult<std::reference_wrapper<DocumentSession>>
+            resolveDocumentCommand(const CommandContext &context);
 
         template <typename T>
         static AutomationResult<T> decorateHandlerResult(AutomationResult<T> result,

--- a/src/app/Automation/AutomationDispatcher.h
+++ b/src/app/Automation/AutomationDispatcher.h
@@ -24,6 +24,7 @@ namespace Automation {
 
         AutomationResult<DocumentVersion>
             validateDocumentCommand(const CommandContext &context);
+        AutomationResult<DocumentVersion> admitDocumentTask(CommandContext &context);
 
         template <typename T, typename Handler>
         AutomationResult<T> dispatchApplicationQuery(const OperationId &operationId,
@@ -233,7 +234,7 @@ namespace Automation {
                                                               const bool rejectPublicWhileBusy,
                                                               Handler &&handler) {
             return runSerialized([&]() -> AutomationResult<T> {
-                auto validated = resolveDocumentCommand(context, rejectPublicWhileBusy);
+                auto validated = resolveDocumentCommand(context);
                 if (!validated)
                     return decorateError(validated.getError(), operationId);
                 auto &session = validated.get().get();
@@ -248,6 +249,12 @@ namespace Automation {
                         return decorateError(replay.getError(), operationId);
                     if (replay.get())
                         return *replay.get();
+                }
+
+                if (rejectPublicWhileBusy && context.source == InvocationSource::PublicMcp &&
+                    session.isBusy()) {
+                    return decorateError(AutomationError::documentBusy(session.documentId()),
+                                         operationId);
                 }
 
                 if (checkRevision && session.revision() != context.expected.revision) {
@@ -272,7 +279,7 @@ namespace Automation {
         }
 
         AutomationResult<std::reference_wrapper<DocumentSession>>
-            resolveDocumentCommand(const CommandContext &context, bool rejectPublicWhileBusy);
+            resolveDocumentCommand(const CommandContext &context);
 
         template <typename T>
         static AutomationResult<T> decorateHandlerResult(AutomationResult<T> result,

--- a/src/app/Automation/AutomationDispatcher.h
+++ b/src/app/Automation/AutomationDispatcher.h
@@ -143,6 +143,11 @@ namespace Automation {
                                     const DocumentCommandHandler &handler);
 
         AutomationResult<MutationResult>
+            dispatchDocumentControlCommand(const OperationId &operationId,
+                                           const CommandContext &context,
+                                           const DocumentCommandHandler &handler);
+
+        AutomationResult<MutationResult>
             dispatchDocumentCommandWithoutRevisionCheck(const OperationId &operationId,
                                                         const CommandContext &context,
                                                         const DocumentCommandHandler &handler);
@@ -179,7 +184,7 @@ namespace Automation {
                         QStringLiteral("Operation does not support document idempotency")),
                     operationId);
             }
-            return dispatchDocumentCommandResultImpl<T>(operationId, context, nullptr, true,
+            return dispatchDocumentCommandResultImpl<T>(operationId, context, nullptr, true, true,
                                                         std::forward<Handler>(handler));
         }
 
@@ -193,7 +198,21 @@ namespace Automation {
                         QStringLiteral("Operation does not support document idempotency")),
                     operationId);
             }
-            return dispatchDocumentCommandResultImpl<T>(operationId, context, nullptr, false,
+            return dispatchDocumentCommandResultImpl<T>(operationId, context, nullptr, false, true,
+                                                        std::forward<Handler>(handler));
+        }
+
+        template <typename T, typename Handler>
+        AutomationResult<T> dispatchDocumentControlCommandResultWithoutRevisionCheck(
+            const OperationId &operationId, const CommandContext &context, Handler &&handler) {
+            if (!context.idempotencyKey.isEmpty()) {
+                return decorateError(
+                    AutomationError::invalidArgument(
+                        QStringLiteral("idempotency_key"),
+                        QStringLiteral("Operation does not support document idempotency")),
+                    operationId);
+            }
+            return dispatchDocumentCommandResultImpl<T>(operationId, context, nullptr, false, false,
                                                         std::forward<Handler>(handler));
         }
 
@@ -202,7 +221,7 @@ namespace Automation {
             const OperationId &operationId, const CommandContext &context,
             const QByteArray &requestFingerprint, Handler &&handler) {
             return dispatchDocumentCommandResultImpl<T>(operationId, context, &requestFingerprint,
-                                                        true, std::forward<Handler>(handler));
+                                                        true, true, std::forward<Handler>(handler));
         }
 
     private:
@@ -211,9 +230,10 @@ namespace Automation {
                                                               const CommandContext &context,
                                                               const QByteArray *requestFingerprint,
                                                               const bool checkRevision,
+                                                              const bool rejectPublicWhileBusy,
                                                               Handler &&handler) {
             return runSerialized([&]() -> AutomationResult<T> {
-                auto validated = resolveDocumentCommand(context);
+                auto validated = resolveDocumentCommand(context, rejectPublicWhileBusy);
                 if (!validated)
                     return decorateError(validated.getError(), operationId);
                 auto &session = validated.get().get();
@@ -252,7 +272,7 @@ namespace Automation {
         }
 
         AutomationResult<std::reference_wrapper<DocumentSession>>
-            resolveDocumentCommand(const CommandContext &context);
+            resolveDocumentCommand(const CommandContext &context, bool rejectPublicWhileBusy);
 
         template <typename T>
         static AutomationResult<T> decorateHandlerResult(AutomationResult<T> result,

--- a/src/app/Automation/AutomationDispatcher.h
+++ b/src/app/Automation/AutomationDispatcher.h
@@ -217,6 +217,9 @@ namespace Automation {
                 if (session.lifecycleState() != DocumentLifecycleState::Active)
                     return decorateError(AutomationError::documentBusy(session.documentId()),
                                          operationId);
+                if (context.source == InvocationSource::PublicMcp && session.isBusy())
+                    return decorateError(AutomationError::documentBusy(session.documentId()),
+                                         operationId);
 
                 QByteArray fingerprint;
                 if (!context.validateOnly && !context.idempotencyKey.isEmpty()) {

--- a/src/app/Automation/AutomationTypes.cpp
+++ b/src/app/Automation/AutomationTypes.cpp
@@ -114,10 +114,10 @@ namespace Automation {
     }
 
     AutomationResult<DocumentVersion>
-        rebaseTaskVersionWithinGeneration(const DocumentVersion &taskVersion,
-                                          const DocumentVersion &currentVersion) {
-        if (taskVersion.documentId != currentVersion.documentId)
-            return AutomationError::documentChanged(taskVersion.documentId,
+        rebaseDocumentVersionWithinGeneration(const DocumentVersion &generationAnchor,
+                                              const DocumentVersion &currentVersion) {
+        if (generationAnchor.documentId != currentVersion.documentId)
+            return AutomationError::documentChanged(generationAnchor.documentId,
                                                     currentVersion.documentId);
         return currentVersion;
     }

--- a/src/app/Automation/AutomationTypes.h
+++ b/src/app/Automation/AutomationTypes.h
@@ -115,6 +115,7 @@ namespace Automation {
         TrustedGui,
         InternalAutomation,
         PublicMcp,
+        PublicMcpContinuation,
         Test,
     };
 

--- a/src/app/Automation/AutomationTypes.h
+++ b/src/app/Automation/AutomationTypes.h
@@ -234,10 +234,10 @@ namespace Automation {
     template <typename T>
     using AutomationResult = Expected<T, AutomationError>;
 
-    // Rebased task results still require an immutable target snapshot check at the write boundary.
+    // Stale work rebased within a generation still requires target-specific validation at commit.
     [[nodiscard]] AutomationResult<DocumentVersion>
-        rebaseTaskVersionWithinGeneration(const DocumentVersion &taskVersion,
-                                          const DocumentVersion &currentVersion);
+        rebaseDocumentVersionWithinGeneration(const DocumentVersion &generationAnchor,
+                                              const DocumentVersion &currentVersion);
 
     struct AutomationUnit {
         friend bool operator==(const AutomationUnit &, const AutomationUnit &) = default;

--- a/src/app/Automation/CoreRuntime.cpp
+++ b/src/app/Automation/CoreRuntime.cpp
@@ -168,9 +168,19 @@ namespace Automation {
     }
 
     bool CoreRuntime::setDocumentBusy(const DocumentId &documentId, const bool busy) {
-        if (documentId != m_session.documentId())
+        if (busy) {
+            if (documentId != m_session.documentId() ||
+                (!m_documentBusyOwner.isNull() && m_documentBusyOwner != documentId)) {
+                return false;
+            }
+            m_documentBusyOwner = documentId;
+            m_session.setBusy(true);
+            return true;
+        }
+        if (documentId != m_documentBusyOwner)
             return false;
-        m_session.setBusy(busy);
+        m_documentBusyOwner = {};
+        m_session.setBusy(false);
         return true;
     }
 

--- a/src/app/Automation/CoreRuntime.cpp
+++ b/src/app/Automation/CoreRuntime.cpp
@@ -58,10 +58,22 @@ namespace Automation {
         return documentId == m_session.documentId() && m_session.isBusy();
     }
 
+    AutomationResult<CommandContext> CoreRuntime::documentWorkflowCommitContext(
+        const DocumentVersion &generationAnchor) const {
+        const auto rebased =
+            rebaseDocumentVersionWithinGeneration(generationAnchor, documentVersion());
+        if (!rebased)
+            return rebased.getError();
+        return CommandContext{
+            .expected = rebased.get(),
+            .source = InvocationSource::TrustedGui,
+        };
+    }
+
     AutomationResult<CommandContext>
         CoreRuntime::derivedWritebackContext(const DocumentVersion &taskVersion,
                                              const bool validateOnly) const {
-        const auto rebased = rebaseTaskVersionWithinGeneration(taskVersion, documentVersion());
+        const auto rebased = rebaseDocumentVersionWithinGeneration(taskVersion, documentVersion());
         if (!rebased)
             return rebased.getError();
         return CommandContext{

--- a/src/app/Automation/CoreRuntime.h
+++ b/src/app/Automation/CoreRuntime.h
@@ -73,6 +73,8 @@ namespace Automation {
 
     private:
         DocumentSession m_session;
+        // 工作流租约由启动它的 generation 持有，换代后仍由该 generation 释放。
+        DocumentId m_documentBusyOwner;
         SingleDocumentSessionResolver m_documentResolver;
         SingleWindowContext m_windowContext;
         AutomationDispatcher m_dispatcher;

--- a/src/app/Automation/CoreRuntime.h
+++ b/src/app/Automation/CoreRuntime.h
@@ -43,6 +43,8 @@ namespace Automation {
         [[nodiscard]] DocumentVersion documentVersion() const;
         [[nodiscard]] bool documentBusy(const DocumentId &documentId) const;
         [[nodiscard]] AutomationResult<CommandContext>
+            documentWorkflowCommitContext(const DocumentVersion &generationAnchor) const;
+        [[nodiscard]] AutomationResult<CommandContext>
             derivedWritebackContext(const DocumentVersion &taskVersion, bool validateOnly) const;
         [[nodiscard]] const WindowId &windowId() const;
 

--- a/src/app/Automation/DocumentSession.cpp
+++ b/src/app/Automation/DocumentSession.cpp
@@ -61,7 +61,7 @@ namespace Automation {
         m_path = std::move(path);
         m_projectName = std::move(projectName);
         m_lifecycleState = DocumentLifecycleState::Active;
-        m_busy = false;
+        // 工作流 busy 由外层操作持有，文档换代时必须保留。
         m_idempotencyStore.clear();
         return version();
     }

--- a/src/app/Automation/PlaybackAutomationFacade.cpp
+++ b/src/app/Automation/PlaybackAutomationFacade.cpp
@@ -100,7 +100,7 @@ namespace Automation {
 
     AutomationResult<MutationResult> PlaybackAutomationFacade::setState(
         const OperationId &operationId, const CommandContext &context, const PlaybackState state) {
-        return m_dispatcher.dispatchDocumentCommand(
+        return m_dispatcher.dispatchDocumentControlCommand(
             operationId, context, [this, state](DocumentSession &session, const bool validateOnly) {
                 if (!m_services.snapshot)
                     return AutomationResult<MutationResult>(
@@ -140,7 +140,7 @@ namespace Automation {
 
     AutomationResult<MutationResult>
         PlaybackAutomationFacade::setPosition(const CommandContext &context, const double tick) {
-        return m_dispatcher.dispatchDocumentCommand(
+        return m_dispatcher.dispatchDocumentControlCommand(
             OperationIds::playback::set_position, context,
             [this, tick](DocumentSession &session, const bool validateOnly) {
                 if (!std::isfinite(tick) || tick < 0.0) {
@@ -160,7 +160,7 @@ namespace Automation {
 
     AutomationResult<MutationResult> PlaybackAutomationFacade::seek(const CommandContext &context,
                                                                     const double tick) {
-        return m_dispatcher.dispatchDocumentCommand(
+        return m_dispatcher.dispatchDocumentControlCommand(
             OperationIds::playback::seek, context,
             [this, tick](DocumentSession &session, const bool validateOnly) {
                 if (!std::isfinite(tick) || tick < 0.0) {
@@ -187,7 +187,7 @@ namespace Automation {
     AutomationResult<MutationResult>
         PlaybackAutomationFacade::setLastPosition(const CommandContext &context,
                                                   const double tick) {
-        return m_dispatcher.dispatchDocumentCommand(
+        return m_dispatcher.dispatchDocumentControlCommand(
             OperationIds::playback::set_last_position, context,
             [this, tick](DocumentSession &session, const bool validateOnly) {
                 if (!std::isfinite(tick) || tick < 0.0) {

--- a/src/app/Automation/Public/PublicAutomationHostAdapter.cpp
+++ b/src/app/Automation/Public/PublicAutomationHostAdapter.cpp
@@ -137,15 +137,7 @@ namespace Automation {
 
         AutomationResult<DocumentVersion> validateBase(CoreRuntime &runtime,
                                                        const CommandContext &context) {
-            auto document = runtime.documents().getDocument(context.expected.documentId);
-            if (!document)
-                return document.getError();
-            if (document.get().document.revision != context.expected.revision) {
-                return AutomationError::revisionConflict(context.expected.documentId,
-                                                         context.expected.revision,
-                                                         document.get().document.revision);
-            }
-            return document.get().document;
+            return runtime.dispatcher().validateDocumentCommand(context);
         }
 
         AutomationError projectLoadError(const ProjectOperationError &source,

--- a/src/app/Automation/Public/PublicAutomationHostAdapter.cpp
+++ b/src/app/Automation/Public/PublicAutomationHostAdapter.cpp
@@ -135,9 +135,9 @@ namespace Automation {
             return PreparedAudioPath{hashTask->resultSha512, workspace};
         }
 
-        AutomationResult<DocumentVersion> validateBase(CoreRuntime &runtime,
-                                                       const CommandContext &context) {
-            return runtime.dispatcher().validateDocumentCommand(context);
+        AutomationResult<DocumentVersion> admitTaskBase(CoreRuntime &runtime,
+                                                        CommandContext &context) {
+            return runtime.dispatcher().admitDocumentTask(context);
         }
 
         AutomationError projectLoadError(const ProjectOperationError &source,
@@ -192,7 +192,7 @@ namespace Automation {
             }
 
             AutomationResult<TaskAcceptedResult> prepare() {
-                auto base = validateBase(m_runtime, m_command);
+                auto base = admitTaskBase(m_runtime, m_command);
                 if (!base)
                     return base.getError();
                 auto *handler = projectFormatRegistry->resolveByPath(m_path);
@@ -387,7 +387,7 @@ namespace Automation {
             }
 
             AutomationResult<TaskAcceptedResult> prepare() {
-                auto base = validateBase(m_runtime, m_request.command);
+                auto base = admitTaskBase(m_runtime, m_request.command);
                 if (!base)
                     return base.getError();
                 if (!m_model)
@@ -745,7 +745,7 @@ namespace Automation {
             }
 
             AutomationResult<TaskAcceptedResult> prepare() {
-                auto base = validateBase(m_runtime, m_command);
+                auto base = admitTaskBase(m_runtime, m_command);
                 if (!base)
                     return base.getError();
                 if (!m_model || m_entries.isEmpty()) {
@@ -1176,7 +1176,7 @@ namespace Automation {
             }
 
             AutomationResult<TaskAcceptedResult> prepare() {
-                auto base = validateBase(m_runtime, m_request.command);
+                auto base = admitTaskBase(m_runtime, m_request.command);
                 if (!base)
                     return base.getError();
                 if (m_request.canonicalPath.isEmpty()) {
@@ -1735,7 +1735,7 @@ namespace Automation {
         };
 
         AutomationResult<TaskAcceptedResult> HeadlessInferenceTask::prepare() {
-            auto base = validateBase(m_runtime, m_request.command);
+            auto base = admitTaskBase(m_runtime, m_request.command);
             if (!base)
                 return base.getError();
 

--- a/src/app/Automation/TaskAutomationFacade.cpp
+++ b/src/app/Automation/TaskAutomationFacade.cpp
@@ -34,7 +34,7 @@ namespace Automation {
     AutomationResult<AutomationTaskSnapshot>
         TaskAutomationFacade::cancelTask(const CommandContext &context, const TaskId &taskId) {
         return m_dispatcher
-            .dispatchDocumentCommandResultWithoutRevisionCheck<AutomationTaskSnapshot>(
+            .dispatchDocumentControlCommandResultWithoutRevisionCheck<AutomationTaskSnapshot>(
                 OperationIds::tasks::cancel, context,
                 [this, taskId](DocumentSession &session, const bool validateOnly) {
                     if (!validateOnly)

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.cpp
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.cpp
@@ -5,6 +5,7 @@
 #include "IProjectLoadSession.h"
 #include "AppContext.h"
 #include "Automation/CoreRuntime.h"
+#include "Automation/OperationIds.h"
 #include "Automation/ProjectAutomationDtos.h"
 #include "Controller/EditorViewController.h"
 #include "Controller/TrackController.h"
@@ -20,6 +21,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QLoggingCategory>
 #include <QStandardPaths>
 #include <QState>
 #include <QStateMachine>
@@ -27,6 +29,8 @@
 
 #include <algorithm>
 #include <utility>
+
+Q_LOGGING_CATEGORY(logDocumentWorkflow, "document.workflow")
 
 namespace {
     void addGuardedTransition(QState *source, QObject *sender, const char *signal,
@@ -40,11 +44,30 @@ namespace {
         return AppContext::instance<Automation::CoreRuntime>();
     }
 
-    Automation::CommandContext commandContext(const Automation::DocumentVersion &document) {
-        return {
-            .expected = document,
-            .source = Automation::InvocationSource::TrustedGui,
+    Automation::AutomationResult<Automation::CommandContext> workflowCommitContext(
+        Automation::CoreRuntime *runtime, const Automation::DocumentVersion &generationAnchor) {
+        if (runtime)
+            return runtime->documentWorkflowCommitContext(generationAnchor);
+        return Automation::AutomationError{
+            .code = Automation::AutomationErrorCode::InternalError,
+            .message = QStringLiteral("Automation runtime is unavailable"),
         };
+    }
+
+    void logWorkflowFailure(const quint64 requestId, const QLatin1StringView fallbackOperation,
+                            const Automation::AutomationError &error) {
+        const auto operation =
+            error.operationId.isEmpty() ? fallbackOperation.toString() : error.operationId;
+        const auto expectedRevision = error.expectedRevision
+                                          ? QString::number(*error.expectedRevision)
+                                          : QStringLiteral("n/a");
+        const auto actualRevision = error.actualRevision ? QString::number(*error.actualRevision)
+                                                         : QStringLiteral("n/a");
+        qCWarning(logDocumentWorkflow).nospace()
+            << "commit_failed operation='" << operation << "' request_id=" << requestId
+            << " error_code='" << Automation::errorCodeName(error.code)
+            << "' expected_revision=" << expectedRevision
+            << " actual_revision=" << actualRevision;
     }
 }
 
@@ -73,8 +96,10 @@ void DocumentWorkflowController::initializeNewDocument() {
     newModel.newProject();
     const auto data = newModel.takeProjectData();
     const auto draft = Automation::documentDraftDto(data, LoopSettings());
-    const auto result =
-        runtime->documents().commitNewDocument(commandContext(runtime->documentVersion()), draft);
+    const auto context = runtime->documentWorkflowCommitContext(runtime->documentVersion());
+    if (!context)
+        return;
+    const auto result = runtime->documents().commitNewDocument(context.get(), draft);
     if (!result)
         return;
     emit documentIdentityChanged();
@@ -126,8 +151,8 @@ TerminationRequestResult
     m_pending = {};
     m_pending.requestId = ++m_nextRequestId;
     if (auto *runtime = automationRuntime()) {
-        m_pending.baseDocument = runtime->documentVersion();
-        runtime->setDocumentBusy(m_pending.baseDocument.documentId, true);
+        m_pending.generationAnchor = runtime->documentVersion();
+        runtime->setDocumentBusy(m_pending.generationAnchor.documentId, true);
     }
     m_pending.termination = mode;
     m_skipSaveGuard = savePolicy != TerminationSavePolicy::Prompt;
@@ -232,9 +257,16 @@ void DocumentWorkflowController::initializeStateMachine() {
     addGuardedTransition(m_validatingState, this, SIGNAL(validationCompleted()), m_failedState,
                          [this] { return m_validationResult == ValidationResult::Fail; });
 
-    addGuardedTransition(
-        m_awaitingSaveDecisionState, this, SIGNAL(saveDecisionCompleted()), m_savingState,
-        [this] { return m_saveDecisionResult == SaveDecisionResult::SaveWithPath; });
+    addGuardedTransition(m_awaitingSaveDecisionState, this, SIGNAL(saveDecisionCompleted()),
+                         m_validatingState, [this] {
+                             return m_saveDecisionResult == SaveDecisionResult::SaveWithPath &&
+                                    m_saveResult == SaveResult::SucceededAndResume;
+                         });
+    addGuardedTransition(m_awaitingSaveDecisionState, this, SIGNAL(saveDecisionCompleted()),
+                         m_awaitingSaveDecisionState, [this] {
+                             return m_saveDecisionResult == SaveDecisionResult::SaveWithPath &&
+                                    m_saveResult == SaveResult::FailedAndResume;
+                         });
     addGuardedTransition(
         m_awaitingSaveDecisionState, this, SIGNAL(saveDecisionCompleted()), m_awaitingSavePathState,
         [this] { return m_saveDecisionResult == SaveDecisionResult::SaveWithoutPath; });
@@ -246,8 +278,25 @@ void DocumentWorkflowController::initializeStateMachine() {
                          [this] { return m_saveDecisionResult == SaveDecisionResult::Cancel; });
 
     addGuardedTransition(m_awaitingSavePathState, this, SIGNAL(savePathSelectionCompleted()),
-                         m_savingState,
-                         [this] { return m_savePathResult == SavePathResult::Selected; });
+                         m_validatingState, [this] {
+                             return m_savePathResult == SavePathResult::Selected &&
+                                    m_saveResult == SaveResult::SucceededAndResume;
+                         });
+    addGuardedTransition(m_awaitingSavePathState, this, SIGNAL(savePathSelectionCompleted()),
+                         m_idleState, [this] {
+                             return m_savePathResult == SavePathResult::Selected &&
+                                    m_saveResult == SaveResult::SucceededAndFinish;
+                         });
+    addGuardedTransition(m_awaitingSavePathState, this, SIGNAL(savePathSelectionCompleted()),
+                         m_awaitingSaveDecisionState, [this] {
+                             return m_savePathResult == SavePathResult::Selected &&
+                                    m_saveResult == SaveResult::FailedAndResume;
+                         });
+    addGuardedTransition(m_awaitingSavePathState, this, SIGNAL(savePathSelectionCompleted()),
+                         m_failedState, [this] {
+                             return m_savePathResult == SavePathResult::Selected &&
+                                    m_saveResult == SaveResult::Failed;
+                         });
     addGuardedTransition(m_awaitingSavePathState, this, SIGNAL(savePathSelectionCompleted()),
                          m_idleState,
                          [this] { return m_savePathResult == SavePathResult::Canceled; });
@@ -318,8 +367,8 @@ void DocumentWorkflowController::begin(const DocumentOperation operation, const 
     m_pending = {};
     m_pending.requestId = ++m_nextRequestId;
     if (auto *runtime = automationRuntime()) {
-        m_pending.baseDocument = runtime->documentVersion();
-        runtime->setDocumentBusy(m_pending.baseDocument.documentId, true);
+        m_pending.generationAnchor = runtime->documentVersion();
+        runtime->setDocumentBusy(m_pending.generationAnchor.documentId, true);
     }
     m_pending.operation = operation;
     m_pending.filePath = filePath;
@@ -401,6 +450,7 @@ void DocumentWorkflowController::askSaveDecision() {
             else {
                 m_savePath = projectPath();
                 m_saveDecisionResult = SaveDecisionResult::SaveWithPath;
+                attemptSave();
             }
             break;
         case SaveDecision::Discard:
@@ -422,18 +472,18 @@ void DocumentWorkflowController::askSavePath() {
     }
     m_savePath = m_ui->chooseDocumentSavePath(suggestedSavePath());
     m_savePathResult = m_savePath.isEmpty() ? SavePathResult::Canceled : SavePathResult::Selected;
+    if (m_savePathResult == SavePathResult::Selected)
+        attemptSave();
     emit savePathSelectionCompleted();
 }
 
-void DocumentWorkflowController::performSave() {
+void DocumentWorkflowController::attemptSave() {
     auto *runtime = automationRuntime();
-    const auto result =
-        runtime
-            ? runtime->documents().saveDocument(commandContext(m_pending.baseDocument), m_savePath)
-            : Automation::AutomationResult<Automation::MutationResult>(Automation::AutomationError{
-                  .code = Automation::AutomationErrorCode::InternalError,
-                  .message = QStringLiteral("Automation runtime is unavailable"),
-              });
+    const auto context = workflowCommitContext(runtime, m_pending.generationAnchor);
+    const auto result = context
+                            ? runtime->documents().saveDocument(context.get(), m_savePath)
+                            : Automation::AutomationResult<Automation::MutationResult>(
+                                  context.getError());
     if (result) {
         emit documentIdentityChanged();
         m_lastProjectFolder = QFileInfo(m_savePath).dir().path();
@@ -445,6 +495,8 @@ void DocumentWorkflowController::performSave() {
             m_saveResult = SaveResult::SucceededAndFinish;
         }
     } else {
+        logWorkflowFailure(m_pending.requestId, Automation::OperationIds::documents::save,
+                           result.getError());
         m_error = {tr("Failed to save project"), result.getError().message};
         if (m_resumeAfterSave && m_ui)
             m_ui->showDocumentWorkflowError(m_error);
@@ -453,6 +505,10 @@ void DocumentWorkflowController::performSave() {
         else
             m_saveResult = SaveResult::Failed;
     }
+}
+
+void DocumentWorkflowController::performSave() {
+    attemptSave();
     emit saveCompleted();
 }
 
@@ -518,7 +574,7 @@ void DocumentWorkflowController::commitPreparedProject() {
 
 void DocumentWorkflowController::enterIdle() {
     if (auto *runtime = automationRuntime())
-        runtime->setDocumentBusy(m_pending.baseDocument.documentId, false);
+        runtime->setDocumentBusy(m_pending.generationAnchor.documentId, false);
     closeProgressDialog();
     cleanSession();
     m_pending = {};
@@ -593,10 +649,10 @@ void DocumentWorkflowController::handleSessionCanceled(IProjectLoadSession *sess
     if (session != m_session || session->requestId() != m_pending.requestId)
         return;
     if (m_terminationAfterCancellation) {
-        const auto baseDocument = m_pending.baseDocument;
+        const auto generationAnchor = m_pending.generationAnchor;
         m_pending = {};
         m_pending.requestId = ++m_nextRequestId;
-        m_pending.baseDocument = baseDocument;
+        m_pending.generationAnchor = generationAnchor;
         m_pending.termination = *m_terminationAfterCancellation;
         m_terminationAfterCancellation.reset();
         m_skipSaveGuard = false;
@@ -616,24 +672,29 @@ void DocumentWorkflowController::prepareNewProject() {
 
 bool DocumentWorkflowController::commitReplace(ReplaceProjectPayload &&payload) {
     auto *runtime = automationRuntime();
-    if (!runtime) {
-        m_error = {tr("Failed to apply project"), tr("Automation runtime is unavailable.")};
+    const bool isNew = m_pending.operation == DocumentOperation::New;
+    const auto operationId = isNew ? Automation::OperationIds::documents::commit_new
+                                   : Automation::OperationIds::documents::commit_open;
+    const auto context = workflowCommitContext(runtime, m_pending.generationAnchor);
+    if (!context) {
+        logWorkflowFailure(m_pending.requestId, operationId, context.getError());
+        m_error = {tr("Failed to apply project"), context.getError().message};
         return false;
     }
-    const bool isNew = m_pending.operation == DocumentOperation::New;
     const bool saved = isNew || payload.sourceKind == ProjectSourceKind::Native;
     const auto draft = Automation::documentDraftDto(payload.model, payload.loopSettings);
     Automation::AutomationResult<Automation::MutationResult> result =
         isNew
-            ? runtime->documents().commitNewDocument(commandContext(m_pending.baseDocument), draft)
+            ? runtime->documents().commitNewDocument(context.get(), draft)
             : runtime->documents().commitOpenedDocument(
-                  commandContext(m_pending.baseDocument), draft,
+                  context.get(), draft,
                   payload.sourceKind == ProjectSourceKind::Native ? payload.sourcePath : QString(),
                   payload.sourceKind == ProjectSourceKind::Native
                       ? QFileInfo(payload.sourcePath).fileName()
                       : payload.displayName,
                   saved);
     if (!result) {
+        logWorkflowFailure(m_pending.requestId, operationId, result.getError());
         m_error = {tr("Failed to apply project"), result.getError().message};
         return false;
     }
@@ -649,17 +710,21 @@ bool DocumentWorkflowController::commitReplace(ReplaceProjectPayload &&payload) 
 
 bool DocumentWorkflowController::commitAppend(AppendProjectPayload &&payload) {
     auto *runtime = automationRuntime();
-    if (!runtime) {
-        m_error = {tr("Failed to apply project"), tr("Automation runtime is unavailable.")};
+    const auto context = workflowCommitContext(runtime, m_pending.generationAnchor);
+    if (!context) {
+        logWorkflowFailure(m_pending.requestId, Automation::OperationIds::documents::commit_import,
+                           context.getError());
+        m_error = {tr("Failed to apply project"), context.getError().message};
         return false;
     }
     auto draft = Automation::documentDraftDto(payload.model);
     for (auto &track : draft.tracks)
         track.colorIndex = 0;
     const auto result = runtime->documents().commitImportedDocument(
-        commandContext(m_pending.baseDocument), draft, payload.importTempo,
-        payload.importTimeSignature);
+        context.get(), draft, payload.importTempo, payload.importTimeSignature);
     if (!result) {
+        logWorkflowFailure(m_pending.requestId, Automation::OperationIds::documents::commit_import,
+                           result.getError());
         m_error = {tr("Failed to apply project"), result.getError().message};
         return false;
     }

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.cpp
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.cpp
@@ -331,6 +331,8 @@ void DocumentWorkflowController::initializeStateMachine() {
 
     m_committingState->addTransition(this, &DocumentWorkflowController::commitFinished,
                                      m_idleState);
+    m_committingState->addTransition(
+        this, &DocumentWorkflowController::commitRevalidationRequired, m_validatingState);
     m_committingState->addTransition(this, &DocumentWorkflowController::operationFailed,
                                      m_failedState);
     m_failedState->addTransition(this, &DocumentWorkflowController::failureHandled, m_idleState);
@@ -378,8 +380,9 @@ void DocumentWorkflowController::begin(const DocumentOperation operation, const 
 }
 
 void DocumentWorkflowController::validatePendingRequest() {
-    if (m_pending.operation == DocumentOperation::Open ||
-        m_pending.operation == DocumentOperation::Import) {
+    const bool hasPreparedProject = !std::holds_alternative<std::monostate>(m_prepared);
+    if (!hasPreparedProject && (m_pending.operation == DocumentOperation::Open ||
+                                m_pending.operation == DocumentOperation::Import)) {
         if (!QFile::exists(m_pending.filePath)) {
             m_error = {tr("File not found"), tr("File does not exist: %1").arg(m_pending.filePath)};
             m_validationResult = ValidationResult::Fail;
@@ -406,11 +409,32 @@ void DocumentWorkflowController::validatePendingRequest() {
     const bool needsGuard = m_pending.termination.has_value() ||
                             m_pending.operation == DocumentOperation::New ||
                             m_pending.operation == DocumentOperation::Open;
-    if (needsGuard && !m_skipSaveGuard && !historyManager->isOnSavePoint()) {
-        m_resumeAfterSave = true;
-        m_validationResult = ValidationResult::AwaitSaveDecision;
-        emit validationCompleted();
-        return;
+    if (needsGuard && !m_skipSaveGuard) {
+        auto *runtime = automationRuntime();
+        const auto context = workflowCommitContext(runtime, m_pending.generationAnchor);
+        if (!context) {
+            auto operationId = Automation::OperationIds::documents::commit_open;
+            if (m_pending.operation == DocumentOperation::New)
+                operationId = Automation::OperationIds::documents::commit_new;
+            else if (m_pending.termination == TerminationMode::Exit)
+                operationId = Automation::OperationIds::application::request_exit;
+            else if (m_pending.termination == TerminationMode::Restart)
+                operationId = Automation::OperationIds::application::request_restart;
+            logWorkflowFailure(m_pending.requestId, operationId, context.getError());
+            m_error = {tr("Failed to apply project"), context.getError().message};
+            m_validationResult = ValidationResult::Fail;
+            emit validationCompleted();
+            return;
+        }
+
+        const auto current = context.get().expected;
+        if (!m_pending.revisionGuard.ensureApproved(current,
+                                                    historyManager->isOnSavePoint())) {
+            m_resumeAfterSave = true;
+            m_validationResult = ValidationResult::AwaitSaveDecision;
+            emit validationCompleted();
+            return;
+        }
     }
 
     m_skipSaveGuard = false;
@@ -429,7 +453,10 @@ void DocumentWorkflowController::validatePendingRequest() {
         m_resumeAfterSave = false;
         m_validationResult = ValidationResult::AwaitSavePath;
     } else if (m_pending.operation == DocumentOperation::New) {
-        prepareNewProject();
+        if (std::holds_alternative<std::monostate>(m_prepared))
+            prepareNewProject();
+        m_validationResult = ValidationResult::Commit;
+    } else if (!std::holds_alternative<std::monostate>(m_prepared)) {
         m_validationResult = ValidationResult::Commit;
     } else {
         m_validationResult = ValidationResult::StartSession;
@@ -454,7 +481,12 @@ void DocumentWorkflowController::askSaveDecision() {
             }
             break;
         case SaveDecision::Discard:
-            m_skipSaveGuard = true;
+            if (auto *runtime = automationRuntime()) {
+                const auto context =
+                    workflowCommitContext(runtime, m_pending.generationAnchor);
+                if (context)
+                    m_pending.revisionGuard.approve(context.get().expected);
+            }
             m_saveDecisionResult = SaveDecisionResult::Discard;
             break;
         case SaveDecision::Cancel:
@@ -485,11 +517,12 @@ void DocumentWorkflowController::attemptSave() {
                             : Automation::AutomationResult<Automation::MutationResult>(
                                   context.getError());
     if (result) {
+        if (m_resumeAfterSave)
+            m_pending.revisionGuard.approve(context.get().expected);
         emit documentIdentityChanged();
         m_lastProjectFolder = QFileInfo(m_savePath).dir().path();
         addRecentProjectFile(m_savePath);
         if (m_resumeAfterSave) {
-            m_skipSaveGuard = true;
             m_saveResult = SaveResult::SucceededAndResume;
         } else {
             m_saveResult = SaveResult::SucceededAndFinish;
@@ -552,6 +585,27 @@ void DocumentWorkflowController::startSession() {
 }
 
 void DocumentWorkflowController::commitPreparedProject() {
+    auto *runtime = automationRuntime();
+    const auto context = workflowCommitContext(runtime, m_pending.generationAnchor);
+    auto operationId = Automation::OperationIds::documents::commit_open;
+    if (std::holds_alternative<AppendProjectPayload>(m_prepared))
+        operationId = Automation::OperationIds::documents::commit_import;
+    else if (m_pending.operation == DocumentOperation::New)
+        operationId = Automation::OperationIds::documents::commit_new;
+    if (!context) {
+        logWorkflowFailure(m_pending.requestId, operationId, context.getError());
+        m_error = {tr("Failed to apply project"), context.getError().message};
+        emit operationFailed();
+        return;
+    }
+
+    if (std::holds_alternative<ReplaceProjectPayload>(m_prepared) &&
+        !m_pending.revisionGuard.approves(context.get().expected)) {
+        closeProgressDialog();
+        emit commitRevalidationRequired();
+        return;
+    }
+
     if (m_progressDialog) {
         m_progressDialog->setCancellationEnabled(false);
         m_progressDialog->setMessage(tr("Applying project..."));
@@ -560,9 +614,9 @@ void DocumentWorkflowController::commitPreparedProject() {
 
     bool committed = false;
     if (auto payload = std::get_if<ReplaceProjectPayload>(&m_prepared)) {
-        committed = commitReplace(std::move(*payload));
+        committed = commitReplace(std::move(*payload), context.get());
     } else if (auto payload = std::get_if<AppendProjectPayload>(&m_prepared)) {
-        committed = commitAppend(std::move(*payload));
+        committed = commitAppend(std::move(*payload), context.get());
     } else {
         m_error = {tr("Failed to apply project"), tr("The prepared project is empty.")};
     }
@@ -670,24 +724,19 @@ void DocumentWorkflowController::prepareNewProject() {
     m_prepared = std::move(payload);
 }
 
-bool DocumentWorkflowController::commitReplace(ReplaceProjectPayload &&payload) {
+bool DocumentWorkflowController::commitReplace(ReplaceProjectPayload &&payload,
+                                               const Automation::CommandContext &context) {
     auto *runtime = automationRuntime();
     const bool isNew = m_pending.operation == DocumentOperation::New;
     const auto operationId = isNew ? Automation::OperationIds::documents::commit_new
                                    : Automation::OperationIds::documents::commit_open;
-    const auto context = workflowCommitContext(runtime, m_pending.generationAnchor);
-    if (!context) {
-        logWorkflowFailure(m_pending.requestId, operationId, context.getError());
-        m_error = {tr("Failed to apply project"), context.getError().message};
-        return false;
-    }
     const bool saved = isNew || payload.sourceKind == ProjectSourceKind::Native;
     const auto draft = Automation::documentDraftDto(payload.model, payload.loopSettings);
     Automation::AutomationResult<Automation::MutationResult> result =
         isNew
-            ? runtime->documents().commitNewDocument(context.get(), draft)
+            ? runtime->documents().commitNewDocument(context, draft)
             : runtime->documents().commitOpenedDocument(
-                  context.get(), draft,
+                  context, draft,
                   payload.sourceKind == ProjectSourceKind::Native ? payload.sourcePath : QString(),
                   payload.sourceKind == ProjectSourceKind::Native
                       ? QFileInfo(payload.sourcePath).fileName()
@@ -708,20 +757,14 @@ bool DocumentWorkflowController::commitReplace(ReplaceProjectPayload &&payload) 
     return true;
 }
 
-bool DocumentWorkflowController::commitAppend(AppendProjectPayload &&payload) {
+bool DocumentWorkflowController::commitAppend(AppendProjectPayload &&payload,
+                                              const Automation::CommandContext &context) {
     auto *runtime = automationRuntime();
-    const auto context = workflowCommitContext(runtime, m_pending.generationAnchor);
-    if (!context) {
-        logWorkflowFailure(m_pending.requestId, Automation::OperationIds::documents::commit_import,
-                           context.getError());
-        m_error = {tr("Failed to apply project"), context.getError().message};
-        return false;
-    }
     auto draft = Automation::documentDraftDto(payload.model);
     for (auto &track : draft.tracks)
         track.colorIndex = 0;
     const auto result = runtime->documents().commitImportedDocument(
-        context.get(), draft, payload.importTempo, payload.importTimeSignature);
+        context, draft, payload.importTempo, payload.importTimeSignature);
     if (!result) {
         logWorkflowFailure(m_pending.requestId, Automation::OperationIds::documents::commit_import,
                            result.getError());

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.h
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.h
@@ -4,6 +4,7 @@
 #define documentWorkflowController DocumentWorkflowController::instance()
 
 #include "Automation/AutomationTypes.h"
+#include "DocumentWorkflowRevisionGuard.h"
 #include "ProjectLoadTypes.h"
 #include <lite/Core/Singleton.h>
 
@@ -73,6 +74,7 @@ signals:
     void sessionFailedEvent();
     void sessionCanceledEvent();
     void cancelSessionRequested();
+    void commitRevalidationRequired();
     void commitFinished();
     void failureHandled();
 
@@ -93,6 +95,7 @@ private:
     struct PendingRequest {
         quint64 requestId = 0;
         Automation::DocumentVersion generationAnchor;
+        DocumentWorkflowRevisionGuard revisionGuard;
         std::optional<DocumentOperation> operation;
         std::optional<TerminationMode> termination;
         QString filePath;
@@ -117,8 +120,10 @@ private:
     void handleSessionFailed(IProjectLoadSession *session, const ProjectOperationError &error);
     void handleSessionCanceled(IProjectLoadSession *session);
     void prepareNewProject();
-    bool commitReplace(ReplaceProjectPayload &&payload);
-    bool commitAppend(AppendProjectPayload &&payload);
+    bool commitReplace(ReplaceProjectPayload &&payload,
+                       const Automation::CommandContext &context);
+    bool commitAppend(AppendProjectPayload &&payload,
+                      const Automation::CommandContext &context);
     void activateFirstClip(const QList<Track *> &preferredTracks = {});
     void addRecentProjectFile(const QString &path);
     QString suggestedSavePath() const;

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.h
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.h
@@ -92,7 +92,7 @@ private:
 
     struct PendingRequest {
         quint64 requestId = 0;
-        Automation::DocumentVersion baseDocument;
+        Automation::DocumentVersion generationAnchor;
         std::optional<DocumentOperation> operation;
         std::optional<TerminationMode> termination;
         QString filePath;
@@ -103,6 +103,7 @@ private:
     void validatePendingRequest();
     void askSaveDecision();
     void askSavePath();
+    void attemptSave();
     void performSave();
     void createSession();
     void startSession();

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowRevisionGuard.h
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowRevisionGuard.h
@@ -1,0 +1,29 @@
+#ifndef DOCUMENTWORKFLOWREVISIONGUARD_H
+#define DOCUMENTWORKFLOWREVISIONGUARD_H
+
+#include "Automation/AutomationTypes.h"
+
+#include <optional>
+
+class DocumentWorkflowRevisionGuard final {
+public:
+    [[nodiscard]] bool ensureApproved(const Automation::DocumentVersion &current,
+                                      const bool documentSaved) {
+        if (documentSaved)
+            m_approved = current;
+        return approves(current);
+    }
+
+    void approve(const Automation::DocumentVersion &current) {
+        m_approved = current;
+    }
+
+    [[nodiscard]] bool approves(const Automation::DocumentVersion &current) const {
+        return m_approved && *m_approved == current;
+    }
+
+private:
+    std::optional<Automation::DocumentVersion> m_approved;
+};
+
+#endif // DOCUMENTWORKFLOWREVISIONGUARD_H

--- a/src/app/Modules/Import/DocumentImportController.cpp
+++ b/src/app/Modules/Import/DocumentImportController.cpp
@@ -116,7 +116,7 @@ void DocumentImportController::requestImport(const QStringList &paths,
 
 void DocumentImportController::startPreparation() {
     if (auto *runtime = automationRuntime())
-        m_baseDocument = runtime->documentVersion();
+        m_generationAnchor = runtime->documentVersion();
     m_prepared.clear();
     m_successCount = 0;
     m_canceled = false;
@@ -199,12 +199,17 @@ void DocumentImportController::onAllPrepared() {
 }
 
 void DocumentImportController::commitBatch() {
-    auto *model = appModel;
     auto *runtime = automationRuntime();
     if (!runtime) {
         m_failedMessages.append(tr("Automation runtime is unavailable"));
         return;
     }
+    const auto context = runtime->documentWorkflowCommitContext(m_generationAnchor);
+    if (!context) {
+        m_failedMessages.append(tr("Batch commit failed: %1").arg(context.getError().message));
+        return;
+    }
+    auto *model = appModel;
     const auto language = appOptions->general()->defaultSingingLanguage;
     const auto defaultLyric = appOptions->general()->defaultLyricForLanguage(language);
 
@@ -303,11 +308,7 @@ void DocumentImportController::commitBatch() {
 
     if (batch.items.isEmpty())
         return;
-    Automation::CommandContext context{
-        .expected = m_baseDocument,
-        .source = Automation::InvocationSource::TrustedGui,
-    };
-    const auto result = runtime->project().commitBatchImport(context, batch);
+    const auto result = runtime->project().commitBatchImport(context.get(), batch);
     if (!result) {
         m_successCount = 0;
         m_failedMessages.append(tr("Batch commit failed: %1").arg(result.getError().message));

--- a/src/app/Modules/Import/DocumentImportController.h
+++ b/src/app/Modules/Import/DocumentImportController.h
@@ -52,7 +52,7 @@ private:
     void showMessageDialog(const QString &title, const QString &message) const;
 
     QStringList m_pendingPaths;
-    Automation::DocumentVersion m_baseDocument;
+    Automation::DocumentVersion m_generationAnchor;
     QList<PreparedImportItem> m_prepared;
     DecodeAudioTask *m_currentTask = nullptr;
     std::optional<FileImportDropTarget> m_target;

--- a/src/app/Modules/Inference/InferenceAutomationBridge.cpp
+++ b/src/app/Modules/Inference/InferenceAutomationBridge.cpp
@@ -33,8 +33,8 @@ namespace InferenceAutomationBridge {
     Automation::AutomationResult<Automation::InferenceMutationResultDto>
         executeAfterGate(const Automation::DocumentVersion &taskVersion,
                          const Automation::InferenceMutationRequest &request) {
-        const auto commitVersion =
-            Automation::rebaseTaskVersionWithinGeneration(taskVersion, currentDocumentVersion());
+        const auto commitVersion = Automation::rebaseDocumentVersionWithinGeneration(
+            taskVersion, currentDocumentVersion());
         if (!commitVersion)
             return commitVersion.getError();
         return execute(commitVersion.get(), request);

--- a/src/tests/TestAutomationAsyncFileDomains/main.cpp
+++ b/src/tests/TestAutomationAsyncFileDomains/main.cpp
@@ -190,7 +190,7 @@ namespace {
             const auto sharedBase = runtime.documentVersion();
             const auto first =
                 runtime.inference().applyMutation(RuntimeHarness::contextFor(sharedBase), request);
-            const auto rebased = Automation::rebaseTaskVersionWithinGeneration(
+            const auto rebased = Automation::rebaseDocumentVersionWithinGeneration(
                 sharedBase, runtime.documentVersion());
             auto siblingRequest = request;
             siblingRequest.kind = Automation::InferenceMutationKind::ApplyVariance;
@@ -206,10 +206,19 @@ namespace {
 
             const auto staleGeneration =
                 Automation::DocumentVersion{Automation::DocumentId::create(), sharedBase.revision};
-            const auto rejectedRebase = Automation::rebaseTaskVersionWithinGeneration(
+            const auto workflowContext = runtime.documentWorkflowCommitContext(sharedBase);
+            const auto rejectedRebase = Automation::rebaseDocumentVersionWithinGeneration(
                 staleGeneration, runtime.documentVersion());
-            suite.expect(isError(rejectedRebase, Automation::AutomationErrorCode::DocumentChanged),
-                         QStringLiteral("sibling rebasing must never cross a document generation"));
+            const auto rejectedWorkflowContext =
+                runtime.documentWorkflowCommitContext(staleGeneration);
+            suite.expect(
+                workflowContext && workflowContext.get().expected == runtime.documentVersion() &&
+                    workflowContext.get().source == Automation::InvocationSource::TrustedGui &&
+                    isError(rejectedRebase, Automation::AutomationErrorCode::DocumentChanged) &&
+                    isError(rejectedWorkflowContext,
+                            Automation::AutomationErrorCode::DocumentChanged),
+                QStringLiteral(
+                    "same-generation workflows must use the current revision without crossing generations"));
 
             const auto staleContext = RuntimeHarness::contextFor(runtime.documentVersion());
             const auto preparesBeforeReplacement = harness.inferencePrepareCount;

--- a/src/tests/TestAutomationCore/main.cpp
+++ b/src/tests/TestAutomationCore/main.cpp
@@ -125,6 +125,7 @@ int main(int argc, char *argv[]) {
     publicCommand.expected = first.version();
     publicCommand.source = Automation::InvocationSource::PublicMcp;
     int publicHandlerCalls = 0;
+    const auto publicValidationBusy = dispatcher.validateDocumentCommand(publicCommand);
     const auto publicBusy = dispatcher.dispatchDocumentCommand(
         QStringLiteral("test.command"), publicCommand,
         [&publicHandlerCalls](Automation::DocumentSession &session, const bool validateOnly) {
@@ -154,13 +155,27 @@ int main(int argc, char *argv[]) {
         [](Automation::DocumentSession &session, const bool validateOnly) {
             return commit(session, validateOnly);
         });
-    ok &= expect(queryWhileBusy && queryWhileBusy.get() == first.revision() && !publicBusy &&
+    ok &= expect(queryWhileBusy && queryWhileBusy.get() == first.revision() &&
+                     !publicValidationBusy &&
+                     publicValidationBusy.getError().code ==
+                         Automation::AutomationErrorCode::Busy &&
+                     !publicBusy &&
                      publicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
                      !stalePublicBusy &&
                      stalePublicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
                      publicHandlerCalls == 0 && trustedPreview && internalPreview,
-                 "workflow busy must reject public commands while allowing queries and trusted work");
+                 "workflow busy must reject public commands while allowing queries and trusted "
+                 "work");
     first.setBusy(false);
+    publicCommand.expected = first.version();
+    const auto publicValidation = dispatcher.validateDocumentCommand(publicCommand);
+    ++publicCommand.expected.revision;
+    const auto stalePublicValidation = dispatcher.validateDocumentCommand(publicCommand);
+    ok &= expect(publicValidation && publicValidation.get() == first.version() &&
+                     !stalePublicValidation &&
+                     stalePublicValidation.getError().code ==
+                         Automation::AutomationErrorCode::RevisionConflict,
+                 "public async admission must share the dispatcher revision contract");
 
     auto unsupportedKey = command;
     unsupportedKey.expected = first.version();

--- a/src/tests/TestAutomationCore/main.cpp
+++ b/src/tests/TestAutomationCore/main.cpp
@@ -139,6 +139,26 @@ int main(int argc, char *argv[]) {
             ++publicHandlerCalls;
             return commit(session, validateOnly);
         });
+    auto publicControl = publicCommand;
+    publicControl.expected = first.version();
+    publicControl.validateOnly = true;
+    const auto allowedControl = dispatcher.dispatchDocumentControlCommand(
+        QStringLiteral("test.control"), publicControl,
+        [](Automation::DocumentSession &session, const bool validateOnly) {
+            return commit(session, validateOnly);
+        });
+    ++publicControl.expected.revision;
+    const auto staleControl = dispatcher.dispatchDocumentControlCommand(
+        QStringLiteral("test.control"), publicControl,
+        [](Automation::DocumentSession &session, const bool validateOnly) {
+            return commit(session, validateOnly);
+        });
+    const auto allowedCancellation =
+        dispatcher.dispatchDocumentControlCommandResultWithoutRevisionCheck<Automation::Revision>(
+            QStringLiteral("test.cancel"), publicControl,
+            [](Automation::DocumentSession &session, const bool) {
+                return Automation::AutomationResult<Automation::Revision>(session.revision());
+            });
     auto trustedCommand = publicCommand;
     trustedCommand.expected = first.version();
     trustedCommand.validateOnly = true;
@@ -155,17 +175,17 @@ int main(int argc, char *argv[]) {
         [](Automation::DocumentSession &session, const bool validateOnly) {
             return commit(session, validateOnly);
         });
-    ok &= expect(queryWhileBusy && queryWhileBusy.get() == first.revision() &&
-                     !publicValidationBusy &&
-                     publicValidationBusy.getError().code ==
-                         Automation::AutomationErrorCode::Busy &&
-                     !publicBusy &&
-                     publicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
-                     !stalePublicBusy &&
-                     stalePublicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
-                     publicHandlerCalls == 0 && trustedPreview && internalPreview,
-                 "workflow busy must reject public commands while allowing queries and trusted "
-                 "work");
+    ok &= expect(
+        queryWhileBusy && queryWhileBusy.get() == first.revision() && !publicValidationBusy &&
+            publicValidationBusy.getError().code == Automation::AutomationErrorCode::Busy &&
+            !publicBusy && publicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
+            !stalePublicBusy &&
+            stalePublicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
+            publicHandlerCalls == 0 && allowedControl && !staleControl &&
+            staleControl.getError().code == Automation::AutomationErrorCode::RevisionConflict &&
+            allowedCancellation && trustedPreview && internalPreview,
+        "workflow busy must reject public mutations while allowing document controls, "
+        "queries, and trusted work");
     first.setBusy(false);
     publicCommand.expected = first.version();
     const auto publicValidation = dispatcher.validateDocumentCommand(publicCommand);

--- a/src/tests/TestAutomationCore/main.cpp
+++ b/src/tests/TestAutomationCore/main.cpp
@@ -116,7 +116,21 @@ int main(int argc, char *argv[]) {
                      staleHandlerCalls == 0,
                  "stale revisions must be rejected before entering the handler");
 
+    auto admittedTaskCommand = command;
+    admittedTaskCommand.expected = first.version();
+    admittedTaskCommand.source = Automation::InvocationSource::PublicMcp;
+    const auto admittedTaskBase = dispatcher.admitDocumentTask(admittedTaskCommand);
     first.setBusy(true);
+    const auto admittedTaskCompletion = dispatcher.dispatchDocumentCommand(
+        QStringLiteral("test.task.complete"), admittedTaskCommand,
+        [](Automation::DocumentSession &session, const bool validateOnly) {
+            return commit(session, validateOnly);
+        });
+    const auto staleTaskCompletion = dispatcher.dispatchDocumentCommand(
+        QStringLiteral("test.task.complete"), admittedTaskCommand,
+        [](Automation::DocumentSession &session, const bool validateOnly) {
+            return commit(session, validateOnly);
+        });
     const auto queryWhileBusy = dispatcher.dispatchDocumentQuery<Automation::Revision>(
         QStringLiteral("test.query"), first.documentId(), [](Automation::DocumentSession &session) {
             return Automation::AutomationResult<Automation::Revision>(session.revision());
@@ -126,6 +140,8 @@ int main(int argc, char *argv[]) {
     publicCommand.source = Automation::InvocationSource::PublicMcp;
     int publicHandlerCalls = 0;
     const auto publicValidationBusy = dispatcher.validateDocumentCommand(publicCommand);
+    auto rejectedTaskCommand = publicCommand;
+    const auto rejectedTaskAdmission = dispatcher.admitDocumentTask(rejectedTaskCommand);
     const auto publicBusy = dispatcher.dispatchDocumentCommand(
         QStringLiteral("test.command"), publicCommand,
         [&publicHandlerCalls](Automation::DocumentSession &session, const bool validateOnly) {
@@ -176,16 +192,24 @@ int main(int argc, char *argv[]) {
             return commit(session, validateOnly);
         });
     ok &= expect(
-        queryWhileBusy && queryWhileBusy.get() == first.revision() && !publicValidationBusy &&
+        admittedTaskBase &&
+            admittedTaskCommand.source == Automation::InvocationSource::PublicMcpContinuation &&
+            admittedTaskCompletion && !staleTaskCompletion &&
+            staleTaskCompletion.getError().code ==
+                Automation::AutomationErrorCode::RevisionConflict &&
+            queryWhileBusy && queryWhileBusy.get() == first.revision() && !publicValidationBusy &&
             publicValidationBusy.getError().code == Automation::AutomationErrorCode::Busy &&
+            !rejectedTaskAdmission &&
+            rejectedTaskAdmission.getError().code == Automation::AutomationErrorCode::Busy &&
+            rejectedTaskCommand.source == Automation::InvocationSource::PublicMcp &&
             !publicBusy && publicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
             !stalePublicBusy &&
             stalePublicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
             publicHandlerCalls == 0 && allowedControl && !staleControl &&
             staleControl.getError().code == Automation::AutomationErrorCode::RevisionConflict &&
             allowedCancellation && trustedPreview && internalPreview,
-        "workflow busy must reject public mutations while allowing document controls, "
-        "queries, and trusted work");
+        "workflow busy must reject new public mutations while allowing admitted tasks, document "
+        "controls, queries, and trusted work");
     first.setBusy(false);
     publicCommand.expected = first.version();
     const auto publicValidation = dispatcher.validateDocumentCommand(publicCommand);

--- a/src/tests/TestAutomationCore/main.cpp
+++ b/src/tests/TestAutomationCore/main.cpp
@@ -116,6 +116,52 @@ int main(int argc, char *argv[]) {
                      staleHandlerCalls == 0,
                  "stale revisions must be rejected before entering the handler");
 
+    first.setBusy(true);
+    const auto queryWhileBusy = dispatcher.dispatchDocumentQuery<Automation::Revision>(
+        QStringLiteral("test.query"), first.documentId(), [](Automation::DocumentSession &session) {
+            return Automation::AutomationResult<Automation::Revision>(session.revision());
+        });
+    auto publicCommand = command;
+    publicCommand.expected = first.version();
+    publicCommand.source = Automation::InvocationSource::PublicMcp;
+    int publicHandlerCalls = 0;
+    const auto publicBusy = dispatcher.dispatchDocumentCommand(
+        QStringLiteral("test.command"), publicCommand,
+        [&publicHandlerCalls](Automation::DocumentSession &session, const bool validateOnly) {
+            ++publicHandlerCalls;
+            return commit(session, validateOnly);
+        });
+    ++publicCommand.expected.revision;
+    const auto stalePublicBusy = dispatcher.dispatchDocumentCommand(
+        QStringLiteral("test.command"), publicCommand,
+        [&publicHandlerCalls](Automation::DocumentSession &session, const bool validateOnly) {
+            ++publicHandlerCalls;
+            return commit(session, validateOnly);
+        });
+    auto trustedCommand = publicCommand;
+    trustedCommand.expected = first.version();
+    trustedCommand.validateOnly = true;
+    trustedCommand.source = Automation::InvocationSource::TrustedGui;
+    const auto trustedPreview = dispatcher.dispatchDocumentCommand(
+        QStringLiteral("test.command"), trustedCommand,
+        [](Automation::DocumentSession &session, const bool validateOnly) {
+            return commit(session, validateOnly);
+        });
+    auto internalCommand = trustedCommand;
+    internalCommand.source = Automation::InvocationSource::InternalAutomation;
+    const auto internalPreview = dispatcher.dispatchDocumentCommand(
+        QStringLiteral("test.command"), internalCommand,
+        [](Automation::DocumentSession &session, const bool validateOnly) {
+            return commit(session, validateOnly);
+        });
+    ok &= expect(queryWhileBusy && queryWhileBusy.get() == first.revision() && !publicBusy &&
+                     publicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
+                     !stalePublicBusy &&
+                     stalePublicBusy.getError().code == Automation::AutomationErrorCode::Busy &&
+                     publicHandlerCalls == 0 && trustedPreview && internalPreview,
+                 "workflow busy must reject public commands while allowing queries and trusted work");
+    first.setBusy(false);
+
     auto unsupportedKey = command;
     unsupportedKey.expected = first.version();
     unsupportedKey.idempotencyKey = QStringLiteral("unsupported-key");

--- a/src/tests/TestAutomationDocumentLifecycle/main.cpp
+++ b/src/tests/TestAutomationDocumentLifecycle/main.cpp
@@ -53,6 +53,7 @@ namespace {
         int saveCalls = 0;
         QString lastSavePath;
         QString lateSaveTarget;
+        QByteArray lastSavedModel;
         QList<Automation::DocumentId> replacementNotifications;
     };
 
@@ -61,13 +62,15 @@ namespace {
         services.applyLoopSettings = [&host](const LoopSettings &settings) {
             host.loopSettings = settings;
         };
-        services.saveProject = [&host](const QString &path, AppModel *, QString &errorMessage) {
+        services.saveProject = [&host](const QString &path, AppModel *model,
+                                       QString &errorMessage) {
             ++host.saveCalls;
             host.lastSavePath = path;
             if (!host.saveSucceeds) {
                 errorMessage = QStringLiteral("controlled save failure");
                 return false;
             }
+            host.lastSavedModel = QJsonDocument(model->serialize()).toJson(QJsonDocument::Compact);
             QFile staged(path);
             if (!staged.open(QIODevice::WriteOnly) || staged.write("project") != 7) {
                 errorMessage = QStringLiteral("controlled staging failure");
@@ -510,22 +513,39 @@ namespace {
         const auto dirtyVersion = runtime.documentVersion();
         const auto dirtySnapshot = runtime.documents().getDocument(dirtyVersion.documentId);
         const auto firstPath = directory.filePath(QStringLiteral("first-save-as.dspx"));
-        const auto saveAs = runtime.documents().saveDocument(commandContext(runtime), firstPath);
+        const auto revisionDuringSaveDialog = runtime.timeline().setTempo(
+            commandContext(runtime), 960, 128.0);
+        const auto confirmedVersion = runtime.documentVersion();
+        const auto saveContext = runtime.documentWorkflowCommitContext(dirtyVersion);
+        const auto saveAs =
+            saveContext
+                ? runtime.documents().saveDocument(saveContext.get(), firstPath)
+                : Automation::AutomationResult<Automation::MutationResult>(saveContext.getError());
         const auto afterSaveAs = runtime.documents().getDocument(dirtyVersion.documentId);
+        const auto modelAtConfirmation =
+            QJsonDocument(fixture.model.serialize()).toJson(QJsonDocument::Compact);
 
         test.expect(committedNew && imported && dirtySnapshot && !dirtySnapshot.get().saved &&
-                        saveAs && runtime.documentVersion() == dirtyVersion &&
+                        revisionDuringSaveDialog && saveContext && saveAs &&
+                        runtime.documentVersion() == confirmedVersion &&
                         fixture.host.saveCalls == 1 && afterSaveAs &&
                         afterSaveAs.get().path == firstPath &&
                         afterSaveAs.get().projectName == QStringLiteral("first-save-as.dspx") &&
-                        afterSaveAs.get().saved,
-                    scenario, "save-as must preserve identity/revision and set path/savepoint");
+                        afterSaveAs.get().saved &&
+                        fixture.host.lastSavedModel == modelAtConfirmation,
+                    scenario,
+                    "save-as must commit the current same-generation state after path "
+                    "confirmation");
 
-        const auto edited = runtime.timeline().setTempo(commandContext(runtime), 960, 128.0);
+        const auto savedModel = fixture.host.lastSavedModel;
+        const auto edited = runtime.timeline().setTempo(commandContext(runtime), 1920, 132.0);
         const auto versionBeforeSave = runtime.documentVersion();
+        const auto modelAfterConfirmation =
+            QJsonDocument(fixture.model.serialize()).toJson(QJsonDocument::Compact);
         const auto save = runtime.documents().saveDocument(commandContext(runtime), firstPath);
         const auto afterSave = runtime.documents().getDocument(versionBeforeSave.documentId);
-        test.expect(edited && save && runtime.documentVersion() == versionBeforeSave &&
+        test.expect(edited && savedModel != modelAfterConfirmation && save &&
+                        runtime.documentVersion() == versionBeforeSave &&
                         fixture.host.saveCalls == 2 && afterSave &&
                         afterSave.get().path == firstPath && afterSave.get().saved,
                     scenario,

--- a/src/tests/TestAutomationDocumentLifecycle/main.cpp
+++ b/src/tests/TestAutomationDocumentLifecycle/main.cpp
@@ -389,6 +389,42 @@ namespace {
             "reject the old generation");
     }
 
+    void testWorkflowBusyLeaseAcrossReplacement(TestRun &test) {
+        constexpr auto scenario = "AFC-DOC-LIFECYCLE-WORKFLOW-BUSY";
+        LifecycleFixture fixture;
+        auto &runtime = fixture.runtime;
+        const auto original = runtime.documentVersion();
+        auto continuation = commandContext(runtime);
+        continuation.source = Automation::InvocationSource::PublicMcp;
+        const auto admitted = runtime.dispatcher().admitDocumentTask(continuation);
+        const bool acquired = runtime.setDocumentBusy(original.documentId, true);
+        const auto replacement = runtime.documents().commitOpenedDocument(
+            continuation,
+            makeDocumentDraft(QStringLiteral("Busy Replacement"),
+                              QStringLiteral("busy-replacement")),
+            QStringLiteral("fixtures/busy-replacement.dspx"),
+            QStringLiteral("busy-replacement.dspx"), true);
+        const auto current = runtime.documentVersion();
+        const bool busyAfterReplacement = runtime.documentBusy(current.documentId);
+
+        Automation::CommandContext publicMutation{
+            .expected = current,
+            .source = Automation::InvocationSource::PublicMcp,
+        };
+        const auto blocked = runtime.timeline().setTempo(publicMutation, 960, 131.0);
+        const bool released = runtime.setDocumentBusy(original.documentId, false);
+        const auto committed = runtime.timeline().setTempo(publicMutation, 960, 131.0);
+
+        test.expect(
+            admitted && acquired && replacement && current.documentId != original.documentId &&
+                busyAfterReplacement && released && !runtime.documentBusy(current.documentId) &&
+                !blocked && blocked.getError().code == Automation::AutomationErrorCode::Busy &&
+                committed,
+            scenario,
+            "workflow busy must cross task-driven replacement, reject new public mutations, and "
+            "remain releasable by its original generation");
+    }
+
     void testFailureAndCancellationRollback(TestRun &test) {
         constexpr auto scenario = "AFC-DOC-LIFECYCLE-005";
         LifecycleFixture fixture;
@@ -822,6 +858,7 @@ int main(int argc, char *argv[]) {
 
     testInitialUntitledSession(test);
     testNewOpenAndImport(test);
+    testWorkflowBusyLeaseAcrossReplacement(test);
     testFailureAndCancellationRollback(test);
     testSaveAndSaveAs(test);
     testGenerationCleanup(test);

--- a/src/tests/TestAutomationIdempotency/main.cpp
+++ b/src/tests/TestAutomationIdempotency/main.cpp
@@ -100,6 +100,40 @@ namespace {
                           "ordinary dispatch must reject a key and otherwise bypass the cache"));
     }
 
+    bool completedReplayPrecedesWorkflowBusyAdmission() {
+        AutomationTestSupport::TestRuntime fixture;
+        auto &runtime = fixture.runtime();
+        auto context =
+            commandContext(runtime, QStringLiteral("d0d00000-0000-4000-8000-000000000008"));
+        context.source = Automation::InvocationSource::PublicMcp;
+        int executions = 0;
+        const auto handler = countedHandler(executions);
+        const auto first = runtime.dispatcher().dispatchIdempotentDocumentCommand(
+            Automation::OperationIds::tracks::insert, context, QByteArrayLiteral("alpha"), handler);
+
+        runtime.setDocumentBusy(context.expected.documentId, true);
+        const auto replay = runtime.dispatcher().dispatchIdempotentDocumentCommand(
+            Automation::OperationIds::tracks::insert, context, QByteArrayLiteral("alpha"), handler);
+        const auto conflict = runtime.dispatcher().dispatchIdempotentDocumentCommand(
+            Automation::OperationIds::tracks::insert, context, QByteArrayLiteral("beta"), handler);
+        auto newContext =
+            commandContext(runtime, QStringLiteral("d0d00000-0000-4000-8000-000000000009"));
+        newContext.source = Automation::InvocationSource::PublicMcp;
+        const auto blocked = runtime.dispatcher().dispatchIdempotentDocumentCommand(
+            Automation::OperationIds::tracks::insert, newContext, QByteArrayLiteral("alpha"),
+            handler);
+        runtime.setDocumentBusy(context.expected.documentId, false);
+
+        return expect(
+                   first && replay && replay.get() == first.get() && executions == 1,
+                   QStringLiteral("completed replay must remain available while workflow busy")) &&
+               expect(!conflict && conflict.getError().code ==
+                                       Automation::AutomationErrorCode::IdempotencyConflict,
+                      QStringLiteral("claimed key conflicts must precede workflow busy")) &&
+               expect(!blocked && blocked.getError().code == Automation::AutomationErrorCode::Busy,
+                      QStringLiteral("workflow busy must still reject a new idempotent mutation"));
+    }
+
     bool concurrentReplayExecutesOnce() {
         constexpr int LaneCount = 8;
         AutomationTestSupport::TestRuntime fixture;
@@ -296,6 +330,7 @@ int main(int argc, char *argv[]) {
     QCoreApplication application(argc, argv);
     bool ok = true;
     ok &= serialReplayAndExplicitOptIn();
+    ok &= completedReplayPrecedesWorkflowBusyAdmission();
     ok &= concurrentReplayExecutesOnce();
     ok &= unsuccessfulAttemptsDoNotClaimKeys();
     ok &= documentsAndGenerationsHaveIndependentKeySpaces();

--- a/src/tests/TestAutomationRuntimeDomains/main.cpp
+++ b/src/tests/TestAutomationRuntimeDomains/main.cpp
@@ -756,6 +756,31 @@ namespace {
             unsupportedKey, Automation::AutomationErrorCode::InvalidArgument,
             Automation::OperationIds::playback::pause,
             QStringLiteral("ephemeral playback state must reject document idempotency"));
+
+        log.scenario(QStringLiteral("PLAY-C-WORKFLOW-BUSY"));
+        auto publicControl = commandContext(runtime);
+        publicControl.source = Automation::InvocationSource::PublicMcp;
+        runtime.setDocumentBusy(publicControl.expected.documentId, true);
+        harness.playback.state = Automation::PlaybackState::Playing;
+        const auto pauseWhileBusy = runtime.playback().pause(publicControl);
+        const auto seekWhileBusy = runtime.playback().seek(publicControl, 1440.0);
+        const auto loopWhileBusy =
+            runtime.playback().setLoop(publicControl, LoopSettings(false, 480, 960));
+        ++publicControl.expected.revision;
+        const auto staleSeekWhileBusy = runtime.playback().seek(publicControl, 1920.0);
+        runtime.setDocumentBusy(publicControl.expected.documentId, false);
+        log.expect(pauseWhileBusy && pauseWhileBusy.get().changed &&
+                       harness.playback.state == Automation::PlaybackState::Paused &&
+                       harness.pauseCalls == 2 && seekWhileBusy && seekWhileBusy.get().changed &&
+                       harness.playback.position == 1440.0 &&
+                       harness.playback.lastPosition == 1440.0,
+                   QStringLiteral("workflow busy must keep transient playback control available"));
+        log.expectError(loopWhileBusy, Automation::AutomationErrorCode::Busy,
+                        Automation::OperationIds::playback::set_loop,
+                        QStringLiteral("workflow busy must reject persistent playback changes"));
+        log.expectError(staleSeekWhileBusy, Automation::AutomationErrorCode::RevisionConflict,
+                        Automation::OperationIds::playback::seek,
+                        QStringLiteral("transient playback control must still validate revision"));
     }
 
     using GuiResult = Automation::AutomationResult<Automation::GuiMutationResult>;

--- a/src/tests/TestAutomationTaskRaces/main.cpp
+++ b/src/tests/TestAutomationTaskRaces/main.cpp
@@ -605,6 +605,27 @@ namespace {
                        stableCancel.get().state == Automation::AutomationTaskState::Succeeded,
                    "cancel-after-success must return the stable successful snapshot");
         }
+
+        checks.scenario("public task cancellation while document workflow is busy");
+        {
+            AutomationTestSupport::TestRuntime fixture;
+            auto &runtime = fixture.runtime();
+            const auto base = runtime.documentVersion();
+            int cancelCallbackCount = 0;
+            const auto task = runtime.automationTasks().createTask(
+                Automation::OperationIds::extract::pitch::start, base, std::nullopt,
+                [&cancelCallbackCount] { ++cancelCallbackCount; });
+            const bool running = runtime.automationTasks().markRunning(task.taskId);
+            const bool busy = runtime.setDocumentBusy(base.documentId, true);
+            const auto canceled = runtime.tasks().cancelTask(
+                {.expected = base, .source = Automation::InvocationSource::PublicMcp}, task.taskId);
+            runtime.setDocumentBusy(base.documentId, false);
+            EXPECT(checks,
+                   running && busy && canceled &&
+                       canceled.get().state == Automation::AutomationTaskState::CancelRequested &&
+                       cancelCallbackCount == 1,
+                   "workflow busy must not prevent a public client from canceling its task");
+        }
     }
 
     void testCommittingGenerationReplacement(Checks &checks) {

--- a/src/tests/TestDocumentWorkflow/main.cpp
+++ b/src/tests/TestDocumentWorkflow/main.cpp
@@ -1,4 +1,5 @@
 #include "Controller/DocumentWorkflow/DocumentWorkflowPathUtils.h"
+#include "Controller/DocumentWorkflow/DocumentWorkflowRevisionGuard.h"
 #include "Model/AppStatus/AppStatus.h"
 #include <lite/History/ActionSequence.h>
 #include "AppContext.h"
@@ -134,6 +135,29 @@ namespace {
                      "existing DSPX project path must remain unchanged");
         return ok;
     }
+
+    bool verifyRevisionGuard() {
+        DocumentWorkflowRevisionGuard guard;
+        const Automation::DocumentVersion original{Automation::DocumentId::create(), 194};
+        const Automation::DocumentVersion advanced{original.documentId, 225};
+        const Automation::DocumentVersion replacement{Automation::DocumentId::create(), 0};
+
+        bool ok = true;
+        ok &= expect(!guard.ensureApproved(original, false),
+                     "an unconfirmed dirty revision must not permit replacement");
+        ok &= expect(guard.ensureApproved(original, true),
+                     "a saved revision must permit replacement");
+        ok &= expect(guard.ensureApproved(original, false),
+                     "the approved revision must remain valid while unchanged");
+        ok &= expect(!guard.ensureApproved(advanced, false),
+                     "a later dirty revision must require confirmation again");
+        guard.approve(advanced);
+        ok &= expect(guard.approves(advanced),
+                     "explicit confirmation must approve the current revision");
+        ok &= expect(!guard.approves(replacement),
+                     "approval must never carry into another generation");
+        return ok;
+    }
 }
 
 int main(int argc, char *argv[]) {
@@ -201,6 +225,7 @@ int main(int argc, char *argv[]) {
     ok &= expect(verifyGuardedBranch(true), "true guard must select the true target state");
     ok &= expect(verifyGuardedBranch(false), "false guard must select the false target state");
     ok &= verifySuggestedSavePaths();
+    ok &= verifyRevisionGuard();
 
     return ok ? 0 : 1;
 }

--- a/src/tests/TestMidiImportAutomation/main.cpp
+++ b/src/tests/TestMidiImportAutomation/main.cpp
@@ -14,6 +14,8 @@
 #include <QTemporaryDir>
 #include <QTextStream>
 
+#include <utility>
+
 namespace {
     class Suite final {
     public:
@@ -279,6 +281,62 @@ namespace {
 
         history->reset();
     }
+
+    void testPreparedBatchCommitBoundaries(Suite &suite) {
+        AppModel destination;
+        destination.newProject();
+        auto *history = HistoryManager::instance();
+        history->reset(HistoryManager::ResetState::Saved);
+        Automation::CoreRuntime runtime(&destination, history);
+
+        auto parsed = makeParsedMidi();
+        auto generated = generateSelectedTrack(parsed);
+        auto draft = makeImportDraft(generated);
+        Automation::BatchImportDraftDto batch;
+        batch.timeline = destination.timeline();
+        Automation::BatchImportItemDraftDto item;
+        item.newTrack = std::move(draft.tracks.first());
+        item.clips = std::move(item.newTrack.clips);
+        item.newTrack.clips.clear();
+        batch.items.append(std::move(item));
+
+        suite.run(QStringLiteral("prepared-batch-rebases-after-options-confirmation"), [&] {
+            const auto generationAnchor = runtime.documentVersion();
+            const auto interveningEdit =
+                runtime.timeline().setTempo(context(runtime), 960, 132.0);
+            const auto confirmedVersion = runtime.documentVersion();
+            batch.timeline = destination.timeline();
+            const auto commitContext =
+                runtime.documentWorkflowCommitContext(generationAnchor);
+            const auto committed =
+                commitContext
+                    ? runtime.project().commitBatchImport(commitContext.get(), batch)
+                    : Automation::AutomationResult<Automation::MutationResult>(
+                          commitContext.getError());
+            suite.expect(interveningEdit && commitContext &&
+                             commitContext.get().expected == confirmedVersion && committed &&
+                             committed.get().previous == confirmedVersion &&
+                             committed.get().current.revision == confirmedVersion.revision + 1,
+                         QStringLiteral("confirmed imports must commit against the current "
+                                        "same-generation document"));
+        });
+
+        suite.run(QStringLiteral("deleted-target-rejects-batch-atomically"), [&] {
+            auto missingTarget = batch;
+            missingTarget.timeline = destination.timeline();
+            missingTarget.items.first().existingTrackId = Automation::TrackId(999999);
+            const auto before = runtime.documentVersion();
+            const auto rejected =
+                runtime.project().commitBatchImport(context(runtime), missingTarget);
+            suite.expect(!rejected &&
+                             rejected.getError().code ==
+                                 Automation::AutomationErrorCode::NotFound &&
+                             runtime.documentVersion() == before,
+                         QStringLiteral("a deleted destination track must reject the whole batch"));
+        });
+
+        history->reset();
+    }
 }
 
 int main(int argc, char *argv[]) {
@@ -287,5 +345,6 @@ int main(int argc, char *argv[]) {
     testBatchPreparationFailures(suite);
     testSelectionAndGeometry(suite);
     testFacadeCommitUndoRedo(suite);
+    testPreparedBatchCommitBoundaries(suite);
     return suite.finish();
 }


### PR DESCRIPTION
## 问题

GUI 文档工作流在弹窗前捕获 revision。另存为弹窗期间，推理写回可推进 revision，最终保存仍携带旧 revision，因而出现 `revision_conflict`。

## 改动

- 将同代版本重定位泛化为共享能力，并提供可信 GUI 文档提交 context。
- Save/Save As 在用户完成最终确认后同步取得同代当前 revision 并保存；New/Open/Import 在不可撤销提交边界重新取得 context。
- GUI 文档工作流 busy 时统一拒绝同步及异步 Public MCP 文档命令；公共 MCP 仍严格使用调用方的 `expected_revision`，查询与内部写回不受影响。
- 批量 MIDI/音频导入在选项确认后、读取当前时间轴和目标轨前取得同代 context。
- 增加 `document.workflow` 结构化失败日志及回归测试。

## 验证

- Debug preset 完整 configure/build：通过。
- 定向及相关回归：7/7 通过（Automation Core、Idempotency、Document Lifecycle、Async File Domains、Public Registry、Document Workflow、MIDI Import）。
- 完整 CTest：62/63 通过。唯一失败 `TestMcpProcessIntegration` 为 Editor 在 `server_ready` 前以 `0xC0000005` 退出；已切换到未修改的 `main` 重建并单独复现相同失败，确认是当前环境的基线问题。