### PR TITLE
fix(dspx): preserve tone shift and mouth opening parameters

### DIFF
--- a/src/libs/ProjectConverters/DspxProjectConverter.cpp
+++ b/src/libs/ProjectConverters/DspxProjectConverter.cpp
@@ -866,8 +866,10 @@ bool DspxProjectConverter::loadParsedProject(const opendspx::Model &dspxModel, A
         params.breathiness = std::move(decodeSingingParam(dspxParams_["breathiness"], clip));
         params.voicing = std::move(decodeSingingParam(dspxParams_["voicing"], clip));
         params.tension = std::move(decodeSingingParam(dspxParams_["tension"], clip));
+        params.mouthOpening = std::move(decodeSingingParam(dspxParams_["mouthOpening"], clip));
         params.gender = std::move(decodeSingingParam(dspxParams_["gender"], clip));
         params.velocity = std::move(decodeSingingParam(dspxParams_["velocity"], clip));
+        params.toneShift = std::move(decodeSingingParam(dspxParams_["toneShift"], clip));
         return params;
     };
 
@@ -1158,8 +1160,10 @@ bool DspxProjectConverter::save(const QString &path, AppModel *model, QString &e
         encodeSingingParam(dsParams.breathiness, params["breathiness"]);
         encodeSingingParam(dsParams.voicing, params["voicing"]);
         encodeSingingParam(dsParams.tension, params["tension"]);
+        encodeSingingParam(dsParams.mouthOpening, params["mouthOpening"]);
         encodeSingingParam(dsParams.gender, params["gender"]);
         encodeSingingParam(dsParams.velocity, params["velocity"]);
+        encodeSingingParam(dsParams.toneShift, params["toneShift"]);
     };
 
 


### PR DESCRIPTION
DSPX 转换器未读写 `toneShift` 和 `mouthOpening`，导致参数曲线无法保存，重新打开工程时也不会恢复。补齐这两个参数的编码和解码调用，复用现有曲线转换逻辑，覆盖 original、edited 和 transform 层。

验证：
- 通过项目 VS 环境和 CMake debug preset 完成 configure 及 `DsEditorLite` 构建。
- 使用 ds-connector-lite 完成一次保存、重新打开检查：`toneShift` 自由曲线的起点、步长和数值，以及 `mouthOpening` 锚点的位置、数值和插值方式均保持一致。
- `git diff --check` 通过。