### PR TITLE
feat(automation): expose shared curve transforms to MCP and headless

### DIFF
--- a/docs/automation/02-mcp-server-and-connector/public-tool-matrix.md
+++ b/docs/automation/02-mcp-server-and-connector/public-tool-matrix.md
@@ -2,7 +2,7 @@
 
 ## 1. 冻结口径
 
-二期工具面按业务域组织。Editor 提供 **176** 个公共工具，DS Connector Lite 提供 **6** 个桥接工具，合计 **182** 个。MCP tool name 是跨 Contract、Registry、Editor 与 Connector 的稳定身份，不使用依赖表内顺序的编号。
+二期工具面按业务域组织。Editor 提供 **179** 个公共工具，DS Connector Lite 提供 **6** 个桥接工具，合计 **185** 个。MCP tool name 是跨 Contract、Registry、Editor 与 Connector 的稳定身份，不使用依赖表内顺序的编号。
 
 公共工具集维持 v1：`toolset_version = 1`。每个工具只声明自己的
 `minimum_toolset_version`，当前均为 1；兼容性只由这两个版本字段决定。Schema 不一致属于
@@ -31,7 +31,7 @@
 | 声库 | 2 | 可用声库发现与描述 |
 | Speaker Mix | 13 | 固定/动态混合、关键帧与预设 |
 | 音符、歌词、语言、发音与音素 | 19 | 叶节点创建、几何、歌词、语言、发音和音素 |
-| 参数曲线与锚点 | 12 | 有界曲线查询、采样和显式锚点曲线编辑 |
+| 参数曲线与锚点 | 15 | 有界曲线查询、采样变换和显式锚点曲线编辑 |
 | 时间线 | 5 | Tempo 与拍号 |
 | 历史记录 | 3 | 历史记录状态、Undo、Redo |
 | 播放 | 8 | 播放状态、定位与循环 |
@@ -45,7 +45,7 @@
 | 设置 | 9 | 允许公开的应用设置查询、稀疏更新、候选值与生效状态 |
 | 包信息 | 3 | 已安装包查询、详情与异步刷新 |
 | 歌词规则 | 7 | splitter/tagger 规则管理与只读流水线测试 |
-| **Editor 合计** | **176** | **41 Q/S + 122 C/S + 13 C/A** |
+| **Editor 合计** | **179** | **41 Q/S + 125 C/S + 13 C/A** |
 
 ## 3. Editor 公共工具
 
@@ -197,7 +197,7 @@
 | `notes.reset_phonemes` | L1 | C/S | 恢复自动音素与边界 |
 | `notes.fill_lyrics` | L1 | C/S | 批量歌词填充与分词/语言选项 |
 
-### 3.11 参数曲线与锚点（12）
+### 3.11 参数曲线与锚点（15）
 
 | 工具 | 控制层级 | 类型 | 契约要点 |
 |---|---|---|---|
@@ -206,7 +206,10 @@
 | `parameters.replace` | L1 | C/S | Edited 层的完整曲线替换 |
 | `parameters.draw` | L1 | C/S | 局部采样绘制与 merge mode |
 | `parameters.erase` | L1 | C/S | 局部区间擦除 |
-| `parameters.trace` | L1 | C/S | 原始曲线描摹与可选区间；局部描摹在锚点采样前执行点数与时间轴上界预检 |
+| `parameters.trace` | L1 | C/S | 原始采样曲线描摹与可选区间；保留原始数据空洞中的编辑值及完整锚点曲线，无原始采样数据时不修改 |
+| `parameters.modulate` | L1 | C/S | 固定处理 pitch，不接受 `name`；用已有音符音高与音素时序构建平滑基线并调节音高偏差，无法构建可用基线时返回 `operation_unavailable` |
+| `parameters.shape` | L1 | C/S | 相对于所选区间端点连线，在归一化值域中调节参数偏差 |
+| `parameters.scale` | L1 | C/S | 在归一化值域中缩放参数值 |
 | `parameters.create_anchor_curve` | L1 | C/S | 以至少两个初始锚点显式创建一条不重叠曲线并返回稳定 ID |
 | `parameters.insert_anchors` | L1 | C/S | 向显式 `curve_id` 批量插入锚点，不隐式创建或合并曲线 |
 | `parameters.move_anchors` | L1 | C/S | 批量稳定 ID 移动位置和值；不得隐式跨曲线合并或制造重叠 |
@@ -216,6 +219,16 @@
 
 参数曲线编辑工具统一只写入 `Edited`，不接受 `layer` 参数；MCP 与无头模式共用此约束。
 `parameters.get` 仍通过 `layer` 选择查询层，`parameters.get_capabilities` 的 `layers` 表示可查询层。
+
+调制、整形和缩放复用 GUI 的曲线变换会话，以原始与编辑采样曲线的合并结果为输入，保留锚点曲线。
+整形、缩放的 `name` 支持 `energy`、`breathiness`、`voicing`、`tension`、`mouth_opening`。
+三者均接受 `factor`（0～2）、半开区间 `local_start` / `local_end`，以及可选过渡边界
+`transition_start` / `transition_end`；所有边界使用非负 5 tick 网格，主区间至少 10 tick。
+选择跨越边界时，从左向右取第一个触及的连续采样分段并 clamp 到该段；调制同时遵守推理分段边界。
+过渡区间同样 clamp 到该段，缺省使用 GUI 的 60 ms 过渡。
+响应的 `resolved_values` 始终返回 `/local_start`、`/local_end`、`/transition_start`、
+`/transition_end` 四个实际边界，包括 `changed: false` 的情况。外层区间表示参与处理的范围，
+其中每个采样点是否发生变化取决于源曲线和变换；`changed` 表示整体是否产生实际修改。
 
 ### 3.12 时间线（5）
 
@@ -396,7 +409,7 @@ Editor PublicToolDefinitions
 Connector bridge definitions
 = Connector downstream 固定桥接工具 names
 
