### PR TITLE
fix(lyrics): reject exhausted syllable assignment markers

### DIFF
--- a/src/app/Modules/Inference/Tasks/Syllabification.cpp
+++ b/src/app/Modules/Inference/Tasks/Syllabification.cpp
@@ -8,28 +8,6 @@
 #include <algorithm>
 
 namespace {
-    using PhonemeRange = Syllabification::PhonemeRange;
-
-    QList<PhonemeRange> splitSyllables(const QList<PhonemeName> &phonemes) {
-        QList<PhonemeRange> syllables;
-        int syllableStart = 0;
-        bool hasOnset = false;
-
-        for (int i = 0; i < phonemes.size(); ++i) {
-            const auto &phoneme = phonemes.at(i);
-            if (phoneme.isOnset && hasOnset) {
-                syllables.append({syllableStart, i - syllableStart});
-                syllableStart = i;
-            }
-            if (phoneme.isOnset)
-                hasOnset = true;
-        }
-
-        if (!phonemes.isEmpty())
-            syllables.append({syllableStart, static_cast<int>(phonemes.size()) - syllableStart});
-        return syllables;
-    }
-
     bool isWordContinuationLyric(const QString &lyric) {
         return Note::isSlurLyric(lyric) || Syllabification::isSyllabificationLyric(lyric);
     }
@@ -56,46 +34,6 @@ namespace {
 }
 
 namespace Syllabification {
-    bool isSyllabificationLyric(const QString &lyric) {
-        return Note::isSyllabificationLyric(lyric);
-    }
-
-    QList<PhonemeRange> phonemeRangesForNotes(const QStringList &lyrics,
-                                              const QList<PhonemeName> &phonemes) {
-        QList<PhonemeRange> result(lyrics.size());
-        if (lyrics.isEmpty() || phonemes.isEmpty())
-            return result;
-
-        QList<int> syllabificationTargets{0};
-        for (int i = 1; i < lyrics.size(); ++i) {
-            if (isSyllabificationLyric(lyrics.at(i)))
-                syllabificationTargets.append(i);
-        }
-
-        const auto syllables = splitSyllables(phonemes);
-        int syllableIndex = 0;
-        for (int i = 0; i < syllabificationTargets.size(); ++i) {
-            const auto target = syllabificationTargets.at(i);
-            if (syllableIndex >= syllables.size())
-                break;
-
-            const bool isLastTarget = i == syllabificationTargets.size() - 1;
-            const int quota = target == 0 ? 1 + Note::trailingSyllabificationCount(lyrics.first())
-                                          : static_cast<int>(lyrics.at(target).trimmed().size());
-            const int remainingSyllables = static_cast<int>(syllables.size()) - syllableIndex;
-            const int takenSyllables =
-                isLastTarget ? remainingSyllables : std::min(quota, remainingSyllables);
-            if (takenSyllables <= 0)
-                continue;
-
-            const auto first = syllables.at(syllableIndex);
-            const auto last = syllables.at(syllableIndex + takenSyllables - 1);
-            result[target] = {first.start, last.start + last.count - first.start};
-            syllableIndex += takenSyllables;
-        }
-        return result;
-    }
-
     void keepPhonemesOnWordRoots(const QList<NoteInferenceSnapshot> &notes,
                                  QList<PhonemeNameResult> &results) {
         if (notes.size() != results.size())

--- a/src/app/Modules/Inference/Tasks/Syllabification.h
+++ b/src/app/Modules/Inference/Tasks/Syllabification.h
@@ -4,20 +4,12 @@
 #include "Modules/Inference/Models/NoteInferenceSnapshot.h"
 #include "Modules/Inference/Models/PhonemeNameResult.h"
 
-#include <QStringList>
+#include <lite/ProjectModel/Utils/Syllabification.h>
 
 class InferInputNote;
 class Timeline;
 
 namespace Syllabification {
-    struct PhonemeRange {
-        int start = 0;
-        int count = 0;
-    };
-
-    bool isSyllabificationLyric(const QString &lyric);
-    QList<PhonemeRange> phonemeRangesForNotes(const QStringList &lyrics,
-                                              const QList<PhonemeName> &phonemes);
     void keepPhonemesOnWordRoots(const QList<NoteInferenceSnapshot> &notes,
                                  QList<PhonemeNameResult> &results);
     void distributeForInference(const QStringList &lyrics, QList<InferInputNote> &notes,

--- a/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicer.cpp
+++ b/src/libs/ProjectModel/SingingClipSlicer/SingingClipSlicer.cpp
@@ -3,8 +3,43 @@
 #include <lite/ProjectModel/SingingClipSlicer/SingingClipSlicerGlobal.h>
 #include <lite/ProjectModel/AppModel/Note.h>
 #include <lite/MusicBase/Timeline.h>
+#include <lite/ProjectModel/Utils/Syllabification.h>
 
 #include <QDebug>
+
+#include <algorithm>
+
+namespace {
+    bool hasUnassignedSyllabificationNotes(const NoteList &notes) {
+        int rootIndex = 0;
+        while (rootIndex < notes.size()) {
+            const auto root = notes.at(rootIndex);
+            if (root->isSyllabification())
+                return true;
+
+            QStringList lyrics{root->lyric()};
+            auto wordEndTick = root->localStart() + root->length();
+            int end = rootIndex + 1;
+            for (; end < notes.size(); ++end) {
+                const auto note = notes.at(end);
+                if ((!note->isSlur() && !note->isSyllabification()) ||
+                    note->localStart() > wordEndTick)
+                    break;
+                lyrics.append(note->lyric());
+                wordEndTick = std::max(wordEndTick, note->localStart() + note->length());
+            }
+
+            const auto ranges =
+                Syllabification::phonemeRangesForNotes(lyrics, root->phonemeNameSeq().result());
+            for (int i = 1; i < lyrics.size(); ++i) {
+                if (Note::isSyllabificationLyric(lyrics.at(i)) && ranges.at(i).count == 0)
+                    return true;
+            }
+            rootIndex = end;
+        }
+        return false;
+    }
+}
 
 SliceResult SingingClipSlicer::slice(const Timeline &timeline, const NoteList &source) {
     // Slice options
@@ -144,9 +179,9 @@ SliceResult SingingClipSlicer::slice(const Timeline &timeline, const NoteList &s
                 }
             }
 
-            // Skip the segment if the complete phrase has missing phoneme info
-            // or if the first note is a slur or orphan syllabification note
-            if (hasMissingPhonemeInfo || firstNoteIsInvalid) {
+            // Skip phrases with missing phonemes or unassigned continuation notes.
+            if (hasMissingPhonemeInfo || firstNoteIsInvalid ||
+                hasUnassignedSyllabificationNotes(buffer)) {
                 buffer.clear();
                 continue;
             }

--- a/src/libs/ProjectModel/Utils/Syllabification.cpp
+++ b/src/libs/ProjectModel/Utils/Syllabification.cpp
@@ -1,0 +1,71 @@
+#include <lite/ProjectModel/Utils/Syllabification.h>
+
+#include <lite/ProjectModel/AppModel/Note.h>
+
+#include <algorithm>
+
+namespace {
+    using PhonemeRange = Syllabification::PhonemeRange;
+
+    QList<PhonemeRange> splitSyllables(const QList<PhonemeName> &phonemes) {
+        QList<PhonemeRange> syllables;
+        int syllableStart = 0;
+        bool hasOnset = false;
+
+        for (int i = 0; i < phonemes.size(); ++i) {
+            const auto &phoneme = phonemes.at(i);
+            if (phoneme.isOnset && hasOnset) {
+                syllables.append({syllableStart, i - syllableStart});
+                syllableStart = i;
+            }
+            if (phoneme.isOnset)
+                hasOnset = true;
+        }
+
+        if (!phonemes.isEmpty())
+            syllables.append({syllableStart, static_cast<int>(phonemes.size()) - syllableStart});
+        return syllables;
+    }
+}
+
+namespace Syllabification {
+    bool isSyllabificationLyric(const QString &lyric) {
+        return Note::isSyllabificationLyric(lyric);
+    }
+
+    QList<PhonemeRange> phonemeRangesForNotes(const QStringList &lyrics,
+                                            const QList<PhonemeName> &phonemes) {
+        QList<PhonemeRange> result(lyrics.size());
+        if (lyrics.isEmpty() || phonemes.isEmpty())
+            return result;
+
+        QList<int> syllabificationTargets{0};
+        for (int i = 1; i < lyrics.size(); ++i) {
+            if (isSyllabificationLyric(lyrics.at(i)))
+                syllabificationTargets.append(i);
+        }
+
+        const auto syllables = splitSyllables(phonemes);
+        int syllableIndex = 0;
+        for (int i = 0; i < syllabificationTargets.size(); ++i) {
+            const auto target = syllabificationTargets.at(i);
+            if (syllableIndex >= syllables.size())
+                break;
+
+            const bool isLastTarget = i == syllabificationTargets.size() - 1;
+            const int quota = target == 0 ? 1 + Note::trailingSyllabificationCount(lyrics.first())
+                                         : static_cast<int>(lyrics.at(target).trimmed().size());
+            const int remainingSyllables = static_cast<int>(syllables.size()) - syllableIndex;
+            const int takenSyllables =
+                isLastTarget ? remainingSyllables : std::min(quota, remainingSyllables);
+            if (takenSyllables <= 0)
+                continue;
+
+            const auto first = syllables.at(syllableIndex);
+            const auto last = syllables.at(syllableIndex + takenSyllables - 1);
+            result[target] = {first.start, last.start + last.count - first.start};
+            syllableIndex += takenSyllables;
+        }
+        return result;
+    }
+}

--- a/src/libs/ProjectModel/Utils/Syllabification.h
+++ b/src/libs/ProjectModel/Utils/Syllabification.h
@@ -1,0 +1,19 @@
+#ifndef PROJECTMODEL_SYLLABIFICATION_H
+#define PROJECTMODEL_SYLLABIFICATION_H
+
+#include <lite/ProjectModel/AppModel/Phonemes.h>
+
+#include <QStringList>
+
+namespace Syllabification {
+    struct PhonemeRange {
+        int start = 0;
+        int count = 0;
+    };
+
+    bool isSyllabificationLyric(const QString &lyric);
+    QList<PhonemeRange> phonemeRangesForNotes(const QStringList &lyrics,
+                                            const QList<PhonemeName> &phonemes);
+}
+
+#endif // PROJECTMODEL_SYLLABIFICATION_H

--- a/src/tests/TestSyllabification/main.cpp
+++ b/src/tests/TestSyllabification/main.cpp
@@ -8,6 +8,8 @@
 #include <lite/MusicBase/Timeline.h>
 #include <lite/ProjectModel/AppModel/Note.h>
 #include <lite/ProjectModel/AppModel/SingingClip.h>
+#include <lite/ProjectModel/SingingClipSlicer/SingingClipSlicer.h>
+#include <lite/ProjectModel/InferenceData/InferPiece.h>
 
 #include <QCoreApplication>
 #include <QTextStream>
@@ -63,6 +65,92 @@ namespace {
         const auto single = Syllabification::phonemeRangesForNotes({"international+"}, phones);
         expect(single.at(0).count == phones.size(),
                "a word without syllabification notes retains every phoneme on its root");
+    }
+
+    void testSlicerSyllableAssignment() {
+        const auto check = [](const QStringList &lyrics, const QList<PhonemeName> &rootPhones,
+                              const bool accepted) {
+            QList<Note *> notes;
+            for (int i = 0; i < lyrics.size(); ++i) {
+                auto *note = new Note;
+                configureNote(*note, 960 + i * 480, lyrics.at(i));
+                if (!note->isSlur() && !note->isSyllabification())
+                    note->setPhonemeNameSeq(Note::Original,
+                                           i == 0 ? rootPhones
+                                                  : QList{phone("dh", false), phone("eh", true)});
+                notes.append(note);
+            }
+            SingingClip clip(notes);
+            const auto segments = SingingClipSlicer::slice(Timeline{}, notes).segments;
+            if (accepted != !segments.isEmpty()) {
+                QTextStream(stderr) << "Unexpected syllable assignment validity: "
+                                    << lyrics.join(' ') << Qt::endl;
+                ++failures;
+            }
+        };
+
+        const QList mono{phone("hh", false), phone("ay", true)};
+        const QList disyllabic{phone("hh", false), phone("eh", true), phone("l", false),
+                              phone("ow", true)};
+        check({QString::fromUtf8("你"), "+", QString::fromUtf8("好")},
+              {phone("n", false), phone("i", true)}, false);
+        check({"hi", "+", "there"}, mono, false);
+        check({"hi", "+"}, mono, false);
+        check({"hi", "++", "there"}, mono, false);
+        check({"hi", "-", "+", "there"}, mono, false);
+        check({"hello+", "+", "there"}, disyllabic, false);
+        check({"hello", "+", "+", "there"}, disyllabic, false);
+        check({"hi", "-", "there"}, mono, true);
+        check({"hello", "+", "there"}, disyllabic, true);
+        check({"hello", "-", "+", "there"}, disyllabic, true);
+        check({"hello", "++", "there"}, disyllabic, true);
+        check({"international+", "-", "+", "++", "there"}, internationalPhones(), true);
+        check({"international", "+", "there"}, internationalPhones(), true);
+    }
+
+    void testSlicerAssignmentRecovery() {
+        auto *root = new Note;
+        configureNote(*root, 960, "hello");
+        root->setPhonemeNameSeq(Note::Original,
+                               {phone("hh", false), phone("eh", true), phone("ow", true)});
+        auto *continuation = new Note;
+        configureNote(*continuation, 1440, "+");
+        auto *nextRoot = new Note;
+        configureNote(*nextRoot, 1920, "there");
+        nextRoot->setPhonemeNameSeq(Note::Original, {phone("dh", false), phone("eh", true)});
+        SingingClip clip({root, continuation, nextRoot});
+        const Timeline timeline;
+        clip.reSegment(timeline);
+        expect(clip.pieces().size() == 1, "a valid syllable assignment creates an inference piece");
+
+        root->setPhonemeNameSeq(Note::Edited, {phone("hh", false), phone("ay", true)});
+        const auto invalidated = clip.reSegment(timeline);
+        expect(clip.pieces().isEmpty() && invalidated.removedPieceIds.size() == 1,
+               "edited phonemes that exhaust syllables remove the existing inference piece");
+
+        root->setPhonemeNameSeq(Note::Edited, {});
+        clip.reSegment(timeline);
+        expect(clip.pieces().size() == 1, "resetting phonemes restores a valid assignment");
+
+        continuation->setLocalStart(1500);
+        continuation->setLength(420);
+        clip.reSegment(timeline);
+        expect(clip.pieces().isEmpty(), "a detached assignment note cannot borrow root syllables");
+        continuation->setLocalStart(1440);
+        continuation->setLength(480);
+        clip.reSegment(timeline);
+        expect(clip.pieces().size() == 1, "reconnecting an assignment note restores inference");
+
+        root->setPhonemeNameSeq(Note::Edited, {phone("hh", false), phone("ay", true)});
+        continuation->setLyric("-");
+        clip.reSegment(timeline);
+        expect(clip.pieces().size() == 1, "replacing an exhausted assignment with a slur is valid");
+
+        continuation->setLyric("+");
+        nextRoot->setLocalStart(4800);
+        clip.reSegment(timeline);
+        expect(clip.pieces().size() == 1 && clip.pieces().first()->notes == QList{nextRoot},
+               "an invalid assignment does not suppress a separate valid phrase");
     }
 
     void testStorageAndInferenceRoundTrip() {
@@ -391,6 +479,8 @@ namespace {
 int main(int argc, char *argv[]) {
     QCoreApplication app(argc, argv);
     testRanges();
+    testSlicerSyllableAssignment();
+    testSlicerAssignmentRecovery();
     testStorageAndInferenceRoundTrip();
     testBuildWordsRejectsPendingOffsets();
     testDetachedSyllabificationNotesStayOrphaned();


### PR DESCRIPTION
当单音节词后输入 `+`（如 `你 + 好`、`hi + there`）时，音节分配会留下空音符，而分句检查无条件放行分配记号。时长推理随后把后一个词的前置辅音放进空音符；在 120 BPM、480 tick 音符上，`h` / `dh` 的偏移均变为 `-500 ms`。

将现有音节分配算法移到 ProjectModel，供分句检查与推理共用。分不到音节或脱离所属词的 `+` 现在与缺少音素的歌词一样，使所在乐句不参与合成；有效的多音节分配、末尾分配记号吸收剩余音节和 `-` 延音规则保持原有行为。检查使用实际生效的音素，修改音素、歌词或音符位置后会重新判断，并移除失效的推理分段。

验证：
- `TestSyllabification`：新增用例在修复前失败、修复后全部通过，覆盖中英文例子、连续记号、词尾记号、延音、音素编辑、断开/重连、恢复和独立乐句。
- 使用项目 CMake preset 脚本完成 Debug configure、测试目标构建和 `DsEditorLite` 构建。
- ds-connector-lite + Debug headless 编辑器，使用挚彬 CE：重新打开旧工程及新建输入均拒绝合成 `你 + 好`、`hi + there`；`你 - 好`、`hi - there`、`hello + there` 的 duration / pitch / variance / acoustic 均成功。已合成后改回无效 `+` 会移除该句推理分段，同时保留另一剪辑的正常合成。
