### PR TITLE
fix(document): unify lifecycle completion across GUI and automation

### DIFF
--- a/docs/design/multi-format-import-design.md
+++ b/docs/design/multi-format-import-design.md
@@ -8,8 +8,8 @@ DSPX 异步读取、Package metadata 等前置工作的历史背景见
 
 ## 背景与目标
 
-DS Editor Lite 的 New、Open、Import、Save、Save As、Close、Restart 工作流统一为一个外层文档状态机，
-格式内部加载统一为 Session 协议；在此之上接入 DSPX Import 与经 LibreSVIP 桥接的外部歌声工程格式
+DS Editor Lite 的 GUI 文档请求由外层状态机处理保存保护和交互，MCP / JSON-RPC 使用显式参数与任务。
+两者共享格式 Session、文档提交和提交后的收尾；在此之上接入 DSPX Import 与经 LibreSVIP 桥接的外部歌声工程格式
 （SVP、USTX、VSQX、VSPX 等）。
 
 整个设计分为两层：
@@ -17,16 +17,21 @@ DS Editor Lite 的 New、Open、Import、Save、Save As、Close、Restart 工作
 ```mermaid
 flowchart TD
     UI["菜单 / 最近工程 / 拖放 / 启动参数"] --> Outer["DocumentWorkflowController\n外层文档状态机"]
+    API["MCP / JSON-RPC"] --> Adapter["PublicAutomationHostAdapter\n无交互任务"]
     Outer --> Session["IProjectLoadSession\n格式内部加载会话"]
+    Adapter --> Session
+    Outer --> Committer
+    Adapter --> Committer
     Session --> Prepared["PreparedProject\nReplace / Append payload"]
-    Prepared --> Committer["统一提交器"]
+    Prepared --> Committer["DocumentAutomationFacade\n共享提交"]
     Committer --> Model["AppModel / History / 文档身份"]
+    Committer --> Completed["afterCommit\n最近工程 / 默认目录 / 标题 / 活动片段"]
 
     Session -. "扩展" .-> Registry["ProjectFormatRegistry"]
     Registry -.-> Wizard["配置页 / 轨道选择"]
 ```
 
-- 外层状态机负责当前文档生命周期、保存保护、并发拒绝、终止和统一提交。
+- GUI 外层状态机负责保存保护、并发拒绝和终止交互，自动化入口负责显式策略与任务受理。
 - 内层 Session 负责格式解析、格式专用配置、进度、取消和错误报告。
 - 外层只接收 `ready / failed / canceled` 和 `PreparedProject`，不理解 MIDI 通道、编码或歌手映射。
 - Session 和 Converter 不得修改当前文档、历史、路径或最近工程。
@@ -91,8 +96,20 @@ using PreparedProject =
 ### 统一提交
 
 Replace 顺序：Session 物化完成 → Committing（禁用取消）→ 清理旧历史 → `AppModel::replaceProject()` →
-设置 loop → 更新路径/名称/最近工程/最后目录 → 重置 Saved / Unsaved 历史基线 → 激活首个 Clip。
+设置 loop → 重置 Saved / Unsaved 历史基线 → 更新文档身份与路径并恢复 Active → 切换任务归属 →
+`DocumentRuntimeServices::afterCommit`。
 历史基线在 `modelChanged` 后再次建立（现有 UI 初始化可能产生模型 Action，避免误显示未保存圆点）。
+
+`DocumentCommitInfo` 包含操作类型、前后身份、最终文档快照、原始来源路径和调用来源。
+回调接收者可同步查询完整的新状态；失败、取消和预验证不会触发回调。异步打开在回调完成后才标记成功，
+但工作流 busy 租约仍由原持有者释放。保存/另存为先完成文件写入，再更新路径与名称、设置保存点并通知，
+因此保存点的观察者也能立即读到新的路径。
+
+`AppContext` 统一更新最近 DSPX，并将完成信息交给 GUI 工作流控制器处理最后目录、标题和活动片段。
+原始来源路径与加载临时副本、未保存文档的空身份路径分开传递。GUI 和自动化入口不再各自重复收尾；
+派生的设置和界面命令保留 `InvocationSource` 与客户端身份，避免将无交互请求变成 GUI 请求。
+Headless 不创建 GUI 控制器。GUI 在文档替换后激活首个歌声片段，空工程和纯音频工程清除旧活动片段；
+保存不改变选择。标题从单次有效快照读取名称、路径和保存状态，替换中查询不可用时保留原显示。
 
 文档身份规则：
 

--- a/src/app/AppContext.cpp
+++ b/src/app/AppContext.cpp
@@ -29,6 +29,7 @@
 #include "Modules/ProjectConverters/DspxProjectConverterUi.h"
 #include "Controller/AppController.h"
 #include "Controller/DocumentWorkflow/DocumentWorkflowController.h"
+#include "Controller/DocumentWorkflow/DocumentWorkflowPathUtils.h"
 #include "Controller/AudioDecodingController.h"
 #include "Controller/ClipboardController.h"
 #include "Controller/TrackController.h"
@@ -48,6 +49,7 @@
 #include "Global/AppGlobal.h"
 
 #include <QCoreApplication>
+#include <QFileInfo>
 #include <QMetaObject>
 #include <QObject>
 #include <QSysInfo>