-176 + 6 = 182
+179 + 6 = 185
 ```
 
 每个 Editor 工具必须具备唯一 operation ID、域、最低控制层级、Query/Command、同步模式、严格

--- a/docs/automation/02-mcp-server-and-connector/public-tool-matrix.md
+++ b/docs/automation/02-mcp-server-and-connector/public-tool-matrix.md
@@ -226,9 +226,11 @@
 调制、整形和缩放复用 GUI 的曲线变换会话，以原始与编辑采样曲线的合并结果为输入，保留锚点曲线。
 整形、缩放的 `name` 支持 `energy`、`breathiness`、`voicing`、`tension`、`mouth_opening`。
 三者均接受 `factor`（0～2）、半开区间 `local_start` / `local_end`，以及可选过渡边界
-`transition_start` / `transition_end`；所有边界使用非负 5 tick 网格，主区间至少 10 tick。
+`transition_start` / `transition_end`；调用方可传入任意非负整数 tick。
+主区间端点按 GUI 选区规则向上对齐到 5 tick 网格，可选过渡端点取最近的 5 tick 格点。
 选择跨越边界时，从左向右取第一个触及的连续采样分段并 clamp 到该段；调制同时遵守推理分段边界。
-过渡区间同样 clamp 到该段，缺省使用 GUI 的 60 ms 过渡。
+对齐并 clamp 后的主区间至少包含两个采样点（10 tick）。过渡区间同样 clamp 到该段，
+缺省在 5 tick 网格上选取不超过 60 ms 的最宽过渡，因此缺省外端点也落在格点上。
 响应的 `resolved_values` 始终返回 `/local_start`、`/local_end`、`/transition_start`、
 `/transition_end` 四个实际边界，包括 `changed: false` 的情况。外层区间表示参与处理的范围，
 其中每个采样点是否发生变化取决于源曲线和变换；`changed` 表示整体是否产生实际修改。

--- a/docs/automation/02-mcp-server-and-connector/public-tool-matrix.md
+++ b/docs/automation/02-mcp-server-and-connector/public-tool-matrix.md
@@ -225,6 +225,7 @@
 
 调制、整形和缩放复用 GUI 的曲线变换会话，以原始与编辑采样曲线的合并结果为输入，保留锚点曲线。
 整形、缩放的 `name` 支持 `energy`、`breathiness`、`voicing`、`tension`、`mouth_opening`。
+描摹支持这五种参数及 `pitch`，与 GUI 中具有 Original 曲线的参数范围一致。
 三者均接受 `factor`（0～2）、半开区间 `local_start` / `local_end`，以及可选过渡边界
 `transition_start` / `transition_end`；调用方可传入任意非负整数 tick。
 主区间端点按 GUI 选区规则向上对齐到 5 tick 网格，可选过渡端点取最近的 5 tick 格点。

--- a/docs/automation/02-mcp-server-and-connector/public-tool-matrix.md
+++ b/docs/automation/02-mcp-server-and-connector/public-tool-matrix.md
@@ -220,6 +220,9 @@
 参数曲线编辑工具统一只写入 `Edited`，不接受 `layer` 参数；MCP 与无头模式共用此约束。
 `parameters.get` 仍通过 `layer` 选择查询层，`parameters.get_capabilities` 的 `layers` 表示可查询层。
 
+描摹与 GUI 绘制共用笔画语义：接触非标准采样网格的 Edited 曲线时，会将整条相交曲线重采样为
+5 tick 网格，因此局部描摹也可能改变笔画区间外的采样表示及插值。原始数据空洞保留重采样后网格上的编辑值。
+
 调制、整形和缩放复用 GUI 的曲线变换会话，以原始与编辑采样曲线的合并结果为输入，保留锚点曲线。
 整形、缩放的 `name` 支持 `energy`、`breathiness`、`voicing`、`tension`、`mouth_opening`。
 三者均接受 `factor`（0～2）、半开区间 `local_start` / `local_end`，以及可选过渡边界
@@ -229,6 +232,8 @@
 响应的 `resolved_values` 始终返回 `/local_start`、`/local_end`、`/transition_start`、
 `/transition_end` 四个实际边界，包括 `changed: false` 的情况。外层区间表示参与处理的范围，
 其中每个采样点是否发生变化取决于源曲线和变换；`changed` 表示整体是否产生实际修改。
+`factor = 1` 是中性变换，但仍可能将 Original 固化到 Edited，或对源值执行 GUI 的值域归一化；
+这些 Edited 层的实际变化仍会创建历史记录。只有最终 Edited 数据不变时才返回 `changed: false`。
 
 ### 3.12 时间线（5）
 

--- a/src/app/AppContext.cpp
+++ b/src/app/AppContext.cpp
@@ -7,6 +7,7 @@
 #include "Automation/ExtractionAutomationAdapter.h"
 #include "Automation/InferenceAutomationAdapter.h"
 #include "Automation/PackageAutomationAdapter.h"
+#include "Automation/ParameterAutomationAdapter.h"
 
 #include <lite/Core/SingletonRegistry.h>
 #include <lite/BuildInfo.h>
@@ -378,7 +379,8 @@ AppContext::AppContext(std::unique_ptr<AppOptions> options, const AppHostMode ho
         std::move(applicationServices),
         m_hostMode == AppHostMode::Gui
             ? std::optional<Automation::WindowId>(Automation::WindowId::create())
-            : std::nullopt);
+            : std::nullopt,
+        Automation::createParameterAutomationServices());
 
     // L3: Runtime host must outlive the inference facade.
     m_synthrtEngine = SingletonRegistry::create<SynthrtEngine>();

--- a/src/app/Automation/CoreRuntime.cpp
+++ b/src/app/Automation/CoreRuntime.cpp
@@ -26,11 +26,13 @@ namespace Automation {
         PackageRuntimeServices packageServices, InferenceRuntimeServices inferenceServices,
         FileRuntimeServices fileServices, AudioExportRuntimeServices audioExportServices,
         ExtractionRuntimeServices extractionServices,
-        ApplicationRuntimeServices applicationServices, std::optional<WindowId> windowId)
+        ApplicationRuntimeServices applicationServices, std::optional<WindowId> windowId,
+        ParameterRuntimeServices parameterServices)
         : m_session(model, historyManager), m_documentResolver(m_session),
           m_windowContext(std::move(windowId)), m_dispatcher(m_documentResolver, m_windowContext),
           m_applicationFacade(m_dispatcher, std::move(applicationServices)),
-          m_parameterFacade(m_dispatcher, m_committer, m_objectResolver),
+          m_parameterFacade(m_dispatcher, m_committer, m_objectResolver,
+                            std::move(parameterServices)),
           m_projectFacade(m_dispatcher, m_committer, m_objectResolver),
           m_noteFacade(m_dispatcher, m_committer, m_objectResolver),
           m_audioExportFacade(m_dispatcher, m_taskManager, std::move(audioExportServices)),

--- a/src/app/Automation/CoreRuntime.h
+++ b/src/app/Automation/CoreRuntime.h
@@ -39,7 +39,8 @@ namespace Automation {
                     AudioExportRuntimeServices audioExportServices = {},
                     ExtractionRuntimeServices extractionServices = {},
                     ApplicationRuntimeServices applicationServices = {},
-                    std::optional<WindowId> windowId = WindowId::create());
+                    std::optional<WindowId> windowId = WindowId::create(),
+                    ParameterRuntimeServices parameterServices = {});
 
         [[nodiscard]] DocumentVersion documentVersion() const;
         [[nodiscard]] const QString &documentPath() const;

--- a/src/app/Automation/OperationIds.h
+++ b/src/app/Automation/OperationIds.h
@@ -136,6 +136,9 @@ namespace Automation::OperationIds {
     X(packages, set_search_paths, "packages.set_search_paths")                                     \
     X(packages, validate, "packages.validate")                                                     \
     X(parameters, trace, "parameters.trace")                                                       \
+    X(parameters, modulate, "parameters.modulate")                                                 \
+    X(parameters, shape, "parameters.shape")                                                       \
+    X(parameters, scale, "parameters.scale")                                                       \
     X(parameters, create_anchor_curve, "parameters.create_anchor_curve")                           \
     X(parameters, draw, "parameters.draw")                                                         \
     X(parameters, erase, "parameters.erase")                                                       \

--- a/src/app/Automation/ParameterAutomationAdapter.cpp
+++ b/src/app/Automation/ParameterAutomationAdapter.cpp
@@ -1,0 +1,38 @@
+#include "ParameterAutomationAdapter.h"
+
+#include "Model/Utils/ParamUtils.h"
+#include "UI/Views/ClipEditor/CurveTransform/PitchCurveTransformContext.h"
+#include <lite/ProjectModel/AppModel/AppModel.h>
+#include <lite/ProjectModel/AppModel/SingingClip.h>
+
+namespace Automation {
+    ParameterRuntimeServices createParameterAutomationServices() {
+        return {
+            .prepareTransform =
+                [](SingingClip *clip, const ParamInfo::Name name,
+                   const CurveTransform::Kind kind) -> AutomationResult<CurveTransform::Config> {
+                CurveTransform::Config config;
+                config.kind = kind;
+                config.properties = paramUtils->getPropertiesByName(name);
+                config.tickToMilliseconds = [timeline = appModel->timeline(),
+                                             start = clip->start()](const int localTick) {
+                    return timeline.tickToMs(start + localTick);
+                };
+                if (kind == CurveTransform::Kind::ModulatePitch) {
+                    auto pitch = std::make_shared<CurveTransform::PitchContext>();
+                    pitch->rebuild(clip);
+                    if (pitch->partitions().isEmpty()) {
+                        return AutomationError{AutomationErrorCode::OperationUnavailable,
+                                               QStringLiteral("Pitch modulation requires segmented "
+                                                              "notes with valid phoneme timing")};
+                    }
+                    config.partitions = pitch->partitions();
+                    config.pitchBaselineAtTick = [pitch](const int tick) {
+                        return pitch->baselineAtTick(tick);
+                    };
+                }
+                return config;
+            },
+        };
+    }
+}

--- a/src/app/Automation/ParameterAutomationAdapter.h
+++ b/src/app/Automation/ParameterAutomationAdapter.h
@@ -1,0 +1,10 @@
+#ifndef PARAMETERAUTOMATIONADAPTER_H
+#define PARAMETERAUTOMATIONADAPTER_H
+
+#include "ParameterAutomationFacade.h"
+
+namespace Automation {
+    ParameterRuntimeServices createParameterAutomationServices();
+}
+
+#endif // PARAMETERAUTOMATIONADAPTER_H

--- a/src/app/Automation/ParameterAutomationFacade.cpp
+++ b/src/app/Automation/ParameterAutomationFacade.cpp
@@ -1147,18 +1147,13 @@ namespace Automation {
                     return AutomationError::invalidArgument(
                         QStringLiteral("factor"), QStringLiteral("Factor must be between 0 and 2"));
                 }
-                const auto onGrid = [](const int tick) {
-                    return tick >= 0 && tick % CurveTransform::SampleStep == 0;
-                };
-                if (!onGrid(transform.localStart) || !onGrid(transform.localEnd) ||
-                    qint64(transform.localEnd) - transform.localStart <
-                        2 * CurveTransform::SampleStep ||
-                    (transform.transitionStart && !onGrid(*transform.transitionStart)) ||
-                    (transform.transitionEnd && !onGrid(*transform.transitionEnd))) {
+                if (transform.localStart < 0 || transform.localEnd <= transform.localStart ||
+                    (transform.transitionStart && *transform.transitionStart < 0) ||
+                    (transform.transitionEnd && *transform.transitionEnd < 0)) {
                     return AutomationError::invalidArgument(
                         QStringLiteral("local_end"),
-                        QStringLiteral("Transform boundaries must use the non-negative 5-tick "
-                                       "grid, with a main range of at least 10 ticks"));
+                        QStringLiteral("Transform boundaries must be non-negative ticks, "
+                                       "with an ordered non-empty main range"));
                 }
                 for (const auto &curves : {original, edited}) {
                     for (const auto *curve : curves) {

--- a/src/app/Automation/ParameterAutomationFacade.cpp
+++ b/src/app/Automation/ParameterAutomationFacade.cpp
@@ -3,6 +3,8 @@
 
 #include "Controller/Actions/AppModel/Param/ParamsActions.h"
 #include "Controller/Actions/AppModel/SpeakerMix/SpeakerMixActions.h"
+#include "UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.h"
+#include "UI/Views/ClipEditor/DrawCurveEditUtils.h"
 
 #include <lite/AutomationWire/PublicConstants.h>
 #include <lite/ProjectModel/AppModel/SingingClip.h>
@@ -14,6 +16,7 @@
 #include <QHash>
 #include <QJsonDocument>
 #include <QSet>
+#include <QScopeGuard>
 
 #include <memory>
 #include <algorithm>
@@ -78,67 +81,21 @@ namespace Automation {
             return false;
         }
 
-        void clearCurveIdentity(CurveDraftDto &curve) {
-            curve.id = {};
-            for (auto &node : curve.nodes)
-                node.id = {};
-        }
-
-        DrawCurve *freshDrawCurve(const CurveDraftDto &draft) {
-            if (draft.type == CurveDraftDto::Type::Draw) {
-                auto *result = new DrawCurve;
-                result->Curve::setLocalStart(draft.localStart);
-                result->step = draft.step;
-                result->setValues(draft.values);
-                return result;
-            }
-            const auto curve = buildCurve(draft);
-            return static_cast<const AnchorCurve *>(curve.get())->toDrawCurve();
-        }
-
-        std::optional<qint64> drawMaterializationPointCount(const CurveDraftDto &draft) {
-            if (draft.type == CurveDraftDto::Type::Draw) {
-                if (draft.step <= 0 || draft.localStart < 0)
-                    return std::nullopt;
-                const auto end = static_cast<qint64>(draft.localStart) +
-                                 static_cast<qint64>(draft.step) * draft.values.size();
-                if (end > std::numeric_limits<int>::max())
-                    return std::nullopt;
-                return draft.values.size();
-            }
-            if (draft.nodes.size() < 2)
-                return 0;
-
-            const auto first = static_cast<qint64>(draft.nodes.constFirst().position);
-            const auto last = static_cast<qint64>(draft.nodes.constLast().position);
-            if (first < 0 || last < first)
-                return std::nullopt;
+        bool reserveDrawMaterialization(const QList<DrawCurve *> &curves, qint64 &reservedPoints) {
             constexpr qint64 step = 5;
-            const auto start = first / step * step;
-            const auto count = (last - start) / step + 1;
-            if (start + step * count > std::numeric_limits<int>::max())
-                return std::nullopt;
-            return count;
-        }
-
-        bool reserveTraceMaterialization(const CurveDraftDto &draft, qint64 &reservedPoints) {
-            const auto count = drawMaterializationPointCount(draft);
-            if (!count || *count > AutomationWire::MaximumCurveSampleItems - reservedPoints)
-                return false;
-            reservedPoints += *count;
-            return true;
-        }
-
-        void retainDrawRange(QList<DrawCurve *> &curves, const int localStart, const int localEnd) {
-            if (localStart > 0)
-                AppModelUtils::eraseDrawCurveRange(curves, 0, localStart);
-            int maximumEnd = localEnd;
             for (const auto *curve : curves) {
-                if (curve)
-                    maximumEnd = std::max(maximumEnd, curve->localEndTick());
+                if (curve->step <= 0 || curve->localStart() < 0)
+                    return false;
+                const auto span = qint64(curve->step) * curve->values().size();
+                const auto end = qint64(curve->localStart()) + span;
+                if (end > std::numeric_limits<int>::max() - step)
+                    return false;
+                const auto count = std::max<qint64>(curve->values().size(), (span + step - 1) / step);
+                if (count > AutomationWire::MaximumCurveSampleItems - reservedPoints)
+                    return false;
+                reservedPoints += count;
             }
-            if (maximumEnd > localEnd)
-                AppModelUtils::eraseDrawCurveRange(curves, localEnd, maximumEnd);
+            return true;
         }
 
         QByteArray parameterMutationFingerprint(const QByteArray &operationTag, const ClipId clipId,
@@ -1069,128 +1026,98 @@ namespace Automation {
             });
     }
 
-    AutomationResult<MutationResult> ParameterAutomationFacade::traceParameter(
-        const CommandContext &context, const ClipId clipId, const ParamInfo::Name name,
-        const std::optional<int> localStart, const std::optional<int> localEnd) {
-        const int rangeStart = localStart.value_or(-1);
-        const int rangeEnd = localEnd.value_or(-1);
-        auto isolatedContext = context;
-        if (!isolatedContext.idempotencyKey.isEmpty()) {
-            isolatedContext.idempotencyKey =
-                QStringLiteral("trace:") + isolatedContext.idempotencyKey;
-        }
+    AutomationResult<MutationResult> ParameterAutomationFacade::mutateDrawParameter(
+        const OperationId &operationId, const CommandContext &context, const ClipId clipId,
+        const ParamInfo::Name name, DrawCurveMutation mutation) {
         return m_dispatcher.dispatchDocumentCommand(
-            OperationIds::parameters::trace, isolatedContext,
-            [this, clipId, name, localStart, localEnd](DocumentSession &session,
-                                                       const bool validateOnly) {
+            operationId, context,
+            [this, clipId, name, mutation = std::move(mutation)](
+                DocumentSession &session, const bool validateOnly) -> AutomationResult<MutationResult> {
                 auto resolved = m_objects.singingClip(session, clipId);
                 if (!resolved)
-                    return AutomationResult<MutationResult>(resolved.getError());
-                if (!supportedParameter(name, Param::Edited)) {
-                    return AutomationResult<MutationResult>(AutomationError::invalidArgument(
-                        QStringLiteral("name"), QStringLiteral("Parameter is unsupported")));
-                }
-                if (localStart.has_value() != localEnd.has_value() ||
-                    (localStart && (*localStart < 0 || *localEnd <= *localStart))) {
-                    return AutomationResult<MutationResult>(AutomationError::invalidArgument(
-                        QStringLiteral("local_end"),
-                        QStringLiteral(
-                            "Trace range must provide an ordered non-negative interval")));
+                    return resolved.getError();
+                if (!supportedParameter(name, Param::Edited) || !ParamInfo::hasOriginalParam(name)) {
+                    return AutomationError::invalidArgument(
+                        QStringLiteral("name"), QStringLiteral("Parameter has no original curve"));
                 }
                 auto *clip = static_cast<SingingClip *>(resolved.get().clip);
                 const auto *param = clip->params.getParamByName(name);
-                QList<CurveDraftDto> original;
-                QList<CurveDraftDto> edited;
-                for (const auto *curve : param->curves(Param::Original))
-                    original.append(curveDraftDto(*curve));
+                const auto original = AppModelUtils::getDrawCurves(param->curves(Param::Original));
+                const auto edited = AppModelUtils::getDrawCurves(param->curves(Param::Edited));
+                qint64 materializedPoints = 0;
+                if (!reserveDrawMaterialization(original, materializedPoints) ||
+                    !reserveDrawMaterialization(edited, materializedPoints)) {
+                    return AutomationError::invalidArgument(
+                        QStringLiteral("local_end"),
+                        QStringLiteral("Curve resampling exceeds the supported point or tick limit"));
+                }
+                QList<DrawCurve *> preview;
+                AppModelUtils::copyCurves(edited, preview);
+                const auto deletePreview = qScopeGuard([&] { qDeleteAll(preview); });
+                auto mutated = mutation(*clip, original, preview);
+                if (!mutated)
+                    return mutated.getError();
+                const auto affected = QList<ObjectRef>{{ObjectKind::Clip, clipId.value()}};
+                if (!mutated.get())
+                    return validateOnly ? m_committer.preview(session, false, affected)
+                                        : m_committer.unchanged(session);
+
+                const auto replacement =
+                    AnchorEditor::replaceDrawCurves(param->curves(Param::Edited), preview);
+                const auto deleteReplacement = qScopeGuard([&] { qDeleteAll(replacement); });
+                QList<CurveDraftDto> before;
+                QList<CurveDraftDto> after;
                 for (const auto *curve : param->curves(Param::Edited))
-                    edited.append(curveDraftDto(*curve));
-
-                QList<CurveDraftDto> replacement;
-                if (!localStart) {
-                    replacement = original;
-                    for (auto &curve : replacement)
-                        clearCurveIdentity(curve);
-                } else {
-                    qint64 materializedPoints = 0;
-                    for (const auto &draft : edited) {
-                        if (draft.type == CurveDraftDto::Type::Anchor) {
-                            const int anchorEnd = draft.nodes.isEmpty()
-                                                      ? draft.localStart
-                                                      : draft.nodes.constLast().position;
-                            if (anchorEnd <= *localStart || draft.localStart >= *localEnd)
-                                continue;
-                        }
-                        if (!reserveTraceMaterialization(draft, materializedPoints)) {
-                            return AutomationResult<MutationResult>(
-                                AutomationError::invalidArgument(
-                                    QStringLiteral("local_end"),
-                                    QStringLiteral("Trace curve materialization exceeds the "
-                                                   "supported point limit")));
-                        }
-                    }
-                    for (const auto &draft : original) {
-                        if (!reserveTraceMaterialization(draft, materializedPoints)) {
-                            return AutomationResult<MutationResult>(
-                                AutomationError::invalidArgument(
-                                    QStringLiteral("local_end"),
-                                    QStringLiteral("Trace curve materialization exceeds the "
-                                                   "supported point limit")));
-                        }
-                    }
-
-                    QList<DrawCurve *> editedDraws;
-                    for (const auto &draft : edited) {
-                        if (draft.type == CurveDraftDto::Type::Anchor) {
-                            const int anchorEnd = draft.nodes.isEmpty()
-                                                      ? draft.localStart
-                                                      : draft.nodes.constLast().position;
-                            if (anchorEnd <= *localStart || draft.localStart >= *localEnd) {
-                                replacement.append(draft);
-                                continue;
-                            }
-                        }
-                        if (auto *draw = freshDrawCurve(draft))
-                            editedDraws.append(draw);
-                    }
-                    AppModelUtils::eraseDrawCurveRange(editedDraws, *localStart, *localEnd);
-
-                    QList<DrawCurve *> tracedDraws;
-                    for (const auto &draft : original) {
-                        if (auto *draw = freshDrawCurve(draft))
-                            tracedDraws.append(draw);
-                    }
-                    retainDrawRange(tracedDraws, *localStart, *localEnd);
-                    auto merged = AppModelUtils::mergeCurves(editedDraws, tracedDraws);
-                    for (const auto *curve : merged)
-                        replacement.append(curveDraftDto(*curve));
-                    qDeleteAll(editedDraws);
-                    qDeleteAll(tracedDraws);
-                    qDeleteAll(merged);
-                }
-                QCryptographicHash originalHash(QCryptographicHash::Sha256);
-                QCryptographicHash editedHash(QCryptographicHash::Sha256);
-                hashCurveShapes(originalHash, replacement);
-                hashCurveShapes(editedHash, edited);
-                const bool changed = originalHash.result() != editedHash.result();
-                const auto affected = QList<ObjectRef>{
-                    {ObjectKind::Clip, clipId.value()}
-                };
+                    before.append(curveDraftDto(*curve));
+                for (const auto *curve : replacement)
+                    after.append(curveDraftDto(*curve));
+                QCryptographicHash beforeHash(QCryptographicHash::Sha256);
+                QCryptographicHash afterHash(QCryptographicHash::Sha256);
+                hashCurveShapes(beforeHash, before);
+                hashCurveShapes(afterHash, after);
+                const bool changed = beforeHash.result() != afterHash.result();
                 if (validateOnly)
-                    return AutomationResult<MutationResult>(
-                        m_committer.preview(session, changed, affected));
+                    return m_committer.preview(session, changed, affected);
                 if (!changed)
-                    return AutomationResult<MutationResult>(m_committer.unchanged(session));
-                std::vector<std::unique_ptr<Curve>> owned;
-                QList<Curve *> raw;
-                for (const auto &draft : replacement) {
-                    auto curve = buildCurve(draft);
-                    raw.append(curve.get());
-                    owned.push_back(std::move(curve));
-                }
+                    return m_committer.unchanged(session);
                 auto actions = std::make_unique<ParamsActions>();
-                actions->replaceParam(name, Param::Edited, raw, clip);
+                actions->replaceParam(name, Param::Edited, replacement, clip);
                 return m_committer.commit(session, std::move(actions), affected);
+            });
+    }
+
+    AutomationResult<MutationResult> ParameterAutomationFacade::traceParameter(
+        const CommandContext &context, const ClipId clipId, const ParamInfo::Name name,
+        const std::optional<int> localStart, const std::optional<int> localEnd) {
+        return mutateDrawParameter(
+            OperationIds::parameters::trace, context, clipId, name,
+            [localStart, localEnd](SingingClip &, const QList<DrawCurve *> &original,
+                                   QList<DrawCurve *> &edited) -> AutomationResult<bool> {
+                if (localStart.has_value() != localEnd.has_value() ||
+                    (localStart && (*localStart < 0 || *localEnd <= *localStart))) {
+                    return AutomationError::invalidArgument(
+                        QStringLiteral("local_end"),
+                        QStringLiteral("Trace range must provide an ordered non-negative interval"));
+                }
+                DrawCurveEditUtils::GeneratedCurveSnapshot source;
+                source.capture(original);
+                bool applied = false;
+                for (const auto *curve : original) {
+                    const auto first = std::max(curve->localStart(), localStart.value_or(0));
+                    if (first >= curve->localEndTick())
+                        continue;
+                    const auto start = (first + 4) / 5 * 5;
+                    const auto end = std::min(curve->localEndTick(),
+                                              localEnd.value_or(curve->localEndTick()));
+                    if (start >= end)
+                        continue;
+                    const QPoint from(start, 0);
+                    auto stroke = DrawCurveEditUtils::beginStroke(edited, from);
+                    applied |= DrawCurveEditUtils::updateStroke(
+                        edited, stroke, from, QPoint(end, 0),
+                        [&source](const int tick) { return source.valueAt(tick); });
+                }
+                return applied;
             });
     }
 

--- a/src/app/Automation/ParameterAutomationFacade.cpp
+++ b/src/app/Automation/ParameterAutomationFacade.cpp
@@ -332,8 +332,10 @@ namespace Automation {
 
     ParameterAutomationFacade::ParameterAutomationFacade(AutomationDispatcher &dispatcher,
                                                          CommandCommitter &committer,
-                                                         DocumentObjectResolver &objects)
-        : m_dispatcher(dispatcher), m_committer(committer), m_objects(objects) {
+                                                         DocumentObjectResolver &objects,
+                                                         ParameterRuntimeServices services)
+        : m_dispatcher(dispatcher), m_committer(committer), m_objects(objects),
+          m_services(std::move(services)) {
     }
 
     AutomationResult<ParameterSnapshotDto>
@@ -1119,6 +1121,102 @@ namespace Automation {
                 }
                 return applied;
             });
+    }
+
+    AutomationResult<MutationResult> ParameterAutomationFacade::transformParameter(
+        const CommandContext &context, const ClipId clipId, const ParamInfo::Name name,
+        const CurveTransform::Kind kind, const ParameterTransformDto &transform) {
+        const auto &operationId =
+            kind == CurveTransform::Kind::ModulatePitch ? OperationIds::parameters::modulate
+            : kind == CurveTransform::Kind::Shape       ? OperationIds::parameters::shape
+                                                        : OperationIds::parameters::scale;
+        QList<ResolvedValue> resolvedValues;
+        auto result = mutateDrawParameter(
+            operationId, context, clipId, name,
+            [this, name, kind, transform,
+             &resolvedValues](SingingClip &clip, const QList<DrawCurve *> &original,
+                              QList<DrawCurve *> &edited) -> AutomationResult<bool> {
+                if ((kind == CurveTransform::Kind::ModulatePitch) != (name == ParamInfo::Pitch)) {
+                    return AutomationError::invalidArgument(
+                        QStringLiteral("name"),
+                        QStringLiteral("Modulation supports pitch; shape and scale support "
+                                       "variance parameters"));
+                }
+                if (!std::isfinite(transform.factor) || transform.factor < 0.0 ||
+                    transform.factor > 2.0) {
+                    return AutomationError::invalidArgument(
+                        QStringLiteral("factor"), QStringLiteral("Factor must be between 0 and 2"));
+                }
+                const auto onGrid = [](const int tick) {
+                    return tick >= 0 && tick % CurveTransform::SampleStep == 0;
+                };
+                if (!onGrid(transform.localStart) || !onGrid(transform.localEnd) ||
+                    qint64(transform.localEnd) - transform.localStart <
+                        2 * CurveTransform::SampleStep ||
+                    (transform.transitionStart && !onGrid(*transform.transitionStart)) ||
+                    (transform.transitionEnd && !onGrid(*transform.transitionEnd))) {
+                    return AutomationError::invalidArgument(
+                        QStringLiteral("local_end"),
+                        QStringLiteral("Transform boundaries must use the non-negative 5-tick "
+                                       "grid, with a main range of at least 10 ticks"));
+                }
+                for (const auto &curves : {original, edited}) {
+                    for (const auto *curve : curves) {
+                        if (qint64(clip.start()) + curve->localEndTick() >
+                            std::numeric_limits<int>::max()) {
+                            return AutomationError::invalidArgument(
+                                QStringLiteral("local_end"),
+                                QStringLiteral("Curve exceeds the global timeline limit"));
+                        }
+                    }
+                }
+                if (!m_services.prepareTransform) {
+                    return AutomationError{
+                        AutomationErrorCode::HostCapabilityUnavailable,
+                        QStringLiteral("Curve transform context is unavailable")};
+                }
+                auto config = m_services.prepareTransform(&clip, name, kind);
+                if (!config)
+                    return config.getError();
+                CurveTransform::Session session;
+                session.setSource(original, edited, config.get());
+                if (!session.selectRange(transform.localStart, transform.localEnd,
+                                         transform.transitionStart, transform.transitionEnd)) {
+                    return AutomationError{
+                        AutomationErrorCode::OperationUnavailable,
+                        QStringLiteral("The selected range has no complete curve segment")};
+                }
+                const auto &bounds = session.bounds();
+                if (kind == CurveTransform::Kind::ModulatePitch) {
+                    for (auto tick = bounds.c; tick < bounds.d;
+                         tick += CurveTransform::SampleStep) {
+                        const auto baseline = config.get().pitchBaselineAtTick
+                                                  ? config.get().pitchBaselineAtTick(tick)
+                                                  : std::nullopt;
+                        if (!baseline || !std::isfinite(*baseline)) {
+                            return AutomationError{
+                                AutomationErrorCode::OperationUnavailable,
+                                QStringLiteral(
+                                    "Pitch modulation requires a valid note pitch baseline")};
+                        }
+                    }
+                }
+                resolvedValues = {
+                    {QStringLiteral("/local_start"),      bounds.a},
+                    {QStringLiteral("/local_end"),        bounds.b},
+                    {QStringLiteral("/transition_start"), bounds.c},
+                    {QStringLiteral("/transition_end"),   bounds.d},
+                };
+                session.beginTransform();
+                session.setFactor(transform.factor);
+                auto preview = session.buildEditedPreview();
+                qDeleteAll(edited);
+                edited = std::move(preview);
+                return true;
+            });
+        if (result)
+            result.get().resolvedValues = std::move(resolvedValues);
+        return result;
     }
 
     AutomationResult<MutationResult> ParameterAutomationFacade::replaceClipSpeakerMix(

--- a/src/app/Automation/ParameterAutomationFacade.h
+++ b/src/app/Automation/ParameterAutomationFacade.h
@@ -5,6 +5,7 @@
 #include "CommandCommitter.h"
 #include "DocumentObjectResolver.h"
 #include "ProjectAutomationDtos.h"
+#include "UI/Views/ClipEditor/CurveTransform/CurveTransformSession.h"
 
 #include <lite/ProjectModel/AppModel/EffectiveVoiceContext.h>
 
@@ -68,10 +69,25 @@ namespace Automation {
         int value = 0;
     };
 
+    struct ParameterTransformDto {
+        int localStart = 0;
+        int localEnd = 0;
+        double factor = 1.0;
+        std::optional<int> transitionStart;
+        std::optional<int> transitionEnd;
+    };
+
+    struct ParameterRuntimeServices {
+        std::function<AutomationResult<CurveTransform::Config>(SingingClip *, ParamInfo::Name,
+                                                               CurveTransform::Kind)>
+            prepareTransform;
+    };
+
     class ParameterAutomationFacade final {
     public:
         ParameterAutomationFacade(AutomationDispatcher &dispatcher, CommandCommitter &committer,
-                                  DocumentObjectResolver &objects);
+                                  DocumentObjectResolver &objects,
+                                  ParameterRuntimeServices services = {});
 
         AutomationResult<ParameterSnapshotDto> getParameter(const DocumentId &documentId,
                                                             ClipId clipId, ParamInfo::Name name,
@@ -130,6 +146,10 @@ namespace Automation {
             traceParameter(const CommandContext &context, ClipId clipId, ParamInfo::Name name,
                            std::optional<int> localStart = std::nullopt,
                            std::optional<int> localEnd = std::nullopt);
+        AutomationResult<MutationResult> transformParameter(const CommandContext &context,
+                                                            ClipId clipId, ParamInfo::Name name,
+                                                            CurveTransform::Kind kind,
+                                                            const ParameterTransformDto &transform);
 
         AutomationResult<MutationResult>
             replaceClipSpeakerMix(const CommandContext &context, ClipId clipId,
@@ -238,6 +258,7 @@ namespace Automation {
         AutomationDispatcher &m_dispatcher;
         CommandCommitter &m_committer;
         DocumentObjectResolver &m_objects;
+        ParameterRuntimeServices m_services;
     };
 
 } // namespace Automation

--- a/src/app/Automation/ParameterAutomationFacade.h
+++ b/src/app/Automation/ParameterAutomationFacade.h
@@ -201,6 +201,11 @@ namespace Automation {
                                 const SingerInfo &singerInfo, const SpeakerInfo &speakerInfo,
                                 const SpeakerMixModel::SpeakerMixData &data);
         using CurveMutation = std::function<AutomationResult<bool>(QList<CurveDraftDto> &curves)>;
+        using DrawCurveMutation = std::function<AutomationResult<bool>(
+            SingingClip &clip, const QList<DrawCurve *> &original, QList<DrawCurve *> &edited)>;
+        AutomationResult<MutationResult> mutateDrawParameter(
+            const OperationId &operationId, const CommandContext &context, ClipId clipId,
+            ParamInfo::Name name, DrawCurveMutation mutation);
         AutomationResult<MutationResult> mutateParameter(const OperationId &operationId,
                                                          const CommandContext &context,
                                                          ClipId clipId, ParamInfo::Name name,

--- a/src/app/Automation/Public/PublicAutomationRegistry.cpp
+++ b/src/app/Automation/Public/PublicAutomationRegistry.cpp
@@ -3009,6 +3009,32 @@ namespace Automation {
                         ? std::optional<int>(arguments.value(QStringLiteral("local_end")).toInt())
                         : std::nullopt));
             });
+        for (const auto &[id, kind] : {
+                 std::pair{ToolNames::parameters_modulate, CurveTransform::Kind::ModulatePitch},
+                 std::pair{ToolNames::parameters_shape,    CurveTransform::Kind::Shape        },
+                 std::pair{ToolNames::parameters_scale,    CurveTransform::Kind::Scale        },
+        }) {
+            addBinding(id, [this, kind](const QJsonObject &arguments,
+                                        const PublicInvocationContext &invocation) {
+                ParameterTransformDto transform;
+                transform.localStart = arguments.value(QStringLiteral("local_start")).toInt();
+                transform.localEnd = arguments.value(QStringLiteral("local_end")).toInt();
+                transform.factor = arguments.value(QStringLiteral("factor")).toDouble();
+                if (arguments.contains(QStringLiteral("transition_start")))
+                    transform.transitionStart =
+                        arguments.value(QStringLiteral("transition_start")).toInt();
+                if (arguments.contains(QStringLiteral("transition_end")))
+                    transform.transitionEnd =
+                        arguments.value(QStringLiteral("transition_end")).toInt();
+                return mutationResult(m_runtime.parameters().transformParameter(
+                    commandContext(arguments, invocation),
+                    ClipId(arguments.value(QStringLiteral("clip_id")).toInt()),
+                    kind == CurveTransform::Kind::ModulatePitch
+                        ? ParamInfo::Pitch
+                        : parameterName(arguments.value(QStringLiteral("name")).toString()),
+                    kind, transform));
+            });
+        }
         addBinding(ToolNames::tracks_set_voice, [this](const QJsonObject &arguments,
                                                        const PublicInvocationContext &invocation) {
             auto voice = resolveVoiceSelection(m_runtime,

--- a/src/app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.cpp
+++ b/src/app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.cpp
@@ -262,10 +262,8 @@ namespace CurveTransform {
                               const std::optional<int> transitionStart,
                               const std::optional<int> transitionEnd) {
         resetInteraction();
-        const auto onGrid = [](const int tick) { return tick >= 0 && tick % SampleStep == 0; };
-        if (!onGrid(startTick) || !onGrid(endTick) || endTick <= startTick ||
-            (transitionStart && !onGrid(*transitionStart)) ||
-            (transitionEnd && !onGrid(*transitionEnd))) {
+        if (startTick < 0 || endTick <= startTick || (transitionStart && *transitionStart < 0) ||
+            (transitionEnd && *transitionEnd < 0)) {
             return false;
         }
         beginSelection(startTick);
@@ -273,10 +271,16 @@ namespace CurveTransform {
             resetInteraction();
             return false;
         }
-        m_bounds.c =
-            std::clamp(transitionStart.value_or(m_bounds.c), m_bounds.componentStart, m_bounds.a);
-        m_bounds.d =
-            std::clamp(transitionEnd.value_or(m_bounds.d), m_bounds.b, m_bounds.componentEnd);
+        if (transitionStart) {
+            beginBoundaryDrag(Boundary::C);
+            updateBoundaryDrag(*transitionStart);
+            endBoundaryDrag();
+        }
+        if (transitionEnd) {
+            beginBoundaryDrag(Boundary::D);
+            updateBoundaryDrag(*transitionEnd);
+            endBoundaryDrag();
+        }
         return true;
     }
 
@@ -425,8 +429,8 @@ namespace CurveTransform {
         }
         const auto &component = m_components.at(m_selectedComponent);
         const auto [rawStart, rawEnd] = std::minmax(m_selectionStartTick, tick);
-        const auto a = std::max(component.startTick, alignedAtOrAfter(rawStart));
-        const auto b = std::min(component.endTick(), alignedAtOrAfter(rawEnd));
+        const auto a = alignedAtOrAfter(std::max(component.startTick, rawStart));
+        const auto b = alignedAtOrAfter(std::min(component.endTick(), rawEnd));
         if (b - a < 2 * SampleStep) {
             m_bounds = {};
             m_selectedComponent = -1;

--- a/src/app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.cpp
+++ b/src/app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.cpp
@@ -128,7 +128,7 @@ namespace {
 
 namespace CurveTransform {
     bool Bounds::isValid() const {
-        return componentStart <= c && c <= a && a + 2 * SampleStep <= b && b <= d &&
+        return componentStart <= c && c <= a && qint64(a) + 2 * SampleStep <= b && b <= d &&
                d <= componentEnd;
     }
 
@@ -258,6 +258,30 @@ namespace CurveTransform {
         return true;
     }
 
+    bool Session::selectRange(const int startTick, const int endTick,
+                              const std::optional<int> transitionStart,
+                              const std::optional<int> transitionEnd) {
+        resetInteraction();
+        const auto onGrid = [](const int tick) { return tick >= 0 && tick % SampleStep == 0; };
+        if (!onGrid(startTick) || !onGrid(endTick) || endTick <= startTick ||
+            (transitionStart && !onGrid(*transitionStart)) ||
+            (transitionEnd && !onGrid(*transitionEnd))) {
+            return false;
+        }
+        beginSelection(startTick);
+        if (!finishSelection(endTick) || m_bounds.a != startTick || m_bounds.b != endTick) {
+            resetInteraction();
+            return false;
+        }
+        m_bounds.c = transitionStart.value_or(m_bounds.c);
+        m_bounds.d = transitionEnd.value_or(m_bounds.d);
+        if (!m_bounds.isValid()) {
+            resetInteraction();
+            return false;
+        }
+        return true;
+    }
+
     bool Session::beginBoundaryDrag(const Boundary boundary) {
         if (m_phase != Phase::Adjusting || m_selectedComponent < 0 || boundary == Boundary::None)
             return false;
@@ -318,10 +342,15 @@ namespace CurveTransform {
         return true;
     }
 
+    bool Session::setFactor(const double factor) {
+        if (m_phase != Phase::Transforming || !std::isfinite(factor) || factor < 0.0 || factor > 2.0)
+            return false;
+        m_factor = factor;
+        return true;
+    }
+
     void Session::updateTransform(const double verticalLogicalPixelDelta) {
-        if (m_phase != Phase::Transforming)
-            return;
-        m_factor = std::clamp(1.0 - verticalLogicalPixelDelta / 100.0, 0.0, 2.0);
+        setFactor(std::clamp(1.0 - verticalLogicalPixelDelta / 100.0, 0.0, 2.0));
     }
 
     QList<DrawCurve *> Session::buildEditedPreview() const {

--- a/src/app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.cpp
+++ b/src/app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.cpp
@@ -269,16 +269,14 @@ namespace CurveTransform {
             return false;
         }
         beginSelection(startTick);
-        if (!finishSelection(endTick) || m_bounds.a != startTick || m_bounds.b != endTick) {
+        if (!finishSelection(endTick)) {
             resetInteraction();
             return false;
         }
-        m_bounds.c = transitionStart.value_or(m_bounds.c);
-        m_bounds.d = transitionEnd.value_or(m_bounds.d);
-        if (!m_bounds.isValid()) {
-            resetInteraction();
-            return false;
-        }
+        m_bounds.c =
+            std::clamp(transitionStart.value_or(m_bounds.c), m_bounds.componentStart, m_bounds.a);
+        m_bounds.d =
+            std::clamp(transitionEnd.value_or(m_bounds.d), m_bounds.b, m_bounds.componentEnd);
         return true;
     }
 

--- a/src/app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.h
+++ b/src/app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.h
@@ -66,11 +66,15 @@ namespace CurveTransform {
         void beginSelection(int tick);
         bool updateSelection(int tick);
         bool finishSelection(int tick);
+        bool selectRange(int startTick, int endTick,
+                         std::optional<int> transitionStart = std::nullopt,
+                         std::optional<int> transitionEnd = std::nullopt);
 
         bool beginBoundaryDrag(Boundary boundary);
         bool updateBoundaryDrag(int tick);
         void endBoundaryDrag();
         bool beginTransform();
+        bool setFactor(double factor);
         void updateTransform(double verticalLogicalPixelDelta);
 
         [[nodiscard]] QList<DrawCurve *> buildEditedPreview() const;

--- a/src/libs/AutomationWire/PublicToolContract.cpp
+++ b/src/libs/AutomationWire/PublicToolContract.cpp
@@ -554,7 +554,9 @@ namespace AutomationWire {
                 if (name == QStringLiteral("local_start") || name == QStringLiteral("local_end") ||
                     name == QStringLiteral("transition_start") ||
                     name == QStringLiteral("transition_end")) {
-                    return nonNegativeModelIntegerSchema();
+                    auto boundary = nonNegativeModelIntegerSchema();
+                    boundary.insert(QStringLiteral("multipleOf"), 5);
+                    return boundary;
                 }
                 if (name == QStringLiteral("name")) {
                     return JsonSchema::string({QStringLiteral("energy"),

--- a/src/libs/AutomationWire/PublicToolContract.cpp
+++ b/src/libs/AutomationWire/PublicToolContract.cpp
@@ -554,9 +554,7 @@ namespace AutomationWire {
                 if (name == QStringLiteral("local_start") || name == QStringLiteral("local_end") ||
                     name == QStringLiteral("transition_start") ||
                     name == QStringLiteral("transition_end")) {
-                    auto boundary = nonNegativeModelIntegerSchema();
-                    boundary.insert(QStringLiteral("multipleOf"), 5);
-                    return boundary;
+                    return nonNegativeModelIntegerSchema();
                 }
                 if (name == QStringLiteral("name")) {
                     return JsonSchema::string({QStringLiteral("energy"),
@@ -4073,26 +4071,21 @@ namespace AutomationWire {
                     } else {
                         description = QStringLiteral("Scale normalized parameter values. ");
                     }
-                    return description +
-                           QStringLiteral(
-                               "Apply factor 0..2 to merged original and edited sampled curves and "
-                               "write "
-                               "only Edited, retaining anchors. factor 1 may still populate Edited "
-                               "from Original or normalize source values. local_start/local_end "
-                               "form a "
-                               "clip-local "
-                               "half-open range of at least 10 ticks; all boundaries use the "
-                               "non-negative "
-                               "5-tick grid. Clamp to the first touched continuous segment from "
-                               "left to "
-                               "right; pitch also respects inference-piece boundaries. Optional "
-                               "transition_start/transition_end clamp to that segment; defaults "
-                               "use 60ms "
-                               "shoulders. resolved_values always reports the four actual "
-                               "boundaries, even "
-                               "when changed is false. The outer interval is the processing range, "
-                               "not a "
-                               "claim that every sample changed. Commits one History step.");
+                    description += QStringLiteral(
+                        "Apply factor 0..2 to merged original and edited sampled curves and write "
+                        "only Edited, retaining anchors. factor 1 may still populate Edited from "
+                        "Original or normalize source values. All boundaries accept non-negative "
+                        "integer ticks. local_start/local_end form a clip-local half-open range; "
+                        "align both upward to the 5-tick grid and clamp to the first touched "
+                        "continuous segment from left to right. Pitch also respects "
+                        "inference-piece "
+                        "boundaries. The resolved main range must span at least 10 ticks. Optional "
+                        "transition_start/transition_end snap to the nearest 5-tick grid point and "
+                        "clamp to that segment; defaults choose grid-aligned shoulders of at most "
+                        "60ms. resolved_values always reports the four actual boundaries, even "
+                        "when changed is false. The outer interval is the processing range, not a "
+                        "claim that every sample changed. Commits one History step.");
+                    return description;
                 }
                 return QStringLiteral(
                            "Apply %1 to the Edited parameter layer through the shared parameter "

--- a/src/libs/AutomationWire/PublicToolContract.cpp
+++ b/src/libs/AutomationWire/PublicToolContract.cpp
@@ -4050,9 +4050,11 @@ namespace AutomationWire {
                 if (operationId == PublicToolNames::parameters_trace) {
                     return QStringLiteral(
                         "Trace original sampled curves into Edited, optionally within a clip-local "
-                        "half-open tick range. Preserve edited samples in original-data gaps and "
-                        "retain anchor curves. Without original data this is a no-op. Commits one "
-                        "History step.");
+                        "half-open tick range. As in the GUI, overlapping Edited curves on a "
+                        "nonstandard sample grid are resampled as whole curves to the 5-tick grid, "
+                        "including portions outside the stroke range. Original-data gaps retain "
+                        "existing edited values on that grid. Preserve anchor curves. Without "
+                        "original sampled data this is a no-op. Commits one History step.");
                 }
                 if (isCurveTransformOperation(operationId)) {
                     QString description;
@@ -4073,7 +4075,9 @@ namespace AutomationWire {
                            QStringLiteral(
                                "Apply factor 0..2 to merged original and edited sampled curves and "
                                "write "
-                               "only Edited, retaining anchors. local_start/local_end form a "
+                               "only Edited, retaining anchors. factor 1 may still populate Edited "
+                               "from Original or normalize source values. local_start/local_end "
+                               "form a "
                                "clip-local "
                                "half-open range of at least 10 ticks; all boundaries use the "
                                "non-negative "
@@ -4090,7 +4094,8 @@ namespace AutomationWire {
                 }
                 return QStringLiteral(
                            "Apply %1 to the Edited parameter layer through the shared parameter "
-                           "domain facade. Only Edited curves can be modified. The editor validates "
+                           "domain facade. Only Edited curves can be modified. The editor "
+                           "validates "
                            "the expected revision and commits one atomic History entry.")
                     .arg(action);
             }

--- a/src/libs/AutomationWire/PublicToolContract.cpp
+++ b/src/libs/AutomationWire/PublicToolContract.cpp
@@ -556,12 +556,6 @@ namespace AutomationWire {
                     name == QStringLiteral("transition_end")) {
                     return nonNegativeModelIntegerSchema();
                 }
-                if (name == QStringLiteral("name")) {
-                    return JsonSchema::string({QStringLiteral("energy"),
-                                               QStringLiteral("breathiness"),
-                                               QStringLiteral("voicing"), QStringLiteral("tension"),
-                                               QStringLiteral("mouth_opening")});
-                }
             }
             if (name == QStringLiteral("document_id") ||
                 name == QStringLiteral("current_document_id") ||
@@ -630,8 +624,17 @@ namespace AutomationWire {
                 name == QStringLiteral("discard_changes")) {
                 return JsonSchema::boolean();
             }
-            if (name == QStringLiteral("name") && id.startsWith(QStringLiteral("parameters.")))
+            if (name == QStringLiteral("name") && id.startsWith(QStringLiteral("parameters."))) {
+                if (id == PublicToolNames::parameters_trace || isCurveTransformOperation(id)) {
+                    QStringList names{QStringLiteral("energy"), QStringLiteral("breathiness"),
+                                      QStringLiteral("voicing"), QStringLiteral("tension"),
+                                      QStringLiteral("mouth_opening")};
+                    if (id == PublicToolNames::parameters_trace)
+                        names.prepend(QStringLiteral("pitch"));
+                    return JsonSchema::string(names);
+                }
                 return parameterNameSchema();
+            }
             if (name == QStringLiteral("idempotency_key"))
                 return JsonSchema::string({}, 0, MaximumIdempotencyKeyLength);
             if (name == QStringLiteral("cursor") ||

--- a/src/libs/AutomationWire/PublicToolContract.cpp
+++ b/src/libs/AutomationWire/PublicToolContract.cpp
@@ -541,7 +541,28 @@ namespace AutomationWire {
             return persistentPlaybackOperations().contains(id);
         }
 
+        bool isCurveTransformOperation(const QString &id) {
+            return id == PublicToolNames::parameters_modulate ||
+                   id == PublicToolNames::parameters_shape ||
+                   id == PublicToolNames::parameters_scale;
+        }
+
         QJsonObject inputFieldSchema(const QString &id, const QString &name) {
+            if (isCurveTransformOperation(id)) {
+                if (name == QStringLiteral("factor"))
+                    return JsonSchema::number(0.0, 2.0);
+                if (name == QStringLiteral("local_start") || name == QStringLiteral("local_end") ||
+                    name == QStringLiteral("transition_start") ||
+                    name == QStringLiteral("transition_end")) {
+                    return nonNegativeModelIntegerSchema();
+                }
+                if (name == QStringLiteral("name")) {
+                    return JsonSchema::string({QStringLiteral("energy"),
+                                               QStringLiteral("breathiness"),
+                                               QStringLiteral("voicing"), QStringLiteral("tension"),
+                                               QStringLiteral("mouth_opening")});
+                }
+            }
             if (name == QStringLiteral("document_id") ||
                 name == QStringLiteral("current_document_id") ||
                 name == QStringLiteral("task_id")) {
@@ -936,6 +957,9 @@ namespace AutomationWire {
                 PublicToolNames::parameters_draw,
                 PublicToolNames::parameters_erase,
                 PublicToolNames::parameters_trace,
+                PublicToolNames::parameters_modulate,
+                PublicToolNames::parameters_shape,
+                PublicToolNames::parameters_scale,
                 PublicToolNames::parameters_create_anchor_curve,
                 PublicToolNames::parameters_insert_anchors,
                 PublicToolNames::parameters_merge_anchor_curves,
@@ -1127,34 +1151,40 @@ namespace AutomationWire {
                 {PublicToolNames::parameters_get,
                  {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("layer")}                           },
                 {PublicToolNames::parameters_replace,
-                 {QStringLiteral("clip_id"), QStringLiteral("name"),
-                  QStringLiteral("curves")}                                                                             },
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("curves")}                          },
                 {PublicToolNames::parameters_draw,
-                 {QStringLiteral("clip_id"), QStringLiteral("name"),
-                  QStringLiteral("local_start"), QStringLiteral("step"), QStringLiteral("values")}                      },
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("local_start"),
+                  QStringLiteral("step"), QStringLiteral("values")}                                                     },
                 {PublicToolNames::parameters_erase,
-                 {QStringLiteral("clip_id"), QStringLiteral("name"),
-                  QStringLiteral("local_start"), QStringLiteral("local_end")}                                           },
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("local_start"),
+                  QStringLiteral("local_end")}                                                                          },
                 {PublicToolNames::parameters_trace,
                  {QStringLiteral("clip_id"), QStringLiteral("name")}                                                    },
+                {PublicToolNames::parameters_modulate,
+                 {QStringLiteral("clip_id"), QStringLiteral("local_start"),
+                  QStringLiteral("local_end"), QStringLiteral("factor")}                                                },
+                {PublicToolNames::parameters_shape,
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("local_start"),
+                  QStringLiteral("local_end"), QStringLiteral("factor")}                                                },
+                {PublicToolNames::parameters_scale,
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("local_start"),
+                  QStringLiteral("local_end"), QStringLiteral("factor")}                                                },
                 {PublicToolNames::parameters_create_anchor_curve,
-                 {QStringLiteral("clip_id"), QStringLiteral("name"),
-                  QStringLiteral("client_ref"), QStringLiteral("anchors")}                                              },
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("client_ref"),
+                  QStringLiteral("anchors")}                                                                            },
                 {PublicToolNames::parameters_insert_anchors,
-                 {QStringLiteral("clip_id"), QStringLiteral("name"),
-                  QStringLiteral("curve_id"), QStringLiteral("anchors")}                                                },
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("curve_id"),
+                  QStringLiteral("anchors")}                                                                            },
                 {PublicToolNames::parameters_merge_anchor_curves,
                  {QStringLiteral("clip_id"), QStringLiteral("name"),
                   QStringLiteral("target_curve_id"), QStringLiteral("source_curve_id")}                                 },
                 {PublicToolNames::parameters_move_anchors,
-                 {QStringLiteral("clip_id"), QStringLiteral("name"),
-                  QStringLiteral("moves")}                                                                              },
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("moves")}                           },
                 {PublicToolNames::parameters_remove_anchors,
-                 {QStringLiteral("clip_id"), QStringLiteral("name"),
-                  QStringLiteral("anchor_ids")}                                                                         },
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("anchor_ids")}                      },
                 {PublicToolNames::parameters_set_anchor_interpolation,
-                 {QStringLiteral("clip_id"), QStringLiteral("name"),
-                  QStringLiteral("anchor_ids"), QStringLiteral("interpolation")}                                        },
+                 {QStringLiteral("clip_id"), QStringLiteral("name"), QStringLiteral("anchor_ids"),
+                  QStringLiteral("interpolation")}                                                                      },
                 {PublicToolNames::tempos_set,                          {QStringLiteral("tick"), QStringLiteral("tempo")}},
                 {PublicToolNames::tempos_remove,                       {QStringLiteral("tick")}                         },
                 {PublicToolNames::time_signatures_set,
@@ -1228,6 +1258,12 @@ namespace AutomationWire {
                 {PublicToolNames::parameters_draw,              {QStringLiteral("merge_mode")}                     },
                 {PublicToolNames::parameters_trace,
                  {QStringLiteral("local_start"), QStringLiteral("local_end")}                                      },
+                {PublicToolNames::parameters_modulate,
+                 {QStringLiteral("transition_start"), QStringLiteral("transition_end")}                            },
+                {PublicToolNames::parameters_shape,
+                 {QStringLiteral("transition_start"), QStringLiteral("transition_end")}                            },
+                {PublicToolNames::parameters_scale,
+                 {QStringLiteral("transition_start"), QStringLiteral("transition_end")}                            },
                 {PublicToolNames::inference_start,              {QStringLiteral("stages")}                         },
                 {PublicToolNames::tasks_list,
                  {QStringLiteral("state"), QStringLiteral("kind"), QStringLiteral("cursor"),
@@ -3835,6 +3871,8 @@ namespace AutomationWire {
         }
 
         QString humanTitle(const QString &operationId) {
+            if (operationId == PublicToolNames::parameters_modulate)
+                return QStringLiteral("Modulate pitch");
             auto result = operationId;
             result.replace(u'.', u' ');
             result.replace(u'_', u' ');
@@ -4009,6 +4047,47 @@ namespace AutomationWire {
                     .arg(action);
             }
             if (category == QStringLiteral("parameters")) {
+                if (operationId == PublicToolNames::parameters_trace) {
+                    return QStringLiteral(
+                        "Trace original sampled curves into Edited, optionally within a clip-local "
+                        "half-open tick range. Preserve edited samples in original-data gaps and "
+                        "retain anchor curves. Without original data this is a no-op. Commits one "
+                        "History step.");
+                }
+                if (isCurveTransformOperation(operationId)) {
+                    QString description;
+                    if (operationId == PublicToolNames::parameters_modulate) {
+                        description = QStringLiteral(
+                            "Modulate pitch deviations from the smoothed note pitch baseline. "
+                            "Build the baseline from the clip's existing note pitches and phoneme "
+                            "timings. Return operation_unavailable if those data cannot provide a "
+                            "usable baseline for the selected range. ");
+                    } else if (operationId == PublicToolNames::parameters_shape) {
+                        description = QStringLiteral(
+                            "Shape normalized parameter deviations from the line through the "
+                            "selected endpoints. ");
+                    } else {
+                        description = QStringLiteral("Scale normalized parameter values. ");
+                    }
+                    return description +
+                           QStringLiteral(
+                               "Apply factor 0..2 to merged original and edited sampled curves and "
+                               "write "
+                               "only Edited, retaining anchors. local_start/local_end form a "
+                               "clip-local "
+                               "half-open range of at least 10 ticks; all boundaries use the "
+                               "non-negative "
+                               "5-tick grid. Clamp to the first touched continuous segment from "
+                               "left to "
+                               "right; pitch also respects inference-piece boundaries. Optional "
+                               "transition_start/transition_end clamp to that segment; defaults "
+                               "use 60ms "
+                               "shoulders. resolved_values always reports the four actual "
+                               "boundaries, even "
+                               "when changed is false. The outer interval is the processing range, "
+                               "not a "
+                               "claim that every sample changed. Commits one History step.");
+                }
                 return QStringLiteral(
                            "Apply %1 to the Edited parameter layer through the shared parameter "
                            "domain facade. Only Edited curves can be modified. The editor validates "
@@ -4088,7 +4167,8 @@ namespace AutomationWire {
             }
             if (id.startsWith(QStringLiteral("parameters.")) &&
                 id != PublicToolNames::parameters_get &&
-                id != PublicToolNames::parameters_get_capabilities) {
+                id != PublicToolNames::parameters_get_capabilities &&
+                id != PublicToolNames::parameters_modulate) {
                 add(QStringLiteral("/name"), PublicToolNames::parameters_get_capabilities,
                     {QStringLiteral("/document_id"), QStringLiteral("/clip_id")});
                 if (id == PublicToolNames::parameters_replace) {

--- a/src/libs/AutomationWire/PublicToolDefinitions.inc
+++ b/src/libs/AutomationWire/PublicToolDefinitions.inc
@@ -205,6 +205,12 @@ AUTOMATION_WIRE_PUBLIC_TOOL(parameters_erase, "parameters.erase", "parameters", 
                             Synchronous, 1, NonDestructive, Idempotent, ClosedWorld)
 AUTOMATION_WIRE_PUBLIC_TOOL(parameters_trace, "parameters.trace", "parameters", L1, Command,
                             Synchronous, 1, NonDestructive, Idempotent, ClosedWorld)
+AUTOMATION_WIRE_PUBLIC_TOOL(parameters_modulate, "parameters.modulate", "parameters", L1, Command,
+                            Synchronous, 1, NonDestructive, Idempotent, ClosedWorld)
+AUTOMATION_WIRE_PUBLIC_TOOL(parameters_shape, "parameters.shape", "parameters", L1, Command,
+                            Synchronous, 1, NonDestructive, Idempotent, ClosedWorld)
+AUTOMATION_WIRE_PUBLIC_TOOL(parameters_scale, "parameters.scale", "parameters", L1, Command,
+                            Synchronous, 1, NonDestructive, Idempotent, ClosedWorld)
 AUTOMATION_WIRE_PUBLIC_TOOL(parameters_create_anchor_curve, "parameters.create_anchor_curve",
                             "parameters", L1, Command, Synchronous, 1, NonDestructive, Idempotent,
                             ClosedWorld)

--- a/src/tests/AutomationTestSupport/CMakeLists.txt
+++ b/src/tests/AutomationTestSupport/CMakeLists.txt
@@ -49,6 +49,8 @@ add_library(AutomationTestSupport STATIC
     ../../app/Modules/FillLyric/Utils/LyricRuleAutomationUtils.cpp
     ../../app/Modules/FillLyric/Utils/TaggerRuleOrder.cpp
     ../../app/UI/Views/TrackEditor/AudioClipDragState.cpp
+    ../../app/UI/Views/ClipEditor/DrawCurveEditUtils.cpp
+    ../../app/UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.cpp
     ${_automation_edit_action_sources}
 )
 

--- a/src/tests/AutomationTestSupport/CMakeLists.txt
+++ b/src/tests/AutomationTestSupport/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(AutomationTestSupport STATIC
     ../../app/Modules/FillLyric/Utils/TaggerRuleOrder.cpp
     ../../app/UI/Views/TrackEditor/AudioClipDragState.cpp
     ../../app/UI/Views/ClipEditor/DrawCurveEditUtils.cpp
+    ../../app/UI/Views/ClipEditor/CurveTransform/CurveTransformSession.cpp
     ../../app/UI/Views/ClipEditor/AnchorEditor/AnchorEditUtils.cpp
     ${_automation_edit_action_sources}
 )

--- a/src/tests/AutomationTestSupport/TestRuntime.h
+++ b/src/tests/AutomationTestSupport/TestRuntime.h
@@ -88,13 +88,15 @@ namespace AutomationTestSupport {
                              Automation::PlaybackRuntimeServices playbackServices = {},
                              Automation::ApplicationRuntimeServices applicationServices = {},
                              Automation::SettingsRuntimeServices settingsServices = {},
-                             Automation::PresetRuntimeServices presetServices = {})
+                             Automation::PresetRuntimeServices presetServices = {},
+                             Automation::ParameterRuntimeServices parameterServices = {})
             : m_history(resetHistory()),
               m_runtime(&m_model, m_history, std::move(documentServices),
                         std::move(playbackServices), std::move(editorServices),
                         std::move(settingsServices), std::move(presetServices),
                         std::move(packageServices), {}, std::move(fileServices),
-                        std::move(audioExportServices), {}, std::move(applicationServices)) {
+                        std::move(audioExportServices), {}, std::move(applicationServices),
+                        Automation::WindowId::create(), std::move(parameterServices)) {
         }
 
         ~TestRuntime() {

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -1494,7 +1494,7 @@ namespace {
                                                       Param::Edited, {first, second});
                 testRuntime.history()->reset();
                 const Automation::ParameterTransformDto request{
-                    0, 100, kind == Kind::Scale ? 0.5 : 0.0, 0, 100};
+                    1, 99, kind == Kind::Scale ? 0.5 : 0.0, 1, 99};
                 const auto applied = runtime.parameters().transformParameter(
                     commandContext(runtime), clipId, name, kind, request);
                 const auto snapshot = [&] {

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -1565,7 +1565,7 @@ namespace {
 
         suite.run(
             Automation::OperationIds::parameters::trace,
-            QStringLiteral("anchor-materialization-bounded"), [&] {
+            QStringLiteral("preserve-gaps-and-anchors"), [&] {
                 const auto created = runtime.parameters().createAnchorCurve(
                     commandContext(runtime), clipId, ParamInfo::Pitch, Param::Edited,
                     QStringLiteral("huge-anchor"),
@@ -1578,12 +1578,56 @@ namespace {
                 const auto base = runtime.documentVersion();
                 const auto traced = runtime.parameters().traceParameter(
                     commandContext(runtime), clipId, ParamInfo::Pitch, 0, 5);
-                suite.expect(
-                    isError(traced, AutomationErrorCode::InvalidArgument,
-                            QStringLiteral("local_end")) &&
-                        runtime.documentVersion() == base,
-                    QStringLiteral(
-                        "partial trace must reject an unsafe anchor expansion before mutation"));
+                suite.expect(traced && !traced.get().changed && runtime.documentVersion() == base,
+                             QStringLiteral("trace without original data must preserve anchors"));
+
+                auto before = runtime.parameters().getParameter(
+                    base.documentId, clipId, ParamInfo::Pitch, Param::Edited).get().curves;
+                Automation::CurveDraftDto draw;
+                draw.type = Automation::CurveDraftDto::Type::Draw;
+                draw.localStart = 0;
+                draw.step = 5;
+                draw.values = QList<int>(8, 6000);
+                before.prepend(draw);
+                runtime.parameters().replaceParameter(commandContext(runtime), clipId,
+                                                       ParamInfo::Pitch, Param::Edited, before);
+                auto first = draw;
+                first.values = {6100, 6110};
+                auto second = first;
+                second.localStart = 20;
+                second.values = {6200, 6210};
+                runtime.parameters().replaceParameter(commandContext(runtime), clipId,
+                                                       ParamInfo::Pitch, Param::Original,
+                                                       {first, second});
+                const auto beforeTrace = runtime.documentVersion();
+                const auto applied = runtime.parameters().traceParameter(
+                    commandContext(runtime), clipId, ParamInfo::Pitch, 0, 30);
+                const auto snapshot = [&] {
+                    return runtime.parameters().getParameter(
+                        runtime.documentVersion().documentId, clipId, ParamInfo::Pitch,
+                        Param::Edited).get().curves;
+                };
+                const auto after = snapshot();
+                suite.expect(applied && applied.get().changed &&
+                                 applied.get().current.revision == beforeTrace.revision + 1 &&
+                                 after.size() == 2 &&
+                                 after.first().values == QList<int>{6100, 6110, 6000, 6000,
+                                                                   6200, 6210, 6000, 6000} &&
+                                 after.last().id == before.last().id &&
+                                 after.last().nodes.size() == 2 &&
+                                 after.last().nodes.last().position == std::numeric_limits<int>::max(),
+                             QStringLiteral("trace must preserve holes, outside samples and anchors"));
+                const auto undo = runtime.history().undo(commandContext(runtime));
+                suite.expect(undo && snapshot().first().values == draw.values,
+                             QStringLiteral("one undo must restore the complete trace edit"));
+                const auto redo = runtime.history().redo(commandContext(runtime));
+                suite.expect(redo && snapshot().first().values == after.first().values &&
+                                 snapshot().last().id == after.last().id,
+                             QStringLiteral("one redo must restore the traced curves"));
+                const auto noOp = runtime.parameters().traceParameter(
+                    commandContext(runtime), clipId, ParamInfo::Pitch, 0, 30);
+                suite.expect(noOp && !noOp.get().changed,
+                             QStringLiteral("repeating trace must not add an undo step"));
             });
 
         const auto speakerA = speaker(QStringLiteral("speaker-a"));

--- a/src/tests/TestAutomationEditingDomains/main.cpp
+++ b/src/tests/TestAutomationEditingDomains/main.cpp
@@ -4,6 +4,7 @@
 
 #include <lite/History/HistoryManager.h>
 #include <lite/ProjectModel/AppModel/SpeakerMixData.h>
+#include <lite/ProjectModel/AppModel/ParamProperties.h>
 #include <lite/ProjectModel/Voice/SingerInfo.h>
 #include <lite/ProjectModel/Voice/SpeakerInfo.h>
 
@@ -1456,6 +1457,84 @@ namespace {
         return data;
     }
 
+    void testCurveTransforms(Suite &suite) {
+        using CurveTransform::Kind;
+        const MouthOpeningParamProperties properties;
+        for (const auto kind : {Kind::Shape, Kind::Scale, Kind::ModulatePitch}) {
+            const auto name =
+                kind == Kind::ModulatePitch ? ParamInfo::Pitch : ParamInfo::MouthOpening;
+            Automation::ParameterRuntimeServices services;
+            services.prepareTransform =
+                [&properties](SingingClip *, ParamInfo::Name,
+                              const Kind kind) -> AutomationResult<CurveTransform::Config> {
+                CurveTransform::Config config;
+                config.kind = kind;
+                config.properties = &properties;
+                config.tickToMilliseconds = [](const int tick) { return double(tick); };
+                config.pitchBaselineAtTick = [](int) { return std::optional<double>(6000.0); };
+                return config;
+            };
+            TestRuntime testRuntime({}, {}, {}, {}, {}, {}, {}, {}, {}, std::move(services));
+            auto &runtime = testRuntime.runtime();
+            const auto trackId = insertedTrack(runtime, QStringLiteral("Curves"));
+            const auto clipId = insertedSingingClip(runtime, trackId, QStringLiteral("Curve Clip"));
+            const auto &operation =
+                kind == Kind::ModulatePitch ? Automation::OperationIds::parameters::modulate
+                : kind == Kind::Shape       ? Automation::OperationIds::parameters::shape
+                                            : Automation::OperationIds::parameters::scale;
+            suite.run(operation, QStringLiteral("clamped-range-result-and-undo"), [&] {
+                Automation::CurveDraftDto first;
+                first.type = Automation::CurveDraftDto::Type::Draw;
+                first.localStart = 20;
+                first.values = kind == Kind::ModulatePitch ? QList<int>{6100, 6500, 6200}
+                                                           : QList<int>{100, 900, 500};
+                auto second = first;
+                second.localStart = 60;
+                runtime.parameters().replaceParameter(commandContext(runtime), clipId, name,
+                                                      Param::Edited, {first, second});
+                testRuntime.history()->reset();
+                const Automation::ParameterTransformDto request{
+                    0, 100, kind == Kind::Scale ? 0.5 : 0.0, 0, 100};
+                const auto applied = runtime.parameters().transformParameter(
+                    commandContext(runtime), clipId, name, kind, request);
+                const auto snapshot = [&] {
+                    return runtime.parameters()
+                        .getParameter(runtime.documentVersion().documentId, clipId, name,
+                                      Param::Edited)
+                        .get()
+                        .curves;
+                };
+                const auto expected = kind == Kind::ModulatePitch ? QList<int>{6000, 6000, 6000}
+                                      : kind == Kind::Shape       ? QList<int>{100, 300, 500}
+                                                                  : QList<int>{50, 450, 250};
+                const QList<Automation::ResolvedValue> bounds{
+                    {QStringLiteral("/local_start"),      20},
+                    {QStringLiteral("/local_end"),        35},
+                    {QStringLiteral("/transition_start"), 20},
+                    {QStringLiteral("/transition_end"),   35},
+                };
+                suite.expect(
+                    applied && applied.get().changed && applied.get().resolvedValues == bounds &&
+                        snapshot().first().values == expected &&
+                        snapshot().last().values == second.values,
+                    QStringLiteral(
+                        "transform must report its clamped range and preserve the next segment"));
+                const auto undo = runtime.history().undo(commandContext(runtime));
+                suite.expect(undo && snapshot().first().values == first.values,
+                             QStringLiteral("one undo must restore the transform source"));
+                const auto redo = runtime.history().redo(commandContext(runtime));
+                suite.expect(redo && snapshot().first().values == expected,
+                             QStringLiteral("one redo must restore the transform result"));
+                auto unchanged = request;
+                unchanged.factor = 1.0;
+                const auto noOp = runtime.parameters().transformParameter(
+                    commandContext(runtime), clipId, name, kind, unchanged);
+                suite.expect(noOp && !noOp.get().changed && noOp.get().resolvedValues == bounds,
+                             QStringLiteral("a no-op must still report the actual selected range"));
+            });
+        }
+    }
+
     void testParameterAndSpeakerDomain(Suite &suite) {
         TestRuntime testRuntime;
         auto &runtime = testRuntime.runtime();
@@ -2200,6 +2279,7 @@ int main(int argc, char *argv[]) {
     testProjectDomain(suite);
     testNoteDomain(suite);
     testParameterAndSpeakerDomain(suite);
+    testCurveTransforms(suite);
     testTimelineAndHistoryDomain(suite);
     testQuantizeInChild(suite);
     return suite.result();

--- a/src/tests/TestCurveTransform/main.cpp
+++ b/src/tests/TestCurveTransform/main.cpp
@@ -119,6 +119,36 @@ namespace {
         return ok;
     }
 
+    bool testExplicitRange() {
+        using namespace CurveTransform;
+        bool ok = true;
+        auto source = curve(0, QList<int>(40, 400));
+        MouthOpeningParamProperties properties;
+        Config config;
+        config.kind = Kind::Scale;
+        config.properties = &properties;
+        config.tickToMilliseconds = [](const int tick) { return double(tick); };
+        config.partitions = {{0, 95}, {100, 195}};
+        Session session;
+        session.setSource({&source}, {}, config);
+        ok &= expect(!session.selectRange(80, 120) && session.phase() == Phase::Idle,
+                     "explicit range must not silently truncate at a pitch partition");
+        ok &= expect(!session.selectRange(40, 60, 20, 110),
+                     "explicit shoulder must stay in the selected component");
+        ok &= expect(session.selectRange(40, 60), "explicit range accepts default shoulders");
+        ok &= expect(session.bounds().c == 0 && session.bounds().d == 100,
+                     "default shoulders stop at the component boundaries");
+        ok &= expect(session.selectRange(40, 60, 20, 80) && session.beginTransform() &&
+                         session.setFactor(0.5),
+                     "explicit range and factor start the shared transform");
+        auto preview = session.buildEditedPreview();
+        ok &= expect(valueAt(preview, 20) == 400 && valueAt(preview, 30) == 300 &&
+                         valueAt(preview, 40) == 200 && valueAt(preview, 70) == 300,
+                     "explicit transform applies the shared smooth shoulders");
+        qDeleteAll(preview);
+        return ok;
+    }
+
     bool testShouldersAndBoundaries() {
         using namespace CurveTransform;
         bool ok = true;
@@ -625,6 +655,7 @@ int main(int argc, char *argv[]) {
     bool ok = true;
     ok &= testMappings();
     ok &= testSelectionDirectionAndPartitions();
+    ok &= testExplicitRange();
     ok &= testCompleteSampleIntervals();
     ok &= testShouldersAndBoundaries();
     ok &= testShapeAndScale();

--- a/src/tests/TestCurveTransform/main.cpp
+++ b/src/tests/TestCurveTransform/main.cpp
@@ -131,10 +131,11 @@ namespace {
         config.partitions = {{0, 95}, {100, 195}};
         Session session;
         session.setSource({&source}, {}, config);
-        ok &= expect(!session.selectRange(80, 120) && session.phase() == Phase::Idle,
-                     "explicit range must not silently truncate at a pitch partition");
-        ok &= expect(!session.selectRange(40, 60, 20, 110),
-                     "explicit shoulder must stay in the selected component");
+        ok &= expect(session.selectRange(80, 120) && session.bounds().a == 80 &&
+                         session.bounds().b == 100,
+                     "explicit range clamps to the first touched pitch partition");
+        ok &= expect(session.selectRange(40, 60, 20, 110) && session.bounds().d == 100,
+                     "explicit shoulder clamps to the selected component");
         ok &= expect(session.selectRange(40, 60), "explicit range accepts default shoulders");
         ok &= expect(session.bounds().c == 0 && session.bounds().d == 100,
                      "default shoulders stop at the component boundaries");

--- a/src/tests/TestCurveTransform/main.cpp
+++ b/src/tests/TestCurveTransform/main.cpp
@@ -131,17 +131,20 @@ namespace {
         config.partitions = {{0, 95}, {100, 195}};
         Session session;
         session.setSource({&source}, {}, config);
-        ok &= expect(session.selectRange(80, 120) && session.bounds().a == 80 &&
-                         session.bounds().b == 100,
+        ok &= expect(session.selectRange(80, std::numeric_limits<int>::max()) &&
+                         session.bounds().a == 80 && session.bounds().b == 100,
                      "explicit range clamps to the first touched pitch partition");
         ok &= expect(session.selectRange(40, 60, 20, 110) && session.bounds().d == 100,
                      "explicit shoulder clamps to the selected component");
         ok &= expect(session.selectRange(40, 60), "explicit range accepts default shoulders");
         ok &= expect(session.bounds().c == 0 && session.bounds().d == 100,
                      "default shoulders stop at the component boundaries");
-        ok &= expect(session.selectRange(40, 60, 20, 80) && session.beginTransform() &&
+        ok &= expect(session.selectRange(39, 48) && session.bounds().a == 40 &&
+                         session.bounds().b == 50,
+                     "minimum selection width is checked after alignment");
+        ok &= expect(session.selectRange(36, 59, 18, 81) && session.beginTransform() &&
                          session.setFactor(0.5),
-                     "explicit range and factor start the shared transform");
+                     "off-grid range and shoulders use the shared GUI alignment");
         auto preview = session.buildEditedPreview();
         ok &= expect(valueAt(preview, 20) == 400 && valueAt(preview, 30) == 300 &&
                          valueAt(preview, 40) == 200 && valueAt(preview, 70) == 300,
@@ -213,12 +216,12 @@ namespace {
                          session.bounds().d == session.bounds().componentEnd,
                      "default shoulders clamp to short component boundaries");
 
-        config.tickToMilliseconds = [](const int tick) { return tick * 2.0; };
+        config.tickToMilliseconds = [](const int tick) { return tick * 2.3; };
         session.setSource({&source}, {}, config);
         session.beginSelection(200);
         ok &= expect(session.finishSelection(600), "tempo-aware shoulder selection succeeds");
-        ok &= expect(session.bounds().c == 170 && session.bounds().d == 630,
-                     "default shoulder cap is converted through the timeline");
+        ok &= expect(session.bounds().c == 175 && session.bounds().d == 625,
+                     "default shoulders stay on the grid within the time cap");
         return ok;
     }
 

--- a/src/tests/TestPublicAutomationContract/main.cpp
+++ b/src/tests/TestPublicAutomationContract/main.cpp
@@ -952,8 +952,8 @@ namespace {
             }
         }
         expect(
-            publicToolContracts().size() == 176 && guiOnly.size() == 25 && both.size() == 151,
-            QStringLiteral("public host split must contain 25 GUI-only and 151 both-host tools"));
+            publicToolContracts().size() == 179 && guiOnly.size() == 25 && both.size() == 154,
+            QStringLiteral("public host split must contain 25 GUI-only and 154 both-host tools"));
         expect(
             guiOnly.size() + both.size() == publicToolContracts().size(),
             QStringLiteral("GUI-only and both-host contracts must partition the public toolset"));

--- a/src/tests/TestPublicAutomationRegistry/main.cpp
+++ b/src/tests/TestPublicAutomationRegistry/main.cpp
@@ -1533,12 +1533,12 @@ namespace {
         Automation::NativeJsonRpcDispatcher native(registry);
 
         const auto enabled = registry.enabledContracts();
-        expect(enabled.size() == 151 && std::all_of(enabled.cbegin(), enabled.cend(),
+        expect(enabled.size() == 154 && std::all_of(enabled.cbegin(), enabled.cend(),
                                                     [](const auto &contract) {
                                                         return contract.hostAvailability ==
                                                                QStringLiteral("both");
                                                     }),
-               QStringLiteral("headless registry must expose exactly the 151 both-host tools"));
+               QStringLiteral("headless registry must expose exactly the 154 both-host tools"));
 
         Automation::McpRequestDispatcher mcp(registry,
                                              {
@@ -1576,9 +1576,9 @@ namespace {
             if (cursor.isEmpty())
                 break;
         }
-        expect(toolsListValid && cursor.isEmpty() && listedToolCount == 151 &&
-                   listedToolIds.size() == 151,
-               QStringLiteral("headless MCP tools/list must expose exactly 151 unique tools"));
+        expect(toolsListValid && cursor.isEmpty() && listedToolCount == 154 &&
+                   listedToolIds.size() == 154,
+               QStringLiteral("headless MCP tools/list must expose exactly 154 unique tools"));
 
         const auto guiOnly = registry.invoke(QStringLiteral("track_panel.set_viewport"), {});
         expect(!guiOnly &&


### PR DESCRIPTION
基于 #179，将 GUI 的描摹、调制、整形和缩放行为接入公共参数工具，MCP 与无头模式共用同一实现。

- 新增 `parameters.modulate`、`parameters.shape`、`parameters.scale`，复用曲线变换会话及音高基线。调制固定处理 pitch，不接受 `name`；全部工具只写入 Edited。
- 变换边界接受任意非负整数 tick，内部按 GUI 规则对齐，并 clamp 到从左向右触及的第一个连续采样/推理分段；默认过渡在 5 tick 网格上取不超过 60 ms 的宽度。`resolved_values` 返回四个实际边界，包括无修改的情况。
- 描摹复用 GUI 笔画与重采样逻辑：非标准网格的相交 Edited 曲线会整体重采样为 5 tick，原始数据空洞保留该网格上的编辑值；保留完整锚点曲线，没有原始采样数据时不修改。中性变换系数仍允许将 Original 固化到 Edited，是否创建历史记录取决于最终 Edited 数据是否变化。

验证：Debug 完整构建；`TestCurveTransform`、`TestAutomationEditingDomains`、`TestPublicAutomationContract`、`TestPublicAutomationRegistry`、`TestDsConnectorLite` 通过。实际通过连接器验证 GUI 与无头模式下的变换结果、clamp 边界及后续分段保留，并验证 Native 接口调用。回归测试覆盖描摹空洞/锚点保留、撤销重做和无修改时的范围响应。