@@ -126,6 +128,23 @@ AppContext::AppContext(std::unique_ptr<AppOptions> options, const AppHostMode ho
     documentServices.saveProject = [this](const QString &path, AppModel *model, QString &error) {
         DspxProjectConverterUi converter(m_appStatus->loopSettings);
         return converter.save(path, model, error);
+    };
+    documentServices.afterCommit = [this](const Automation::DocumentCommitInfo &info) {
+        bool recentFilesChanged = false;
+        if (!info.current.path.isEmpty() &&
+            QFileInfo(info.current.path)
+                    .suffix()
+                    .compare(QStringLiteral("dspx"), Qt::CaseInsensitive) == 0) {
+            const auto recent = m_coreRuntime->settings().addRecentProjectFile(
+                {.source = info.source, .clientId = info.clientId},
+                DocumentWorkflowPathUtils::normalizedProjectPath(info.current.path));
+            if (recent)
+                recentFilesChanged = recent.get().changed;
+            else
+                qWarning() << "Failed to update recent projects:" << recent.getError().message;
+        }
+        if (auto *workflow = guiDocumentWorkflowController())
+            workflow->handleDocumentCommitted(info, recentFilesChanged);
     };
     Automation::PlaybackRuntimeServices playbackServices;
     playbackServices.snapshot = [this] {

--- a/src/app/Automation/DocumentAutomationFacade.cpp
+++ b/src/app/Automation/DocumentAutomationFacade.cpp
@@ -23,6 +23,18 @@ namespace Automation {
             error.message = message;
             return error;
         }
+
+        DocumentSnapshotDto documentSnapshot(const DocumentSession &session) {
+            const auto *history = session.history();
+            return {
+                .document = session.version(),
+                .path = session.path(),
+                .projectName = session.projectName(),
+                .lifecycle = session.lifecycleState(),
+                .busy = session.isBusy(),
+                .saved = !history || history->isOnSavePoint(),
+            };
+        }
     }
 
     DocumentAutomationFacade::DocumentAutomationFacade(AutomationDispatcher &dispatcher,
@@ -37,15 +49,7 @@ namespace Automation {
         DocumentAutomationFacade::getDocument(const DocumentId &documentId) {
         return m_dispatcher.dispatchDocumentQuery<DocumentSnapshotDto>(
             OperationIds::documents::get, documentId, [](DocumentSession &session) {
-                auto *history = session.history();
-                return AutomationResult<DocumentSnapshotDto>({
-                    .document = session.version(),
-                    .path = session.path(),
-                    .projectName = session.projectName(),
-                    .lifecycle = session.lifecycleState(),
-                    .busy = session.isBusy(),
-                    .saved = !history || history->isOnSavePoint(),
-                });
+                return AutomationResult<DocumentSnapshotDto>(documentSnapshot(session));
             });
     }
 
@@ -60,24 +64,24 @@ namespace Automation {
         DocumentAutomationFacade::commitNewDocument(const CommandContext &context,
                                                     const DocumentDraftDto &document) {
         return replaceDocument(OperationIds::documents::commit_new, context, document, {}, {},
-                               true);
+                               true, {});
     }
 
     AutomationResult<MutationResult> DocumentAutomationFacade::commitOpenedDocument(
         const CommandContext &context, const DocumentDraftDto &document, const QString &path,
-        const QString &projectName, const bool savedBaseline) {
+        const QString &projectName, const bool savedBaseline, const QString &sourcePath) {
         return replaceDocument(OperationIds::documents::commit_open, context, document, path,
-                               projectName, savedBaseline);
+                               projectName, savedBaseline, sourcePath.isEmpty() ? path : sourcePath);
     }
 
     AutomationResult<MutationResult> DocumentAutomationFacade::replaceDocument(
         const OperationId &operationId, const CommandContext &context,
         const DocumentDraftDto &document, const QString &path, const QString &projectName,
-        const bool savedBaseline) {
+        const bool savedBaseline, const QString &sourcePath) {
         return m_dispatcher.dispatchDocumentCommand(
             operationId, context,
-            [this, document, path, projectName, savedBaseline,
-             taskId = context.taskId](DocumentSession &session, const bool validateOnly) {
+            [this, operationId, context, document, path, projectName, savedBaseline,
+             sourcePath](DocumentSession &session, const bool validateOnly) {
                 auto validation = validate(document);
                 if (!validation)
                     return AutomationResult<MutationResult>(validation.getError());
@@ -110,10 +114,11 @@ namespace Automation {
                                              : HistoryManager::ResetState::Unsaved);
                 result.current = session.replaceGeneration(path, projectName);
                 m_tasks.replaceDocumentGeneration(result.previous.documentId, result.current,
-                                                  taskId);
+                                                  context.taskId);
                 result.changed = true;
                 result.createdObjects = std::move(createdObjects);
                 result.presentationEffects.append(QStringLiteral("active_document_changed"));
+                notifyCommitted(operationId, context, result, session, sourcePath);
                 return AutomationResult<MutationResult>(std::move(result));
             });
     }
@@ -176,7 +181,8 @@ namespace Automation {
         const bool allowOverwrite) {
         return m_dispatcher.dispatchDocumentCommand(
             operationId, context,
-            [this, path, allowOverwrite](DocumentSession &session, const bool validateOnly) {
+            [this, operationId, context, path, allowOverwrite](DocumentSession &session,
+                                                               const bool validateOnly) {
                 if (path.trimmed().isEmpty()) {
                     return AutomationResult<MutationResult>(AutomationError::invalidArgument(
                         QStringLiteral("path"), QStringLiteral("Save path is empty")));
@@ -243,11 +249,27 @@ namespace Automation {
                 }
                 if (!allowOverwrite)
                     removeStaging.dismiss();
+                session.setPathAndProjectName(path, QFileInfo(path).fileName());
                 if (auto *history = session.history())
                     history->setSavePoint();
-                session.setPathAndProjectName(path, QFileInfo(path).fileName());
+                notifyCommitted(operationId, context, result, session, path);
                 return AutomationResult<MutationResult>(std::move(result));
             });
+    }
+
+    void DocumentAutomationFacade::notifyCommitted(const OperationId &operationId,
+                                                   const CommandContext &context,
+                                                   const MutationResult &result,
+                                                   const DocumentSession &session,
+                                                   const QString &sourcePath) const {
+        if (m_services.afterCommit) {
+            m_services.afterCommit({.operationId = operationId,
+                                    .previous = result.previous,
+                                    .current = documentSnapshot(session),
+                                    .sourcePath = sourcePath,
+                                    .source = context.source,
+                                    .clientId = context.clientId});
+        }
     }
 
 } // namespace Automation

--- a/src/app/Automation/DocumentAutomationFacade.cpp
+++ b/src/app/Automation/DocumentAutomationFacade.cpp
@@ -63,15 +63,16 @@ namespace Automation {
     AutomationResult<MutationResult>
         DocumentAutomationFacade::commitNewDocument(const CommandContext &context,
                                                     const DocumentDraftDto &document) {
-        return replaceDocument(OperationIds::documents::commit_new, context, document, {}, {},
-                               true, {});
+        return replaceDocument(OperationIds::documents::commit_new, context, document, {}, {}, true,
+                               {});
     }
 
     AutomationResult<MutationResult> DocumentAutomationFacade::commitOpenedDocument(
         const CommandContext &context, const DocumentDraftDto &document, const QString &path,
         const QString &projectName, const bool savedBaseline, const QString &sourcePath) {
         return replaceDocument(OperationIds::documents::commit_open, context, document, path,
-                               projectName, savedBaseline, sourcePath.isEmpty() ? path : sourcePath);
+                               projectName, savedBaseline,
+                               sourcePath.isEmpty() ? path : sourcePath);
     }
 
     AutomationResult<MutationResult> DocumentAutomationFacade::replaceDocument(

--- a/src/app/Automation/DocumentAutomationFacade.h
+++ b/src/app/Automation/DocumentAutomationFacade.h
@@ -12,12 +12,6 @@ class AppModel;
 
 namespace Automation {
 
-    struct DocumentRuntimeServices {
-        std::function<void(const LoopSettings &)> applyLoopSettings;
-        std::function<bool(const QString &, AppModel *, QString &)> saveProject;
-        std::function<void(const DocumentId &)> beforeReplaceGeneration;
-    };
-
     struct DocumentSnapshotDto {
         DocumentVersion document;
         QString path;
@@ -25,6 +19,23 @@ namespace Automation {
         DocumentLifecycleState lifecycle = DocumentLifecycleState::Active;
         bool busy = false;
         bool saved = true;
+    };
+
+    struct DocumentCommitInfo {
+        OperationId operationId;
+        DocumentVersion previous;
+        DocumentSnapshotDto current;
+        QString sourcePath;
+        InvocationSource source = InvocationSource::TrustedGui;
+        QString clientId;
+    };
+
+    struct DocumentRuntimeServices {
+        std::function<void(const LoopSettings &)> applyLoopSettings;
+        std::function<bool(const QString &, AppModel *, QString &)> saveProject;
+        std::function<void(const DocumentId &)> beforeReplaceGeneration;
+        // 此时文档已恢复 Active，接收者可同步查询完整的提交状态。
+        std::function<void(const DocumentCommitInfo &)> afterCommit;
     };
 
     class DocumentAutomationFacade final {
@@ -41,7 +52,8 @@ namespace Automation {
                                                               const DocumentDraftDto &document,
                                                               const QString &path,
                                                               const QString &projectName,
-                                                              bool savedBaseline);
+                                                              bool savedBaseline,
+                                                              const QString &sourcePath = {});
         AutomationResult<MutationResult> commitImportedDocument(const CommandContext &context,
                                                                 const DocumentDraftDto &document,
                                                                 bool importTempo,
@@ -57,11 +69,15 @@ namespace Automation {
         AutomationResult<MutationResult>
             replaceDocument(const OperationId &operationId, const CommandContext &context,
                             const DocumentDraftDto &document, const QString &path,
-                            const QString &projectName, bool savedBaseline);
+                            const QString &projectName, bool savedBaseline,
+                            const QString &sourcePath);
         AutomationResult<MutationResult> saveDocumentWithOperation(const OperationId &operationId,
                                                                    const CommandContext &context,
                                                                    const QString &path,
                                                                    bool allowOverwrite);
+        void notifyCommitted(const OperationId &operationId, const CommandContext &context,
+                             const MutationResult &result, const DocumentSession &session,
+                             const QString &sourcePath) const;
 
         AutomationDispatcher &m_dispatcher;
         CommandCommitter &m_committer;

--- a/src/app/Automation/DocumentAutomationFacade.h
+++ b/src/app/Automation/DocumentAutomationFacade.h
@@ -48,12 +48,10 @@ namespace Automation {
         static DocumentDraftDto newDocumentDraft(bool defaultTemplate);
         AutomationResult<MutationResult> commitNewDocument(const CommandContext &context,
                                                            const DocumentDraftDto &document);
-        AutomationResult<MutationResult> commitOpenedDocument(const CommandContext &context,
-                                                              const DocumentDraftDto &document,
-                                                              const QString &path,
-                                                              const QString &projectName,
-                                                              bool savedBaseline,
-                                                              const QString &sourcePath = {});
+        AutomationResult<MutationResult>
+            commitOpenedDocument(const CommandContext &context, const DocumentDraftDto &document,
+                                 const QString &path, const QString &projectName,
+                                 bool savedBaseline, const QString &sourcePath = {});
         AutomationResult<MutationResult> commitImportedDocument(const CommandContext &context,
                                                                 const DocumentDraftDto &document,
                                                                 bool importTempo,

--- a/src/app/Automation/Public/PublicAutomationHostAdapter.cpp
+++ b/src/app/Automation/Public/PublicAutomationHostAdapter.cpp
@@ -319,12 +319,12 @@ namespace Automation {
                         replace->sourceKind == ProjectSourceKind::Native
                             ? QFileInfo(m_path).fileName()
                             : replace->displayName,
-                        replace->sourceKind == ProjectSourceKind::Native);
+                        replace->sourceKind == ProjectSourceKind::Native, m_path);
                 } else if (auto *append = std::get_if<AppendProjectPayload>(&prepared)) {
                     auto draft = documentDraftDto(append->model);
                     if (m_mergeMode == QStringLiteral("replace")) {
                         result = m_runtime.documents().commitOpenedDocument(
-                            m_command, draft, {}, QFileInfo(m_path).fileName(), false);
+                            m_command, draft, {}, QFileInfo(m_path).fileName(), false, m_path);
                     } else {
                         result = m_runtime.documents().commitImportedDocument(
                             m_command, draft, m_importTempo && append->importTempo,

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.cpp
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.cpp
@@ -7,9 +7,9 @@
 #include "Automation/CoreRuntime.h"
 #include "Automation/OperationIds.h"
 #include "Automation/ProjectAutomationDtos.h"
-#include "Controller/EditorViewController.h"
-#include "Controller/TrackController.h"
 #include <lite/ProjectModel/AppModel/AppModel.h>
+#include <lite/ProjectModel/AppModel/Track.h>
+#include <lite/ProjectModel/AppModel/Clip.h>
 #include "Model/AppOptions/AppOptions.h"
 #include "Model/AppStatus/AppStatus.h"
 #include <lite/History/HistoryManager.h>
@@ -99,11 +99,18 @@ void DocumentWorkflowController::initializeNewDocument() {
     const auto context = runtime->documentWorkflowCommitContext(runtime->documentVersion());
     if (!context)
         return;
-    const auto result = runtime->documents().commitNewDocument(context.get(), draft);
-    if (!result)
-        return;
+    runtime->documents().commitNewDocument(context.get(), draft);
+}
+
+void DocumentWorkflowController::handleDocumentCommitted(const Automation::DocumentCommitInfo &info,
+                                                         const bool recentFilesChanged) {
+    if (!info.sourcePath.isEmpty())
+        m_lastProjectFolder = QFileInfo(info.sourcePath).absolutePath();
+    if (info.previous.documentId != info.current.document.documentId)
+        activateFirstClip({}, info.source, info.clientId, true);
     emit documentIdentityChanged();
-    activateFirstClip();
+    if (recentFilesChanged)
+        emit recentProjectFilesChanged(recentProjectFiles());
 }
 
 void DocumentWorkflowController::requestNew() {
@@ -173,22 +180,25 @@ bool DocumentWorkflowController::busy() const {
     return m_busy;
 }
 
-QString DocumentWorkflowController::projectPath() const {
+std::optional<Automation::DocumentSnapshotDto>
+    DocumentWorkflowController::documentSnapshot() const {
     auto *runtime = automationRuntime();
     if (!runtime)
-        return {};
+        return std::nullopt;
     const auto document = runtime->documents().getDocument(runtime->documentVersion().documentId);
-    return document ? document.get().path : QString();
+    return document ? std::optional(document.get()) : std::nullopt;
+}
+
+QString DocumentWorkflowController::projectPath() const {
+    const auto document = documentSnapshot();
+    return document ? document->path : QString();
 }
 
 QString DocumentWorkflowController::projectName() const {
-    auto *runtime = automationRuntime();
-    if (!runtime)
+    const auto document = documentSnapshot();
+    if (!document || (document->path.isEmpty() && document->projectName.isEmpty()))
         return tr("New Project");
-    const auto document = runtime->documents().getDocument(runtime->documentVersion().documentId);
-    if (!document || (document.get().path.isEmpty() && document.get().projectName.isEmpty()))
-        return tr("New Project");
-    return document.get().projectName;
+    return document->projectName;
 }
 
 QString DocumentWorkflowController::lastProjectFolder() const {
@@ -519,9 +529,6 @@ void DocumentWorkflowController::attemptSave() {
     if (result) {
         if (m_resumeAfterSave)
             m_pending.revisionGuard.approve(context.get().expected);
-        emit documentIdentityChanged();
-        m_lastProjectFolder = QFileInfo(m_savePath).dir().path();
-        addRecentProjectFile(m_savePath);
         if (m_resumeAfterSave) {
             m_saveResult = SaveResult::SucceededAndResume;
         } else {
@@ -741,19 +748,13 @@ bool DocumentWorkflowController::commitReplace(ReplaceProjectPayload &&payload,
                   payload.sourceKind == ProjectSourceKind::Native
                       ? QFileInfo(payload.sourcePath).fileName()
                       : payload.displayName,
-                  saved);
+                  saved, payload.sourcePath);
     if (!result) {
         logWorkflowFailure(m_pending.requestId, operationId, result.getError());
         m_error = {tr("Failed to apply project"), result.getError().message};
         return false;
     }
 
-    emit documentIdentityChanged();
-    if (payload.sourceKind == ProjectSourceKind::Native)
-        addRecentProjectFile(payload.sourcePath);
-    if (!payload.sourcePath.isEmpty())
-        m_lastProjectFolder = QFileInfo(payload.sourcePath).dir().path();
-    activateFirstClip();
     return true;
 }
 
@@ -788,28 +789,35 @@ bool DocumentWorkflowController::commitAppend(AppendProjectPayload &&payload,
     return true;
 }
 
-void DocumentWorkflowController::activateFirstClip(const QList<Track *> &preferredTracks) {
+void DocumentWorkflowController::activateFirstClip(const QList<Track *> &preferredTracks,
+                                                   const Automation::InvocationSource source,
+                                                   const QString &clientId,
+                                                   const bool clearIfMissing) {
+    auto *runtime = automationRuntime();
+    if (!runtime || !runtime->windowId())
+        return;
+    const auto version = runtime->documentVersion();
+    const Automation::GuiDocumentCommandContext context{
+        .documentId = version.documentId,
+        .expectedRevision = version.revision,
+        .windowId = *runtime->windowId(),
+        .source = source,
+        .clientId = clientId,
+    };
     const auto &tracks = preferredTracks.isEmpty() ? appModel->tracks() : preferredTracks;
     for (const auto track : tracks) {
-        const auto clips = track->clips();
-        if (clips.count() == 0)
-            continue;
-        trackController->setActiveClip(clips.toList().first()->id());
-        editorViewController->showBottomPanelPage(QStringLiteral("ClipEditor"));
-        return;
+        for (const auto clip : track->clips()) {
+            if (clip->clipType() != Clip::Singing)
+                continue;
+            runtime->facade().setActiveClip(context, Automation::ClipId(clip->id()));
+            runtime->facade().showBottomPanelPage(
+                {.windowId = *runtime->windowId(), .source = source, .clientId = clientId},
+                QStringLiteral("ClipEditor"));
+            return;
+        }
     }
-}
-
-void DocumentWorkflowController::addRecentProjectFile(const QString &path) {
-    if (QFileInfo(path).suffix().compare("dspx", Qt::CaseInsensitive) != 0)
-        return;
-    const auto normalizedPath = DocumentWorkflowPathUtils::normalizedProjectPath(path);
-    auto *runtime = automationRuntime();
-    if (!runtime)
-        return;
-    const auto result = runtime->settings().addRecentProjectFile({}, normalizedPath);
-    if (result && result.get().changed)
-        emit recentProjectFilesChanged(recentProjectFiles());
+    if (clearIfMissing)
+        runtime->facade().setActiveClip(context, std::nullopt);
 }
 
 QString DocumentWorkflowController::suggestedSavePath() const {

--- a/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.h
+++ b/src/app/Controller/DocumentWorkflow/DocumentWorkflowController.h
@@ -4,6 +4,7 @@
 #define documentWorkflowController DocumentWorkflowController::instance()
 
 #include "Automation/AutomationTypes.h"
+#include "Automation/DocumentAutomationFacade.h"
 #include "DocumentWorkflowRevisionGuard.h"
 #include "ProjectLoadTypes.h"
 #include <lite/Core/Singleton.h>
@@ -38,6 +39,8 @@ public:
 
     void setUi(IDocumentWorkflowUi *ui);
     void initializeNewDocument();
+    void handleDocumentCommitted(const Automation::DocumentCommitInfo &info,
+                                 bool recentFilesChanged);
 
     void requestNew();
     void requestOpen(const QString &path);
@@ -50,6 +53,7 @@ public:
     void cancelCurrentOperation();
 
     [[nodiscard]] bool busy() const;
+    [[nodiscard]] std::optional<Automation::DocumentSnapshotDto> documentSnapshot() const;
     [[nodiscard]] QString projectPath() const;
     [[nodiscard]] QString projectName() const;
     [[nodiscard]] QString lastProjectFolder() const;
@@ -124,8 +128,10 @@ private:
                        const Automation::CommandContext &context);
     bool commitAppend(AppendProjectPayload &&payload,
                       const Automation::CommandContext &context);
-    void activateFirstClip(const QList<Track *> &preferredTracks = {});
-    void addRecentProjectFile(const QString &path);
+    void activateFirstClip(
+        const QList<Track *> &preferredTracks = {},
+        Automation::InvocationSource source = Automation::InvocationSource::TrustedGui,
+        const QString &clientId = {}, bool clearIfMissing = false);
     QString suggestedSavePath() const;
     void rejectBusyRequest();
 

--- a/src/app/UI/Window/MainWindow.cpp
+++ b/src/app/UI/Window/MainWindow.cpp
@@ -267,18 +267,14 @@ void MainWindow::updatePanelDetachEnabled() {
 }
 
 void MainWindow::updateWindowTitle() {
-    auto projectName = documentWorkflowController->projectName();
-    auto saved = historyManager->isOnSavePoint();
-    auto appName = qApp->applicationDisplayName();
-    if (projectName.isNull() || projectName.isEmpty())
-        setWindowTitle(appName);
-    else {
-        auto projectPath = documentWorkflowController->projectPath();
-        auto displayName =
-            projectPath.isEmpty() ? projectName : QFileInfo(projectPath).completeBaseName();
-        auto indicator = saved ? "" : "● ";
-        setWindowTitle(indicator + displayName);
-    }
+    const auto document = documentWorkflowController->documentSnapshot();
+    if (!document)
+        return;
+    const auto displayName =
+        !document->path.isEmpty()         ? QFileInfo(document->path).completeBaseName()
+        : document->projectName.isEmpty() ? DocumentWorkflowController::tr("New Project")
+                                          : document->projectName;
+    setWindowTitle((document->saved ? QString() : QStringLiteral("● ")) + displayName);
     updateShutdownBlockReason();
 }
 

--- a/src/tests/TestAutomationDocumentLifecycle/main.cpp
+++ b/src/tests/TestAutomationDocumentLifecycle/main.cpp
@@ -418,7 +418,7 @@ namespace {
             if (info.previous.documentId != info.current.document.documentId) {
                 const auto oldDocument = runtime.documents().getDocument(info.previous.documentId);
                 test.expect(!oldDocument && oldDocument.getError().code ==
-                                               Automation::AutomationErrorCode::DocumentChanged,
+                                                Automation::AutomationErrorCode::DocumentChanged,
                             scenario, "the previous generation must be retired before completion");
             }
         };
@@ -429,7 +429,8 @@ namespace {
             value.clientId = QStringLiteral("document-observer-client");
             return value;
         };
-        const auto draft = makeDocumentDraft(QStringLiteral("Observer"), QStringLiteral("observer"));
+        const auto draft =
+            makeDocumentDraft(QStringLiteral("Observer"), QStringLiteral("observer"));
         const auto initial = runtime.documentVersion();
         const auto created = runtime.documents().commitNewDocument(context(), draft);
         test.expect(created && fixture.host.commits.size() == 1 &&
@@ -482,7 +483,8 @@ namespace {
         const auto previewSave = runtime.documents().saveDocumentAs(
             previewContext, directory.filePath(QStringLiteral("preview.dspx")), false);
         test.expect(previewNew && previewOpen && previewSave && fixture.host.commits.size() == 4 &&
-                        runtime.documentVersion() == versionBeforeSave && savePointNotifications == 2,
+                        runtime.documentVersion() == versionBeforeSave &&
+                        savePointNotifications == 2,
                     scenario, "validation must not emit completion or savepoint notifications");
     }
 
@@ -495,6 +497,12 @@ namespace {
         continuation.source = Automation::InvocationSource::PublicMcp;
         const auto admitted = runtime.dispatcher().admitDocumentTask(continuation);
         const bool acquired = runtime.setDocumentBusy(original.documentId, true);
+        bool notifiedWhileBusy = false;
+        fixture.host.onCommit = [&](const Automation::DocumentCommitInfo &info) {
+            notifiedWhileBusy = info.current.busy &&
+                                runtime.documentBusy(info.current.document.documentId) &&
+                                info.source == continuation.source;
+        };
         const auto replacement = runtime.documents().commitOpenedDocument(
             continuation,
             makeDocumentDraft(QStringLiteral("Busy Replacement"),
@@ -514,9 +522,9 @@ namespace {
 
         test.expect(
             admitted && acquired && replacement && current.documentId != original.documentId &&
-                busyAfterReplacement && released && !runtime.documentBusy(current.documentId) &&
-                !blocked && blocked.getError().code == Automation::AutomationErrorCode::Busy &&
-                committed,
+                notifiedWhileBusy && busyAfterReplacement && released &&
+                !runtime.documentBusy(current.documentId) && !blocked &&
+                blocked.getError().code == Automation::AutomationErrorCode::Busy && committed,
             scenario,
             "workflow busy must cross task-driven replacement, reject new public mutations, and "
             "remain releasable by its original generation");

--- a/src/tests/TestAutomationDocumentLifecycle/main.cpp
+++ b/src/tests/TestAutomationDocumentLifecycle/main.cpp
@@ -55,6 +55,8 @@ namespace {
         QString lateSaveTarget;
         QByteArray lastSavedModel;
         QList<Automation::DocumentId> replacementNotifications;
+        QList<Automation::DocumentCommitInfo> commits;
+        std::function<void(const Automation::DocumentCommitInfo &)> onCommit;
     };
 
     Automation::DocumentRuntimeServices documentServices(DocumentHostState &host) {
@@ -89,6 +91,11 @@ namespace {
         };
         services.beforeReplaceGeneration = [&host](const Automation::DocumentId &documentId) {
             host.replacementNotifications.append(documentId);
+        };
+        services.afterCommit = [&host](const Automation::DocumentCommitInfo &info) {
+            host.commits.append(info);
+            if (host.onCommit)
+                host.onCommit(info);
         };
         return services;
     }
@@ -186,6 +193,7 @@ namespace {
         LoopSettings loopSettings;
         qsizetype idempotencyRecords = 0;
         int replacementNotifications = 0;
+        qsizetype commitNotifications = 0;
     };
 
     std::optional<StateDigest> captureState(LifecycleFixture &fixture) {
@@ -224,6 +232,7 @@ namespace {
         result.loopSettings = fixture.host.loopSettings;
         result.idempotencyRecords = idempotencyRecords.get();
         result.replacementNotifications = fixture.host.replacementNotifications.size();
+        result.commitNotifications = fixture.host.commits.size();
         return result;
     }
 
@@ -248,7 +257,8 @@ namespace {
                left.tasks == right.tasks && left.objectAddresses == right.objectAddresses &&
                left.loopSettings == right.loopSettings &&
                left.idempotencyRecords == right.idempotencyRecords &&
-               left.replacementNotifications == right.replacementNotifications;
+               left.replacementNotifications == right.replacementNotifications &&
+               left.commitNotifications == right.commitNotifications;
     }
 
     enum class PreparationOutcome {
@@ -387,6 +397,93 @@ namespace {
             "AFC-DOC-LIFECYCLE-004",
             "commit-open must preserve legacy clip geometry, publish its savepoint, and "
             "reject the old generation");
+    }
+
+    void testCommitObservers(TestRun &test) {
+        constexpr auto scenario = "document-commit-observers";
+        LifecycleFixture fixture;
+        auto &runtime = fixture.runtime;
+        QTemporaryDir directory;
+        fixture.host.onCommit = [&](const Automation::DocumentCommitInfo &info) {
+            const auto document = runtime.documents().getDocument(info.current.document.documentId);
+            const auto history = runtime.history().getState(info.current.document.documentId);
+            test.expect(document && history && sameDocument(document.get(), info.current) &&
+                            info.current.document == runtime.documentVersion() &&
+                            info.current.lifecycle == Automation::DocumentLifecycleState::Active &&
+                            info.current.saved == history.get().onSavePoint,
+                        scenario, "completion observers must read the coherent committed state");
+            test.expect(runtime.dispatcher().currentInvocationSource() == info.source &&
+                            info.clientId == QStringLiteral("document-observer-client"),
+                        scenario, "completion must retain the initiating invocation source/client");
+            if (info.previous.documentId != info.current.document.documentId) {
+                const auto oldDocument = runtime.documents().getDocument(info.previous.documentId);
+                test.expect(!oldDocument && oldDocument.getError().code ==
+                                               Automation::AutomationErrorCode::DocumentChanged,
+                            scenario, "the previous generation must be retired before completion");
+            }
+        };
+
+        auto context = [&] {
+            auto value = commandContext(runtime);
+            value.source = Automation::InvocationSource::PublicMcp;
+            value.clientId = QStringLiteral("document-observer-client");
+            return value;
+        };
+        const auto draft = makeDocumentDraft(QStringLiteral("Observer"), QStringLiteral("observer"));
+        const auto initial = runtime.documentVersion();
+        const auto created = runtime.documents().commitNewDocument(context(), draft);
+        test.expect(created && fixture.host.commits.size() == 1 &&
+                        fixture.host.commits.last().operationId ==
+                            Automation::OperationIds::documents::commit_new &&
+                        fixture.host.commits.last().previous == initial &&
+                        fixture.host.commits.last().sourcePath.isEmpty(),
+                    scenario, "new must publish exactly one completion for its new generation");
+
+        const auto sourcePath = directory.filePath(QStringLiteral("original.mid"));
+        const auto opened = runtime.documents().commitOpenedDocument(
+            context(), draft, {}, QStringLiteral("original.mid"), false, sourcePath);
+        test.expect(opened && fixture.host.commits.size() == 2 &&
+                        fixture.host.commits.last().operationId ==
+                            Automation::OperationIds::documents::commit_open &&
+                        fixture.host.commits.last().sourcePath == sourcePath &&
+                        fixture.host.commits.last().current.path.isEmpty() &&
+                        !fixture.host.commits.last().current.saved,
+                    scenario, "non-native open must retain its original source and dirty baseline");
+
+        const auto savedPath = directory.filePath(QStringLiteral("observer-save-as.dspx"));
+        QObject saveObserver;
+        int savePointNotifications = 0;
+        QObject::connect(fixture.history, &HistoryManager::savePointChanged, &saveObserver, [&] {
+            ++savePointNotifications;
+            const auto document =
+                runtime.documents().getDocument(runtime.documentVersion().documentId);
+            test.expect(document && document.get().path == savedPath && document.get().saved &&
+                            document.get().projectName == QStringLiteral("observer-save-as.dspx"),
+                        scenario, "savepoint observers must already see the new save-as identity");
+        });
+        const auto versionBeforeSave = runtime.documentVersion();
+        const auto saved = runtime.documents().saveDocumentAs(context(), savedPath, false);
+        const auto resaved = runtime.documents().saveDocument(context(), savedPath);
+        test.expect(saved && resaved && fixture.host.commits.size() == 4 &&
+                        fixture.host.commits.at(2).operationId ==
+                            Automation::OperationIds::documents::save_as &&
+                        fixture.host.commits.last().operationId ==
+                            Automation::OperationIds::documents::save &&
+                        fixture.host.commits.last().sourcePath == savedPath &&
+                        runtime.documentVersion() == versionBeforeSave &&
+                        savePointNotifications == 2,
+                    scenario, "save/save-as must each notify once without advancing the revision");
+
+        auto previewContext = context();
+        previewContext.validateOnly = true;
+        const auto previewNew = runtime.documents().commitNewDocument(previewContext, draft);
+        const auto previewOpen = runtime.documents().commitOpenedDocument(
+            previewContext, draft, sourcePath, QStringLiteral("preview.dspx"), true);
+        const auto previewSave = runtime.documents().saveDocumentAs(
+            previewContext, directory.filePath(QStringLiteral("preview.dspx")), false);
+        test.expect(previewNew && previewOpen && previewSave && fixture.host.commits.size() == 4 &&
+                        runtime.documentVersion() == versionBeforeSave && savePointNotifications == 2,
+                    scenario, "validation must not emit completion or savepoint notifications");
     }
 
     void testWorkflowBusyLeaseAcrossReplacement(TestRun &test) {
@@ -858,6 +955,7 @@ int main(int argc, char *argv[]) {
 
     testInitialUntitledSession(test);
     testNewOpenAndImport(test);
+    testCommitObservers(test);
     testWorkflowBusyLeaseAcrossReplacement(test);
     testFailureAndCancellationRollback(test);
     testSaveAndSaveAs(test);

--- a/src/tests/TestHeadlessProcessIntegration/main.cpp
+++ b/src/tests/TestHeadlessProcessIntegration/main.cpp
@@ -1210,10 +1210,10 @@ namespace {
             if (pageIndex == 15)
                 return fail(QStringLiteral("Headless MCP tools/list pagination did not terminate"));
         }
-        if (toolNames.size() != 151 ||
+        if (toolNames.size() != 154 ||
             !toolNames.contains(QStringLiteral("application.get_status")) ||
             toolNames.contains(QStringLiteral("track_panel.get_state"))) {
-            return fail(QStringLiteral("Headless MCP exposed %1 tools instead of the qualified 151")
+            return fail(QStringLiteral("Headless MCP exposed %1 tools instead of the qualified 154")
                             .arg(toolNames.size()));
         }
 

--- a/src/tests/TestMcpProcessIntegration/main.cpp
+++ b/src/tests/TestMcpProcessIntegration/main.cpp
@@ -278,6 +278,243 @@ namespace {
         return false;
     }
 
+    bool verifyDocumentLifecycle(QProcess &connector, const QString &directory,
+                                 const qint64 audioTrackId) {
+        qint64 requestId = 20000;
+        QString error;
+        QJsonObject document;
+        QString windowId;
+        const auto call = [&](const QString &name, const QJsonObject &arguments = {}) {
+            auto result =
+                connectorToolContent(connector, requestId++, name, arguments, 10000, error);
+            if (!result)
+                fail(QStringLiteral("Lifecycle %1 failed: %2").arg(name, error));
+            return result;
+        };
+        const auto refresh = [&] {
+            const auto status = call(QStringLiteral("application.get_status"));
+            if (!status)
+                return false;
+            document = status->value(QStringLiteral("documents")).toArray().first().toObject();
+            windowId = status->value(QStringLiteral("windows"))
+                           .toArray()
+                           .first()
+                           .toObject()
+                           .value(QStringLiteral("window_id"))
+                           .toString();
+            return !document.value(QStringLiteral("document_id")).toString().isEmpty();
+        };
+        const auto arguments = [&] {
+            return QJsonObject{
+                {QStringLiteral("document_id"),       document.value("document_id")},
+                {QStringLiteral("expected_revision"), document.value("revision")   }
+            };
+        };
+        const auto snapshot = [&] {
+            return call(QStringLiteral("documents.get"),
+                        {
+                            {QStringLiteral("document_id"), document.value("document_id")}
+            });
+        };
+        const auto checkDocument = [&](const QString &path, const bool dirty) {
+            const auto result = snapshot();
+            const auto state = result ? result->value("snapshot").toObject() : QJsonObject{};
+            return result && state.value("path").toString() == path &&
+                   state.value("dirty").toBool() == dirty &&
+                   state.value("saved").toBool() != dirty &&
+                   state.value("lifecycle").toString() == QStringLiteral("active");
+        };
+        const auto activeClip = [&] {
+            return call(QStringLiteral("clip_editor.get_state"),
+                        {
+                            {QStringLiteral("document_id"), document.value("document_id")},
+                            {QStringLiteral("window_id"),   windowId                     }
+            });
+        };
+        const auto checkActiveClip = [&](const bool singing) {
+            const auto editor = activeClip();
+            if (!editor)
+                return false;
+            const auto id = editor->value("active_clip_id");
+            if (!singing)
+                return id.isNull();
+            const auto clips =
+                call(QStringLiteral("clips.list"),
+                     {
+                         {QStringLiteral("document_id"), document.value("document_id")},
+                         {QStringLiteral("type"),        QStringLiteral("singing")    }
+            });
+            const auto items = clips ? clips->value("clips").toArray() : QJsonArray{};
+            return !items.isEmpty() && id == items.first().toObject().value("clip_id");
+        };
+        const auto saveAs = [&](const QString &path) {
+            if (!refresh())
+                return false;
+            const auto before = activeClip();
+            auto input = arguments();
+            input.insert(QStringLiteral("path"), path);
+            input.insert(QStringLiteral("overwrite_policy"), QStringLiteral("reject"));
+            const auto saved = call(QStringLiteral("documents.save_as"), input);
+            const auto after = activeClip();
+            return saved && before && after && checkDocument(path, false) &&
+                   before->value("active_clip_id") == after->value("active_clip_id");
+        };
+        const auto create = [&](const QString &preset) {
+            if (!refresh())
+                return false;
+            const auto result =
+                call(QStringLiteral("documents.new"),
+                     {
+                         {QStringLiteral("current_document_id"), document.value("document_id")},
+                         {QStringLiteral("expected_revision"),   document.value("revision")   },
+                         {QStringLiteral("unsaved_policy"),      QStringLiteral("discard")    },
+                         {QStringLiteral("template"),            preset                       }
+            });
+            return result && refresh() && checkDocument({}, false);
+        };
+        const auto open = [&](const QString &path) {
+            if (!refresh())
+                return false;
+            const auto previous = document.value("document_id");
+            const auto started =
+                call(QStringLiteral("documents.open"),
+                     {
+                         {QStringLiteral("current_document_id"), previous                  },
+                         {QStringLiteral("expected_revision"),   document.value("revision")},
+                         {QStringLiteral("unsaved_policy"),      QStringLiteral("reject")  },
+                         {QStringLiteral("path"),                path                      }
+            });
+            if (!started)
+                return false;
+            const auto taskId = started->value("task_id").toString();
+            for (int attempt = 0; attempt < 100; ++attempt) {
+                if (!refresh())
+                    return false;
+                const auto task = connectorToolContent(
+                    connector, requestId++, QStringLiteral("tasks.get"),
+                    {
+                        {QStringLiteral("scope"),       QStringLiteral("document")   },
+                        {QStringLiteral("document_id"), document.value("document_id")},
+                        {QStringLiteral("task_id"),     taskId                       }
+                },
+                    5000, error);
+                if (!task) {
+                    if (error.contains(QStringLiteral("document_changed")))
+                        continue;
+                    return fail(error);
+                }
+                const auto state = task->value("state").toString();
+                if (state == QStringLiteral("succeeded"))
+                    return document.value("document_id") != previous;
+                if (state == QStringLiteral("failed") || state == QStringLiteral("canceled"))
+                    return fail(
+                        QStringLiteral("Lifecycle open task failed: %1").arg(compactJson(*task)));
+                QThread::msleep(50);
+            }
+            return fail(QStringLiteral("Lifecycle open task timed out"));
+        };
+
+        if (!refresh())
+            return false;
+        const auto tracks =
+            call(QStringLiteral("tracks.list"),
+                 {
+                     {QStringLiteral("document_id"), document.value("document_id")}
+        });
+        if (!tracks)
+            return false;
+        for (const auto &track : tracks->value("tracks").toArray()) {
+            const auto id = track.toObject().value("track_id").toInteger();
+            if (id == audioTrackId)
+                continue;
+            if (!refresh())
+                return false;
+            auto input = arguments();
+            input.insert(QStringLiteral("track_ids"), QJsonArray{id});
+            if (!call(QStringLiteral("tracks.remove"), input))
+                return false;
+        }
+        const auto audioProject = QDir(directory).filePath(QStringLiteral("audio-only.dspx"));
+        const auto firstPath = QDir(directory).filePath(QStringLiteral("生命周期甲.dspx"));
+        const auto secondPath = QDir(directory).filePath(QStringLiteral("生命周期乙.dspx"));
+        if (!saveAs(audioProject) || !create(QStringLiteral("default")) || !checkActiveClip(true) ||
+            !saveAs(firstPath) || !saveAs(secondPath)) {
+            return fail(
+                QStringLiteral("Lifecycle new/save-as did not preserve document or selection"));
+        }
+        const auto recent = call(QStringLiteral("documents.list_recent"));
+        const auto projects = recent ? recent->value("projects").toArray() : QJsonArray{};
+        if (projects.size() < 2 || projects.at(0).toObject().value("path") != secondPath ||
+            projects.at(1).toObject().value("path") != firstPath) {
+            return fail(
+                QStringLiteral("Lifecycle save-as did not update recent projects in order"));
+        }
+        if (!create(QStringLiteral("empty")) || !checkActiveClip(false) || !open(firstPath) ||
+            !checkDocument(firstPath, false) || !checkActiveClip(true)) {
+            return fail(
+                QStringLiteral("Lifecycle open did not restore its document and first clip"));
+        }
+        const auto reopenedRecent = call(QStringLiteral("documents.list_recent"));
+        if (!reopenedRecent ||
+            reopenedRecent->value("projects").toArray().size() != projects.size() ||
+            reopenedRecent->value("projects").toArray().first().toObject().value("path") !=
+                firstPath) {
+            return fail(
+                QStringLiteral("Lifecycle open must promote, not duplicate, its recent path"));
+        }
+
+        const auto openedTracks =
+            call(QStringLiteral("tracks.list"),
+                 {
+                     {QStringLiteral("document_id"), document.value("document_id")}
+        });
+        if (!openedTracks || !refresh())
+            return false;
+        auto renameInput = arguments();
+        renameInput.insert(
+            QStringLiteral("track_id"),
+            openedTracks->value("tracks").toArray().first().toObject().value("track_id"));
+        renameInput.insert(QStringLiteral("name"), QStringLiteral("Lifecycle edited"));
+        const auto selectedBeforeSave = activeClip();
+        if (!call(QStringLiteral("tracks.rename"), renameInput) || !refresh() ||
+            !checkDocument(firstPath, true) ||
+            !call(QStringLiteral("documents.save"), arguments()) ||
+            !checkDocument(firstPath, false)) {
+            return fail(QStringLiteral("Lifecycle save did not clear the dirty state"));
+        }
+        const auto selectedAfterSave = activeClip();
+        if (!selectedBeforeSave || !selectedAfterSave ||
+            selectedBeforeSave->value("active_clip_id") !=
+                selectedAfterSave->value("active_clip_id") ||
+            !open(audioProject) || !checkDocument(audioProject, false) || !checkActiveClip(false)) {
+            return fail(QStringLiteral("Lifecycle audio-only open retained a stale active clip"));
+        }
+
+        QFile midi(QDir(directory).filePath(QStringLiteral("来源.mid")));
+        if (!midi.open(QIODevice::WriteOnly))
+            return fail(QStringLiteral("Could not create lifecycle MIDI fixture"));
+        midi.write(QByteArray::fromHex("4d546864000000060000000101e04d54726b0000001400ff510307a1200"
+                                       "0903c648360803c0000ff2f00"));
+        midi.close();
+        const auto recentBeforeForeign = call(QStringLiteral("documents.list_recent"));
+        if (!open(midi.fileName()) || !checkDocument({}, true) || !checkActiveClip(true))
+            return fail(
+                QStringLiteral("Foreign open must be unsaved and activate its singing clip"));
+        const auto foreign = snapshot();
+        const auto recentAfterForeign = call(QStringLiteral("documents.list_recent"));
+        if (!foreign ||
+            foreign->value("snapshot").toObject().value("project_name") !=
+                QFileInfo(midi.fileName()).completeBaseName() ||
+            !recentBeforeForeign || !recentAfterForeign ||
+            *recentBeforeForeign != *recentAfterForeign) {
+            return fail(QStringLiteral("Foreign lifecycle identity/recent mismatch: %1; %2; %3")
+                            .arg(foreign ? compactJson(*foreign) : error,
+                                 recentBeforeForeign ? compactJson(*recentBeforeForeign) : error,
+                                 recentAfterForeign ? compactJson(*recentAfterForeign) : error));
+        }
+        return true;
+    }
+
     QString schemaIssue(const QJsonValue &schema) {
         const auto validation = AutomationWire::checkJsonSchema(schema);
         if (validation.valid())
@@ -854,7 +1091,7 @@ namespace {
         }
 
         const auto directCatalog = directToolCatalog(directClient, 10000, toolError);
-        if (!directCatalog || directCatalog->size() != 176 ||
+        if (!directCatalog || directCatalog->size() != 179 ||
             !directCatalog->contains(QStringLiteral("application.get_status")) ||
             !directCatalog->contains(QStringLiteral("workspace.get_state")) ||
             !directCatalog->contains(QStringLiteral("track_panel.get_state")) ||
@@ -1418,6 +1655,9 @@ namespace {
                 QStringLiteral("Direct Editor MCP 2025-11-25 tools/call failed: %1")
                     .arg(toolError));
         }
+
+        if (!verifyDocumentLifecycle(connector, isolatedRoot.path(), createdTrackId))
+            return failWithProcessDiagnostics(QStringLiteral("Document lifecycle checks failed"));
 
         const auto rejectedExit = exchange(
             connector,


### PR DESCRIPTION
通过 MCP 新建后再打开工程时，模型已切换到新工程，标题却停留在“新工程”。文档提交后的路径、最近工程和片段激活原先分别由 GUI 工作流补充，自动化入口没有执行同一套收尾。

本层基于 #184，统一在 DocumentAutomationFacade 完成提交后通知宿主。通知发出时，文档身份、路径、历史基线和任务归属已经一致；保存/另存为也会先更新路径再通知保存点。AppContext 统一更新最近 DSPX，GUI 复用工作流收尾来更新默认目录、标题和活动歌声片段。嵌套设置和界面调用保留原始 InvocationSource 与客户端身份，继续遵守 #184 的无交互音频检查策略。公开工具 schema、文档 revision 和任务 busy 租约语义保持兼容。

空工程和纯音频工程清除旧活动片段，保存保持选择；追加导入没有可编辑歌声片段时保留原有选择。标题只消费有效的完整快照，替换中不再把查询失败显示成“新工程”。同步更新文档工作流设计说明。

验证：
- 项目 VS DevShell + debug preset 的 Editor、Connector 和相关测试目标构建通过。
- 9 项 CTest：TestAutomationDocumentLifecycle、TestMcpProcessIntegration、TestAudioDecodingController、TestDocumentWorkflow、TestAutomationTaskRaces、TestPublicAutomationContract、TestHeadlessProcessIntegration、TestAutomationAsyncFileDomains、TestPublicAutomationRegistry。
- 新增提交观察者测试，覆盖通知期间的完整状态、调用来源、保存路径顺序、预验证不通知和 busy 租约。
- 扩展真实连接器进程测试，覆盖中文路径、新建、保存/另存为、最近工程排序与去重、纯音频、空工程和 MIDI 打开；同步两处过期的工具数量断言，与现有公开契约的 179/154 个工具一致。
- 隔离 GUI 实测：MCP 新建、打开、另存为即时更新窗口标题和顶部工程名；MIDI 首次保存采用原始来源目录；GUI 保存正确清除脏标记；取消另存为、打开损坏文件和拒绝覆盖均保持原身份/标题。
- 同一缺失音频工程经 MCP 打开没有资源弹窗，经手动 GUI 打开仍显示资源提示；手动新建正确激活默认歌声片段。

依赖：#184。本 PR 只包含该层之上的生命周期修复。
